### PR TITLE
Add a read-only Store for captured generations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
           packages/nauro/src/nauro/store/replica_control.py
           packages/nauro/src/nauro/store/generation_installation.py
           packages/nauro/src/nauro/store/generation_read.py
+          packages/nauro/src/nauro/store/generation_store.py
           packages/nauro/src/nauro/sync/generation_acquisition.py
           packages/nauro/src/nauro/store/submission_records.py
           packages/nauro/src/nauro/sync/judgment_submission.py
@@ -87,6 +88,7 @@ jobs:
           packages/nauro/tests/test_generation_authority.py
           packages/nauro/tests/test_generation_installation.py
           packages/nauro/tests/test_generation_read.py
+          packages/nauro/tests/test_generation_store.py
           packages/nauro/tests/test_replica_control.py
           packages/nauro/tests/test_sync/test_generation_acquisition.py
           packages/nauro/tests/test_sync/test_submission_records_excluded.py

--- a/packages/nauro/src/nauro/store/generation_store.py
+++ b/packages/nauro/src/nauro/store/generation_store.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from types import MappingProxyType
+
+from nauro_core.constants import DECISIONS_DIR
+from nauro_core.protected_generation_membership import (
+    InvalidGenerationPath,
+    validate_protected_generation_path,
+)
+
+from nauro.store.generation_authority import GenerationAuthorityError
+from nauro.store.generation_projection import (
+    VerifiedGenerationProjection,
+    verify_generation_projection,
+)
+from nauro.store.generation_read import read_installed_generation
+from nauro.store.resolution import ResolvedProjectBinding
+
+
+class GenerationStoreReadOnlyError(GenerationAuthorityError):
+    code = "generation_store_read_only"
+
+
+class GenerationStorePathError(GenerationAuthorityError):
+    code = "generation_store_invalid_path"
+
+
+@dataclass(frozen=True, init=False)
+class GenerationSnapshotStore:
+    _contents: Mapping[str, str] = field(repr=False)
+
+    def __init__(self, projection: VerifiedGenerationProjection) -> None:
+        verified = verify_generation_projection(
+            projection.target,
+            manifest_json=projection.manifest_json,
+            artifacts=tuple((artifact.path, artifact.content) for artifact in projection.artifacts),
+        )
+        contents = {
+            artifact.path: artifact.content.decode("utf-8", errors="replace")
+            for artifact in verified.artifacts
+        }
+        object.__setattr__(self, "_contents", MappingProxyType(contents))
+
+    def read_file(self, path: str) -> str | None:
+        try:
+            canonical = validate_protected_generation_path(path)
+        except InvalidGenerationPath as exc:
+            raise GenerationStorePathError(
+                "The requested path is outside the protected generation."
+            ) from exc
+        return self._contents.get(canonical)
+
+    def write_file(self, path: str, content: str) -> None:
+        raise GenerationStoreReadOnlyError("Generation snapshots do not permit file writes.")
+
+    def delete_file(self, path: str) -> None:
+        raise GenerationStoreReadOnlyError("Generation snapshots do not permit file deletion.")
+
+    def list_decisions(self) -> list[str]:
+        prefix = f"{DECISIONS_DIR}/"
+        return sorted(
+            path[len(prefix) : -len(".md")]
+            for path in self._contents
+            if path.startswith(prefix) and path.endswith(".md")
+        )
+
+    def read_decision(self, file_stem: str) -> str | None:
+        return self.read_file(f"{DECISIONS_DIR}/{file_stem}.md")
+
+    def read_decisions(self, stems: list[str]) -> dict[str, str | None]:
+        return {stem: self.read_decision(stem) for stem in stems}
+
+
+def capture_generation_store(
+    binding: ResolvedProjectBinding,
+    *,
+    active_user_id: str | None,
+    active_projection_scope_id: str | None,
+    timeout: float = -1,
+) -> GenerationSnapshotStore:
+    projection = read_installed_generation(
+        binding,
+        active_user_id=active_user_id,
+        active_projection_scope_id=active_projection_scope_id,
+        timeout=timeout,
+    )
+    return GenerationSnapshotStore(projection)
+
+
+__all__ = [
+    "GenerationSnapshotStore",
+    "GenerationStorePathError",
+    "GenerationStoreReadOnlyError",
+    "capture_generation_store",
+]

--- a/packages/nauro/tests/test_generation_read.py
+++ b/packages/nauro/tests/test_generation_read.py
@@ -120,14 +120,14 @@ def test_capture_refuses_flat_authority(installed):
         )
 
 
-def test_capture_has_no_runtime_consumers():
+def test_capture_has_only_the_dormant_store_consumer():
     root = Path(reader.__file__).parents[1]
     consumers = []
     for path in root.rglob("*.py"):
         for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
             if isinstance(node, ast.ImportFrom) and node.module == "nauro.store.generation_read":
                 consumers.append(path.relative_to(root).as_posix())
-    assert consumers == []
+    assert consumers == ["store/generation_store.py"]
 
 
 def test_capture_refuses_a_replaced_file(installed, monkeypatch):

--- a/packages/nauro/tests/test_generation_store.py
+++ b/packages/nauro/tests/test_generation_store.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import ast
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+
+import pytest
+from nauro_core.operations.get_decision import get_decision
+from nauro_core.operations.store import Store
+
+from nauro.store import generation_installation as installation
+from nauro.store import generation_store
+from nauro.store.generation_projection import GenerationProjectionVerificationError
+from nauro.store.generation_store import (
+    GenerationSnapshotStore,
+    GenerationStorePathError,
+    GenerationStoreReadOnlyError,
+    capture_generation_store,
+)
+from tests.test_generation_installation import SCOPE_ID, USER_ID, _projection
+
+
+@pytest.fixture
+def projection():
+    return _projection(
+        {
+            "decisions/002-second.md": b"# Second\n",
+            "decisions/001-first.md": b"# First\n",
+            "context/brief.md": b"Context\n",
+            "state.md": b"State\n",
+        }
+    )
+
+
+def test_store_implements_reads_and_returns_fresh_lists(projection):
+    store: Store = GenerationSnapshotStore(projection)
+    assert isinstance(store, Store)
+    assert store.list_decisions() == ["001-first", "002-second"]
+    stems = store.list_decisions()
+    stems.clear()
+    assert store.list_decisions() == ["001-first", "002-second"]
+    assert store.read_file("state.md") == "State\n"
+    assert store.read_file("project.md") is None
+    assert store.read_decision("001-first") == "# First\n"
+    assert store.read_decisions(["002-second", "999-missing", "001-first"]) == {
+        "002-second": "# Second\n",
+        "999-missing": None,
+        "001-first": "# First\n",
+    }
+    assert get_decision(store, 1).content == "# First\n"
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "../state.md",
+        "/state.md",
+        "./state.md",
+        "context//brief.md",
+        "context\\brief.md",
+        ".replica/authority.json",
+        "unknown.md",
+        "decisions/sub/file.md",
+        "",
+    ],
+)
+def test_store_refuses_noncanonical_and_nonprotected_paths(projection, path):
+    with pytest.raises(GenerationStorePathError) as raised:
+        GenerationSnapshotStore(projection).read_file(path)
+    assert raised.value.code == "generation_store_invalid_path"
+
+
+@pytest.mark.parametrize("stem", ["../state", "/state", "nested/decision", ""])
+def test_decision_reads_cannot_escape(projection, stem):
+    store = GenerationSnapshotStore(projection)
+    with pytest.raises(GenerationStorePathError):
+        store.read_decision(stem)
+    with pytest.raises(GenerationStorePathError):
+        store.read_decisions(["001-first", stem])
+
+
+@pytest.mark.parametrize("path", ["state.md", "project.md", "../outside.md"])
+def test_every_mutation_refuses(projection, path):
+    store = GenerationSnapshotStore(projection)
+    with pytest.raises(GenerationStoreReadOnlyError) as write:
+        store.write_file(path, "changed")
+    with pytest.raises(GenerationStoreReadOnlyError) as delete:
+        store.delete_file(path)
+    assert write.value.code == delete.value.code == "generation_store_read_only"
+    assert store.read_file("state.md") == "State\n"
+
+
+def test_store_uses_canonical_bytes_and_detaches_metadata(projection):
+    object.__setattr__(projection.manifest, "artifacts", {})
+    store = GenerationSnapshotStore(projection)
+    assert store.read_decision("001-first") == "# First\n"
+    object.__setattr__(projection, "artifacts", ())
+    assert store.read_decision("001-first") == "# First\n"
+    with pytest.raises(FrozenInstanceError):
+        store._contents = {}
+    with pytest.raises(TypeError):
+        store._contents["state.md"] = "changed"
+
+
+def test_store_reverifies_artifact_bytes(projection):
+    object.__setattr__(projection.artifacts[0], "content", b"corrupt")
+    with pytest.raises(GenerationProjectionVerificationError):
+        GenerationSnapshotStore(projection)
+
+
+def test_store_matches_replacement_decoding():
+    store = GenerationSnapshotStore(_projection({"state.md": b"invalid \xff\n"}))
+    assert store.read_file("state.md") == "invalid \ufffd\n"
+
+
+def test_capture_composition_survives_removed_disk_root(projection, monkeypatch):
+    import shutil
+
+    binding = projection.target.binding
+    binding.store_path.mkdir(parents=True)
+    monkeypatch.setattr(installation, "read_active_user_id", lambda: USER_ID)
+    installed = installation.install_generation_root(projection)
+    installation.publish_generation_control(installed)
+    store = capture_generation_store(
+        binding, active_user_id=USER_ID, active_projection_scope_id=SCOPE_ID, timeout=0
+    )
+    shutil.rmtree(installed.root_path)
+    assert get_decision(store, 2).content == "# Second\n"
+    assert store.read_file("context/brief.md") == "Context\n"
+
+
+def test_store_has_no_runtime_consumers():
+    root = Path(generation_store.__file__).parents[1]
+    consumers = []
+    for path in root.rglob("*.py"):
+        for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
+            if isinstance(node, ast.ImportFrom) and node.module == "nauro.store.generation_store":
+                consumers.append(path.relative_to(root).as_posix())
+            if isinstance(node, ast.Import):
+                consumers.extend(
+                    alias.name
+                    for alias in node.names
+                    if alias.name == "nauro.store.generation_store"
+                )
+    assert consumers == []


### PR DESCRIPTION
## Why

Kernel reads need a Store adapter that stays on one captured generation even after the disk root or actor pointer changes.

## What changed

Add a read-only Store over verified generation bytes. Construction verifies the canonical manifest and artifact digests, then copies decoded text into an immutable mapping. Reads accept only canonical protected members; missing members return None. Every file write and delete refuses with a typed read-only error.

Compose the adapter with installed-generation capture and include its tests and typing in CI. The adapter has no runtime consumer.

## Test plan

761 affected generation tests passed, with 77 platform-specific skips. All three explicit cross-repository recovery and alias checks passed without skips. Lint, formatting, targeted typing, source-risk, single-source, and docstring checks passed. Tests cover exact kernel reads after removal of the synthetic disk root, path refusal, corrupt artifacts, metadata replacement, and write refusal.

## Risk / what to review

Review canonical-byte verification, text decoding, detached contents, and path refusal. Capture and constructor verification are eager; runtime memory use and latency remain unproven.

## Deferred

Concurrent writing remains incomplete. Runtime read routing, pointer-safe refresh, hosted reads, and production timing remain open. Production activation, durable formats, cleanup, and deployment are unchanged.
