### PR TITLE
Recover interrupted generation refreshes with durable evidence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,10 @@ jobs:
           packages/nauro/src/nauro/store/generation_installation.py
           packages/nauro/src/nauro/store/generation_read.py
           packages/nauro/src/nauro/store/generation_store.py
+          packages/nauro/src/nauro/store/generation_refresh_state.py
+          packages/nauro/src/nauro/store/generation_refresh_intent.py
+          packages/nauro/src/nauro/store/generation_refresh_io.py
+          packages/nauro/src/nauro/sync/generation_refresh.py
           packages/nauro/src/nauro/sync/generation_acquisition.py
           packages/nauro/src/nauro/store/submission_records.py
           packages/nauro/src/nauro/sync/judgment_submission.py
@@ -89,6 +93,8 @@ jobs:
           packages/nauro/tests/test_generation_installation.py
           packages/nauro/tests/test_generation_read.py
           packages/nauro/tests/test_generation_store.py
+          packages/nauro/tests/test_generation_refresh_state.py
+          packages/nauro/tests/test_generation_refresh.py
           packages/nauro/tests/test_replica_control.py
           packages/nauro/tests/test_sync/test_generation_acquisition.py
           packages/nauro/tests/test_sync/test_submission_records_excluded.py

--- a/packages/nauro/src/nauro/store/generation_installation.py
+++ b/packages/nauro/src/nauro/store/generation_installation.py
@@ -1066,6 +1066,10 @@ def _publish_generation_control(
         if locked != initial or locked_store != store_path or locked_layout != layout:
             raise _publication_failure()
         _reprove_publication_paths(locked, store_path, layout, lock_path)
+        intent_path = layout.actor / "refresh-intent.json"
+        _validate_managed_path(store_path, intent_path)
+        if _lstat_optional(intent_path) is not None:
+            raise RefreshRequiredError("Existing refresh evidence requires explicit recovery.")
         marker_json = _read_control_file(store_path, marker_path)
         if marker_json is not None:
             verified, _, _ = _active_selection(

--- a/packages/nauro/src/nauro/store/generation_read.py
+++ b/packages/nauro/src/nauro/store/generation_read.py
@@ -2,11 +2,16 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from nauro.store.generation_authority import GenerationAuthorityError, GenerationProjectAuthority
+from nauro.store.generation_authority import (
+    GenerationAuthorityError,
+    GenerationProjectAuthority,
+    RefreshRequiredError,
+)
 from nauro.store.generation_installation import (
     GenerationInstallError,
     _installed_file,
     _layout,
+    _lstat_optional,
     _read_expected,
     _require_directory,
     audit_generation_tree,
@@ -88,6 +93,15 @@ def read_installed_generation(
         authority = snapshot.authority
         if not isinstance(authority, GenerationProjectAuthority):
             raise GenerationReadError("The project has no installed generation authority.")
+        intent = (
+            binding.store_path
+            / ".replica/v1/actors"
+            / authority.pointer.installed_for_user_id
+            / "refresh-intent.json"
+        )
+        _validate_managed_path(binding.store_path, intent)
+        if _lstat_optional(intent) is not None:
+            raise RefreshRequiredError("Refresh completion admission is required.")
         try:
             projection = _capture(authority)
         except (GenerationInstallError, GenerationProjectionVerificationError) as exc:

--- a/packages/nauro/src/nauro/store/generation_refresh_intent.py
+++ b/packages/nauro/src/nauro/store/generation_refresh_intent.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, StrictInt, StrictStr, model_validator
+
+from nauro.store.generation_authority import _parse_marker, _strict_json_preflight
+from nauro.store.generation_refresh_state import (
+    GenerationRefreshEvidenceError,
+    RefreshControlPair,
+    RefreshControlState,
+    _carrier,
+    _pointer,
+)
+
+MAX_INTENT_BYTES = 128 * 1024
+
+
+def _canonical(value: object) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode()
+
+
+class RefreshIntent(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    schema_version: StrictInt
+    kind: Literal["refresh", "reconcile"]
+    marker_json: StrictStr
+    base_pointer_json: StrictStr
+    base_authorization_json: StrictStr
+    target_pointer_json: StrictStr
+    target_authorization_json: StrictStr
+    predecessor_digest: StrictStr | None
+
+    @model_validator(mode="after")
+    def validate_transition(self) -> RefreshIntent:
+        if self.schema_version != 1:
+            raise ValueError("unsupported refresh intent version")
+        marker = _parse_marker(self.marker_json)
+        if marker.canonical_bytes() != self.marker_json.encode():
+            raise ValueError("noncanonical refresh marker")
+        before = _pointer(self.base_pointer_json.encode())
+        prior_view = _carrier(self.base_authorization_json.encode())
+        target = RefreshControlPair(
+            self.target_pointer_json.encode(), self.target_authorization_json.encode()
+        )
+        after = _pointer(target.pointer_json)
+        for record in (before, prior_view, after):
+            if (
+                record.project_id != marker.project_id
+                or record.store_format_version != marker.store_format_version
+                or record.installed_for_user_id != before.installed_for_user_id
+            ):
+                raise ValueError("refresh binding mismatch")
+        if after.installed_state_id in (before.installed_state_id, prior_view.installed_state_id):
+            raise ValueError("refresh must allocate a new install identity")
+        if self.kind == "refresh":
+            RefreshControlPair(
+                self.base_pointer_json.encode(), self.base_authorization_json.encode()
+            )
+        elif self.predecessor_digest is None:
+            raise ValueError("reconciliation requires preserved evidence")
+        if self.predecessor_digest is not None and (
+            len(self.predecessor_digest) != 64
+            or any(c not in "0123456789abcdef" for c in self.predecessor_digest)
+        ):
+            raise ValueError("invalid predecessor digest")
+        return self
+
+    def classify(self, marker: bytes, pointer: bytes, carrier: bytes) -> RefreshControlState:
+        _pointer(pointer)
+        _carrier(carrier)
+        if _parse_marker(marker).canonical_bytes() != marker:
+            raise GenerationRefreshEvidenceError("Refresh marker must be canonical.")
+        if marker != self.marker_json.encode():
+            return "conflict"
+        if pointer == self.base_pointer_json.encode():
+            if carrier == self.base_authorization_json.encode():
+                return "base_present"
+            if carrier == self.target_authorization_json.encode():
+                return "carrier_published"
+        if (
+            pointer == self.target_pointer_json.encode()
+            and carrier == self.target_authorization_json.encode()
+        ):
+            return "target_present"
+        return "conflict"
+
+
+def encode_intent(intent: RefreshIntent) -> bytes:
+    checked = RefreshIntent.model_validate(intent.model_dump())
+    payload = checked.model_dump()
+    digest = hashlib.sha256(_canonical(payload)).hexdigest()
+    raw = _canonical({"payload": payload, "digest": digest})
+    if len(raw) > MAX_INTENT_BYTES:
+        raise GenerationRefreshEvidenceError("Refresh intent exceeds the size limit.")
+    return raw
+
+
+def decode_intent(raw: bytes) -> RefreshIntent:
+    if type(raw) is not bytes or len(raw) > MAX_INTENT_BYTES:
+        raise GenerationRefreshEvidenceError("Refresh intent requires bounded bytes.")
+    try:
+        _strict_json_preflight(raw)
+        envelope = json.loads(raw)
+        if type(envelope) is not dict or set(envelope) != {"payload", "digest"}:
+            raise ValueError("invalid envelope")
+        intent = RefreshIntent.model_validate(envelope["payload"])
+        if encode_intent(intent) != raw:
+            raise ValueError("noncanonical or corrupt intent")
+        return intent
+    except (ValueError, TypeError, UnicodeError, RecursionError) as exc:
+        raise GenerationRefreshEvidenceError("Refresh intent is corrupt.") from exc
+
+
+def require_predecessor(intent: RefreshIntent, raw: bytes) -> None:
+    if hashlib.sha256(raw).hexdigest() != intent.predecessor_digest:
+        raise GenerationRefreshEvidenceError("Refresh predecessor digest differs.")
+    prior = decode_intent(raw)
+    state = prior.classify(
+        intent.marker_json.encode(),
+        intent.base_pointer_json.encode(),
+        intent.base_authorization_json.encode(),
+    )
+    if state == "conflict" or (intent.kind == "refresh" and state != "target_present"):
+        raise GenerationRefreshEvidenceError("Refresh predecessor does not bind its successor.")
+    if (
+        _pointer(intent.target_pointer_json.encode()).installed_state_id
+        == _pointer(prior.target_pointer_json.encode()).installed_state_id
+    ):
+        raise GenerationRefreshEvidenceError("Refresh successor reused its predecessor identity.")

--- a/packages/nauro/src/nauro/store/generation_refresh_io.py
+++ b/packages/nauro/src/nauro/store/generation_refresh_io.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import os
+import stat
+from contextlib import suppress
+from dataclasses import dataclass
+from pathlib import Path
+
+from nauro_core.identifiers import IdentifierKind, validate_identifier
+
+from nauro.store._atomic import _open_random_tmp
+from nauro.store.generation_installation import _read_expected
+from nauro.store.generation_refresh_intent import MAX_INTENT_BYTES
+from nauro.store.generation_refresh_state import GenerationRefreshEvidenceError
+from nauro.store.replica_control import (
+    _READ_FLAGS,
+    _is_link_or_reparse,
+    _validate_managed_path,
+    _validate_store_path,
+)
+from nauro.store.resolution import ResolvedProjectBinding
+
+
+@dataclass(frozen=True)
+class RefreshPaths:
+    store: Path
+    actor: Path
+
+    @property
+    def marker(self) -> Path:
+        return self.store / ".replica/authority.json"
+
+    @property
+    def pointer(self) -> Path:
+        return self.actor / "pointer.json"
+
+    @property
+    def carrier(self) -> Path:
+        return self.actor / "authorization-view.json"
+
+    @property
+    def intent(self) -> Path:
+        return self.actor / "refresh-intent.json"
+
+    @property
+    def history(self) -> Path:
+        return self.actor / "refresh-history"
+
+
+def refresh_paths(binding: ResolvedProjectBinding, actor: str) -> RefreshPaths:
+    validate_identifier(IdentifierKind.ulid, actor, field="actor")
+    store = _validate_store_path(binding)
+    paths = RefreshPaths(store, store / ".replica/v1/actors" / actor)
+    _validate_managed_path(store, paths.actor)
+    return paths
+
+
+def read_evidence(paths: RefreshPaths, path: Path, *, archive: bool = False) -> bytes | None:
+    _validate_managed_path(paths.store, path)
+    try:
+        before = path.lstat()
+    except FileNotFoundError:
+        return None
+    if (
+        _is_link_or_reparse(before)
+        or not stat.S_ISREG(before.st_mode)
+        or (before.st_nlink != 1 and not archive)
+        or before.st_size > MAX_INTENT_BYTES
+    ):
+        raise GenerationRefreshEvidenceError("Refresh evidence is not a bounded regular file.")
+    identity = before.st_dev, before.st_ino
+    raw = _read_expected(path, before.st_size, identity, "refresh evidence")
+    _validate_managed_path(paths.store, path)
+    after = path.lstat()
+    if (
+        _is_link_or_reparse(after)
+        or (after.st_dev, after.st_ino, after.st_size, after.st_nlink)
+        != (before.st_dev, before.st_ino, before.st_size, before.st_nlink)
+        or len(raw) != before.st_size
+    ):
+        raise GenerationRefreshEvidenceError("Refresh evidence changed during read.")
+    return raw
+
+
+def sync_directory(paths: RefreshPaths, path: Path) -> None:
+    _validate_managed_path(paths.store, path)
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(path, flags)
+    try:
+        opened = os.fstat(descriptor)
+        before = path.lstat()
+        if (
+            _is_link_or_reparse(opened)
+            or not stat.S_ISDIR(opened.st_mode)
+            or (opened.st_dev, opened.st_ino) != (before.st_dev, before.st_ino)
+        ):
+            raise GenerationRefreshEvidenceError("Refresh directory identity changed.")
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def sync_file(paths: RefreshPaths, path: Path) -> None:
+    _validate_managed_path(paths.store, path)
+    descriptor = os.open(path, _READ_FLAGS)
+    try:
+        opened, before = os.fstat(descriptor), path.lstat()
+        if (
+            _is_link_or_reparse(opened)
+            or not stat.S_ISREG(opened.st_mode)
+            or (opened.st_dev, opened.st_ino) != (before.st_dev, before.st_ino)
+        ):
+            raise GenerationRefreshEvidenceError("Refresh file identity changed.")
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def sync_parents(paths: RefreshPaths, path: Path) -> None:
+    path.relative_to(paths.store)
+    while True:
+        sync_directory(paths, path)
+        if path == paths.store:
+            return
+        path = path.parent
+
+
+def durable_replace(paths: RefreshPaths, path: Path, raw: bytes) -> None:
+    _validate_managed_path(paths.store, path)
+    descriptor, temporary = _open_random_tmp(path, 0o600)
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(raw)
+            handle.flush()
+            os.fsync(handle.fileno())
+        _validate_managed_path(paths.store, path)
+        os.replace(temporary, path)
+        sync_directory(paths, path.parent)
+        if read_evidence(paths, path) != raw:
+            raise GenerationRefreshEvidenceError("Refresh replacement readback differs.")
+    finally:
+        with suppress(OSError):
+            temporary.unlink(missing_ok=True)
+
+
+def preserve_predecessor(paths: RefreshPaths, digest: str, raw: bytes) -> None:
+    import hashlib
+
+    if hashlib.sha256(raw).hexdigest() != digest:
+        raise GenerationRefreshEvidenceError("Refresh archive digest differs.")
+    _validate_managed_path(paths.store, paths.history)
+    paths.history.mkdir(exist_ok=True)
+    _validate_managed_path(paths.store, paths.history)
+    archive = paths.history / f"{digest}.json"
+    existing = read_evidence(paths, archive, archive=True)
+    if existing is None:
+        descriptor, temporary = _open_random_tmp(archive, 0o600)
+        try:
+            with os.fdopen(descriptor, "wb") as handle:
+                handle.write(raw)
+                handle.flush()
+                os.fsync(handle.fileno())
+            # A crash after link can retain the temporary alias; archive reads verify exact bytes.
+            os.link(temporary, archive)
+        finally:
+            with suppress(OSError):
+                temporary.unlink(missing_ok=True)
+    if read_evidence(paths, archive, archive=True) != raw:
+        raise GenerationRefreshEvidenceError("Refresh archive is occupied by different evidence.")
+    sync_file(paths, archive)
+    sync_parents(paths, paths.history)

--- a/packages/nauro/src/nauro/store/generation_refresh_state.py
+++ b/packages/nauro/src/nauro/store/generation_refresh_state.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from nauro.store.generation_authority import (
+    GenerationAuthorityError,
+    InstalledAuthorizationView,
+    InstalledGenerationPointer,
+    _parse_authorization_view,
+    _parse_marker,
+    _parse_pointer,
+)
+
+_MAX_CONTROL_BYTES = 16 * 1024
+
+
+class GenerationRefreshEvidenceError(GenerationAuthorityError):
+    code = "generation_refresh_evidence_invalid"
+
+
+RefreshControlState = Literal["base_present", "carrier_published", "target_present", "conflict"]
+
+
+def _bounded(raw: bytes) -> None:
+    if type(raw) is not bytes or not raw or len(raw) > _MAX_CONTROL_BYTES:
+        raise GenerationRefreshEvidenceError("Refresh control evidence must be bounded bytes.")
+
+
+def _pointer(raw: bytes) -> InstalledGenerationPointer:
+    _bounded(raw)
+    parsed = _parse_pointer(raw)
+    if parsed.canonical_bytes() != raw:
+        raise GenerationRefreshEvidenceError("Refresh pointer evidence must be canonical.")
+    return parsed
+
+
+def _carrier(raw: bytes) -> InstalledAuthorizationView:
+    _bounded(raw)
+    parsed = _parse_authorization_view(raw)
+    if parsed.canonical_bytes() != raw:
+        raise GenerationRefreshEvidenceError("Refresh authorization evidence must be canonical.")
+    return parsed
+
+
+@dataclass(frozen=True)
+class RefreshControlPair:
+    pointer_json: bytes
+    authorization_json: bytes
+
+    def __post_init__(self) -> None:
+        pointer, carrier = _pointer(self.pointer_json), _carrier(self.authorization_json)
+        if any(
+            getattr(pointer, name) != getattr(carrier, name)
+            for name in InstalledAuthorizationView.model_fields
+        ):
+            raise GenerationRefreshEvidenceError("Refresh control records do not form a pair.")
+
+
+@dataclass(frozen=True)
+class RefreshControlTransition:
+    marker_json: bytes
+    base: RefreshControlPair
+    target: RefreshControlPair
+
+    def __post_init__(self) -> None:
+        _bounded(self.marker_json)
+        marker = _parse_marker(self.marker_json)
+        if marker.canonical_bytes() != self.marker_json:
+            raise GenerationRefreshEvidenceError("Refresh marker evidence must be canonical.")
+        if type(self.base) is not RefreshControlPair or type(self.target) is not RefreshControlPair:
+            raise GenerationRefreshEvidenceError("Refresh requires validated control pairs.")
+        base = RefreshControlPair(self.base.pointer_json, self.base.authorization_json)
+        target = RefreshControlPair(self.target.pointer_json, self.target.authorization_json)
+        before, after = _pointer(base.pointer_json), _pointer(target.pointer_json)
+        if any(
+            getattr(before, name) != getattr(after, name)
+            for name in ("project_id", "store_format_version", "installed_for_user_id")
+        ):
+            raise GenerationRefreshEvidenceError("Refresh cannot cross project, format or actor.")
+        if (
+            marker.project_id != before.project_id
+            or marker.store_format_version != before.store_format_version
+        ):
+            raise GenerationRefreshEvidenceError("Refresh marker does not bind the control pairs.")
+        if before.installed_state_id == after.installed_state_id:
+            raise GenerationRefreshEvidenceError("Refresh requires a new install-state identity.")
+        object.__setattr__(self, "base", base)
+        object.__setattr__(self, "target", target)
+
+
+def classify_refresh_control(
+    transition: RefreshControlTransition,
+    *,
+    marker_json: bytes,
+    pointer_json: bytes,
+    authorization_json: bytes,
+) -> RefreshControlState:
+    """Classify exact observations without granting authority to read or write."""
+    if type(transition) is not RefreshControlTransition:
+        raise GenerationRefreshEvidenceError("Refresh requires a validated transition.")
+    checked = RefreshControlTransition(transition.marker_json, transition.base, transition.target)
+    _bounded(marker_json)
+    marker = _parse_marker(marker_json)
+    if marker.canonical_bytes() != marker_json:
+        raise GenerationRefreshEvidenceError("Refresh marker evidence must be canonical.")
+    _pointer(pointer_json)
+    _carrier(authorization_json)
+    if marker_json != checked.marker_json:
+        return "conflict"
+    if pointer_json == checked.base.pointer_json:
+        if authorization_json == checked.base.authorization_json:
+            return "base_present"
+        if authorization_json == checked.target.authorization_json:
+            return "carrier_published"
+    if (
+        pointer_json == checked.target.pointer_json
+        and authorization_json == checked.target.authorization_json
+    ):
+        return "target_present"
+    return "conflict"

--- a/packages/nauro/src/nauro/store/generation_refresh_state.py
+++ b/packages/nauro/src/nauro/store/generation_refresh_state.py
@@ -96,7 +96,7 @@ def classify_refresh_control(
     pointer_json: bytes,
     authorization_json: bytes,
 ) -> RefreshControlState:
-    """Classify exact observations without granting authority to read or write."""
+    """Classify bytes only; target_present proves neither permission nor durability."""
     if type(transition) is not RefreshControlTransition:
         raise GenerationRefreshEvidenceError("Refresh requires a validated transition.")
     checked = RefreshControlTransition(transition.marker_json, transition.base, transition.target)

--- a/packages/nauro/src/nauro/sync/generation_acquisition.py
+++ b/packages/nauro/src/nauro/sync/generation_acquisition.py
@@ -319,6 +319,21 @@ def acquire_generation_projection(
                     raise
 
 
+def check_generation_projection(
+    binding: ResolvedProjectBinding,
+    *,
+    active_user_id: str,
+    session: TransferSession | None = None,
+) -> GenerationProjectionTarget:
+    if binding.mode != "cloud":
+        raise GenerationAcquisitionError("Generation acquisition requires a cloud project binding.")
+    user_id = validate_identifier(IdentifierKind.ulid, active_user_id, field="active_user_id")
+    with operation_session(session) as active:
+        target, manifest = _fetch_projection(active, resolve_api_url(), binding, user_id)
+        _parse_manifest(target, manifest)
+        return target
+
+
 __all__ = [
     "GenerationAcquisitionError",
     "GenerationSupersededError",

--- a/packages/nauro/src/nauro/sync/generation_refresh.py
+++ b/packages/nauro/src/nauro/sync/generation_refresh.py
@@ -1,0 +1,306 @@
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+from nauro.store.generation_authority import (
+    GenerationAuthorityError,
+    GenerationProjectAuthority,
+    RefreshRequiredError,
+    _parse_marker,
+)
+from nauro.store.generation_installation import (
+    _build_carrier,
+    _build_pointer,
+    _layout,
+    _require_active_actor,
+    audit_generation_tree,
+    install_generation_root,
+)
+from nauro.store.generation_projection import (
+    GenerationProjectionIdentity,
+    GenerationProjectionTarget,
+    VerifiedGenerationProjection,
+    verify_generation_projection,
+)
+from nauro.store.generation_read import _capture
+from nauro.store.generation_refresh_intent import (
+    RefreshIntent,
+    decode_intent,
+    encode_intent,
+    require_predecessor,
+)
+from nauro.store.generation_refresh_io import (
+    RefreshPaths,
+    durable_replace,
+    preserve_predecessor,
+    read_evidence,
+    refresh_paths,
+    sync_file,
+    sync_parents,
+)
+from nauro.store.generation_refresh_state import (
+    GenerationRefreshEvidenceError,
+    RefreshControlPair,
+    _pointer,
+)
+from nauro.store.generation_store import GenerationSnapshotStore
+from nauro.store.replica_control import _native_control_lock, _validate_managed_path
+from nauro.store.repo_config import generate_ulid
+from nauro.store.resolution import ResolvedProjectBinding
+from nauro.sync.generation_acquisition import (
+    acquire_generation_projection,
+    check_generation_projection,
+)
+from nauro.sync.remote import TransferSession
+
+
+class GenerationRefreshDurabilityError(GenerationAuthorityError):
+    code = "generation_refresh_unresolved"
+
+
+@dataclass(frozen=True)
+class PreparedGenerationRefresh:
+    projection: VerifiedGenerationProjection
+    marker: bytes
+    pointer: bytes
+    carrier: bytes
+    prior_intent: bytes | None
+
+
+@contextmanager
+def _locked(binding: ResolvedProjectBinding, actor: str) -> Iterator[RefreshPaths]:
+    paths = refresh_paths(binding, actor)
+    lock_path = paths.store / ".replica-control.lock"
+    _validate_managed_path(paths.store, lock_path)
+    try:
+        with _native_control_lock(paths.store, lock_path, -1):
+            _require_active_actor(actor)
+            yield paths
+    except OSError as exc:
+        raise GenerationRefreshDurabilityError("Refresh persistence requires recovery.") from exc
+
+
+def _controls(paths: RefreshPaths) -> tuple[bytes, bytes, bytes]:
+    raw = tuple(read_evidence(paths, path) for path in (paths.marker, paths.pointer, paths.carrier))
+    marker, pointer, carrier = raw
+    if marker is None or pointer is None or carrier is None:
+        raise GenerationRefreshEvidenceError("Refresh control evidence is missing.")
+    return marker, pointer, carrier
+
+
+def _intent(paths: RefreshPaths) -> tuple[bytes, RefreshIntent]:
+    raw = read_evidence(paths, paths.intent)
+    if raw is None:
+        raise RefreshRequiredError("Explicit refresh bootstrap or recovery is required.")
+    intent = decode_intent(raw)
+    if intent.predecessor_digest is not None:
+        archived = read_evidence(
+            paths, paths.history / f"{intent.predecessor_digest}.json", archive=True
+        )
+        if archived is None:
+            raise GenerationRefreshEvidenceError("Refresh predecessor is missing.")
+        require_predecessor(intent, archived)
+    if intent.classify(*_controls(paths)) == "conflict":
+        raise GenerationRefreshEvidenceError("Refresh controls conflict with retained evidence.")
+    return raw, intent
+
+
+def _target(binding: ResolvedProjectBinding, intent: RefreshIntent) -> GenerationProjectionTarget:
+    pointer = _pointer(intent.target_pointer_json.encode())
+    identity = GenerationProjectionIdentity.model_validate(
+        {name: getattr(pointer, name) for name in GenerationProjectionIdentity.model_fields}
+    )
+    return GenerationProjectionTarget(binding, identity)
+
+
+def _authorize(target: GenerationProjectionTarget, session: TransferSession | None) -> None:
+    actor = target.identity.installed_for_user_id
+    _require_active_actor(actor)
+    current = check_generation_projection(target.binding, active_user_id=actor, session=session)
+    _require_active_actor(actor)
+    if current != target:
+        raise RefreshRequiredError("The current authorized projection requires reconciliation.")
+
+
+def _prepare(
+    binding: ResolvedProjectBinding, actor: str, session: TransferSession | None, *, bootstrap: bool
+) -> PreparedGenerationRefresh:
+    with _locked(binding, actor) as paths:
+        marker, pointer, carrier = _controls(paths)
+        raw = read_evidence(paths, paths.intent)
+        if bootstrap:
+            if raw is not None:
+                raise RefreshRequiredError("An existing refresh intent cannot be bootstrapped.")
+            pair = RefreshControlPair(pointer, carrier)
+            observed = _pointer(pair.pointer_json)
+            if observed.installed_for_user_id != actor or observed.project_id != binding.project_id:
+                raise GenerationRefreshEvidenceError(
+                    "Bootstrap controls belong to another binding."
+                )
+        else:
+            raw, _ = _intent(paths)
+    projection = acquire_generation_projection(binding, active_user_id=actor, session=session)
+    return PreparedGenerationRefresh(projection, marker, pointer, carrier, raw)
+
+
+def prepare_initial_generation_refresh(
+    binding: ResolvedProjectBinding, *, actor: str, session: TransferSession | None = None
+) -> PreparedGenerationRefresh:
+    # This entry requires an explicit operator bootstrap, never inference from a missing intent.
+    return _prepare(binding, actor, session, bootstrap=True)
+
+
+def prepare_generation_refresh(
+    binding: ResolvedProjectBinding, *, actor: str, session: TransferSession | None = None
+) -> PreparedGenerationRefresh:
+    return _prepare(binding, actor, session, bootstrap=False)
+
+
+def _new_intent(prepared: PreparedGenerationRefresh) -> RefreshIntent:
+    target = prepared.projection.target
+    actor = target.identity.installed_for_user_id
+    state_id = generate_ulid()
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+    pointer = _build_pointer(target, actor, target.identity.committed_at, now, state_id)
+    carrier = _build_carrier(target, actor, target.identity.committed_at, state_id)
+    prior = prepared.prior_intent
+    return RefreshIntent(
+        schema_version=1,
+        kind="refresh" if prior is None else "reconcile",
+        marker_json=prepared.marker.decode(),
+        base_pointer_json=prepared.pointer.decode(),
+        base_authorization_json=prepared.carrier.decode(),
+        target_pointer_json=pointer.canonical_bytes().decode(),
+        target_authorization_json=carrier.canonical_bytes().decode(),
+        predecessor_digest=None if prior is None else hashlib.sha256(prior).hexdigest(),
+    )
+
+
+def _sync_target(paths: RefreshPaths, projection: VerifiedGenerationProjection) -> None:
+    root = _layout(paths.store, projection.target).root_path
+    audit_generation_tree(root, projection)
+    files = [root / "manifest.json", *(root / "store" / a.path for a in projection.artifacts)]
+    for path in files:
+        sync_file(paths, path)
+    for directory in sorted({path.parent for path in files}, key=lambda path: -len(path.parts)):
+        sync_parents(paths, directory)
+    audit_generation_tree(root, projection)
+
+
+def _complete(
+    paths: RefreshPaths,
+    intent: RefreshIntent,
+    projection: VerifiedGenerationProjection,
+    session: TransferSession | None,
+) -> GenerationSnapshotStore:
+    if projection.target != _target(projection.target.binding, intent):
+        raise GenerationRefreshEvidenceError("Refresh target differs from retained intent.")
+    raw = encode_intent(intent)
+    if _intent(paths)[0] != raw or intent.classify(*_controls(paths)) != "target_present":
+        raise RefreshRequiredError("Explicit refresh recovery is required before admission.")
+    _authorize(projection.target, session)
+    _sync_target(paths, projection)
+    for path in (paths.marker, paths.intent, paths.carrier, paths.pointer):
+        sync_file(paths, path)
+        sync_parents(paths, path.parent)
+    if intent.predecessor_digest is not None:
+        sync_file(paths, paths.history / f"{intent.predecessor_digest}.json")
+        sync_parents(paths, paths.history)
+    if _intent(paths)[0] != raw or intent.classify(*_controls(paths)) != "target_present":
+        raise GenerationRefreshEvidenceError("Refresh evidence changed during completion.")
+    _sync_target(paths, projection)
+    _authorize(projection.target, session)
+    if _intent(paths)[0] != raw or intent.classify(*_controls(paths)) != "target_present":
+        raise GenerationRefreshEvidenceError("Refresh evidence changed before admission.")
+    return GenerationSnapshotStore(projection)
+
+
+def _resume(
+    paths: RefreshPaths,
+    intent: RefreshIntent,
+    projection: VerifiedGenerationProjection,
+    session: TransferSession | None,
+) -> GenerationSnapshotStore:
+    _authorize(projection.target, session)
+    _sync_target(paths, projection)
+    sync_file(paths, paths.marker)
+    sync_file(paths, paths.intent)
+    sync_parents(paths, paths.actor)
+    if _intent(paths)[0] != encode_intent(intent):
+        raise GenerationRefreshEvidenceError("Refresh intent changed before publication.")
+    _authorize(projection.target, session)
+    state = intent.classify(*_controls(paths))
+    if state == "base_present":
+        _require_active_actor(projection.target.identity.installed_for_user_id)
+        durable_replace(paths, paths.carrier, intent.target_authorization_json.encode())
+        state = intent.classify(*_controls(paths))
+    if state == "carrier_published":
+        sync_file(paths, paths.carrier)
+        sync_parents(paths, paths.actor)
+        _require_active_actor(projection.target.identity.installed_for_user_id)
+        durable_replace(paths, paths.pointer, intent.target_pointer_json.encode())
+    return _complete(paths, intent, projection, session)
+
+
+def commit_generation_refresh(
+    prepared: PreparedGenerationRefresh, *, session: TransferSession | None = None
+) -> GenerationSnapshotStore:
+    projection = verify_generation_projection(
+        prepared.projection.target,
+        manifest_json=prepared.projection.manifest_json,
+        artifacts=tuple((a.path, a.content) for a in prepared.projection.artifacts),
+    )
+    target = projection.target
+    actor = target.identity.installed_for_user_id
+    _authorize(target, session)
+    install_generation_root(projection)
+    with _locked(target.binding, actor) as paths:
+        if _controls(paths) != (prepared.marker, prepared.pointer, prepared.carrier):
+            raise GenerationRefreshEvidenceError("The prepared refresh base is stale.")
+        if read_evidence(paths, paths.intent) != prepared.prior_intent:
+            raise GenerationRefreshEvidenceError("The prepared refresh intent is stale.")
+        _authorize(target, session)
+        _sync_target(paths, projection)
+        for path in (paths.marker, paths.pointer, paths.carrier):
+            sync_file(paths, path)
+        sync_parents(paths, paths.actor)
+        if prepared.prior_intent is not None:
+            _, prior = _intent(paths)
+            if _target(target.binding, prior) == target:
+                return _resume(paths, prior, projection, session)
+        intent = _new_intent(prepared)
+        if prepared.prior_intent is not None:
+            require_predecessor(intent, prepared.prior_intent)
+            assert intent.predecessor_digest is not None
+            preserve_predecessor(paths, intent.predecessor_digest, prepared.prior_intent)
+        durable_replace(paths, paths.intent, encode_intent(intent))
+        return _resume(paths, intent, projection, session)
+
+
+def admit_generation_store(
+    binding: ResolvedProjectBinding, *, actor: str, session: TransferSession | None = None
+) -> GenerationSnapshotStore:
+    with _locked(binding, actor) as paths:
+        _, intent = _intent(paths)
+        if intent.classify(*_controls(paths)) != "target_present":
+            raise RefreshRequiredError("Explicit refresh recovery is required before admission.")
+        target = _target(binding, intent)
+        _authorize(target, session)
+        authority = GenerationProjectAuthority(
+            binding,
+            _parse_marker(intent.marker_json),
+            _pointer(intent.target_pointer_json.encode()),
+        )
+        projection = _capture(authority)
+        return _complete(paths, intent, projection, session)
+
+
+def recover_generation_refresh(
+    binding: ResolvedProjectBinding, *, actor: str, session: TransferSession | None = None
+) -> GenerationSnapshotStore:
+    prepared = prepare_generation_refresh(binding, actor=actor, session=session)
+    return commit_generation_refresh(prepared, session=session)

--- a/packages/nauro/tests/test_generation_read.py
+++ b/packages/nauro/tests/test_generation_read.py
@@ -120,14 +120,14 @@ def test_capture_refuses_flat_authority(installed):
         )
 
 
-def test_capture_has_only_the_dormant_store_consumer():
+def test_capture_has_only_the_expected_dormant_consumers():
     root = Path(reader.__file__).parents[1]
     consumers = []
     for path in root.rglob("*.py"):
         for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
             if isinstance(node, ast.ImportFrom) and node.module == "nauro.store.generation_read":
                 consumers.append(path.relative_to(root).as_posix())
-    assert consumers == ["store/generation_store.py"]
+    assert sorted(consumers) == ["store/generation_store.py", "sync/generation_refresh.py"]
 
 
 def test_capture_refuses_a_replaced_file(installed, monkeypatch):

--- a/packages/nauro/tests/test_generation_refresh.py
+++ b/packages/nauro/tests/test_generation_refresh.py
@@ -1,0 +1,515 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import sys
+
+import pytest
+
+from nauro.store import generation_installation as installation
+from nauro.store import generation_refresh_io as durable
+from nauro.store.generation_authority import RefreshRequiredError, ReplicaActorMismatchError
+from nauro.store.generation_projection import (
+    GenerationProjectionIdentity,
+    GenerationProjectionTarget,
+    verify_generation_projection,
+)
+from nauro.store.generation_read import read_installed_generation
+from nauro.store.generation_refresh_intent import decode_intent, encode_intent
+from nauro.store.generation_refresh_state import GenerationRefreshEvidenceError
+from nauro.sync import generation_refresh as refresh
+from tests.test_generation_installation import USER_ID, _projection
+
+POSIX = pytest.mark.skipif(sys.platform == "win32", reason="POSIX durability implementation")
+
+
+def _target(generation="01K66666666666666666666666", scope="b" * 64):
+    seed = _projection({"state.md": b"fresh state\n"})
+    manifest = json.loads(seed.manifest_json)
+    manifest.update(generation_id=generation, projection_scope_id=scope)
+    raw = json.dumps(manifest, sort_keys=True, separators=(",", ":")).encode()
+    fields = seed.target.identity.model_dump()
+    fields.update(
+        generation_id=generation,
+        projection_scope_id=scope,
+        manifest_digest=hashlib.sha256(raw).hexdigest(),
+    )
+    return verify_generation_projection(
+        GenerationProjectionTarget(seed.target.binding, GenerationProjectionIdentity(**fields)),
+        manifest_json=raw,
+        artifacts=(("state.md", b"fresh state\n"),),
+    )
+
+
+@pytest.fixture
+def replica(monkeypatch):
+    base = _projection()
+    base.target.binding.store_path.mkdir(parents=True)
+    monkeypatch.setattr(installation, "read_active_user_id", lambda: USER_ID)
+    root = installation.install_generation_root(base)
+    installation.publish_generation_control(root)
+    current = [_target()]
+    monkeypatch.setattr(refresh, "acquire_generation_projection", lambda *a, **k: current[0])
+    monkeypatch.setattr(refresh, "check_generation_projection", lambda *a, **k: current[0].target)
+    return base.target.binding, current
+
+
+def _bootstrap(binding):
+    return refresh.prepare_initial_generation_refresh(binding, actor=USER_ID)
+
+
+def _active(binding):
+    paths = durable.refresh_paths(binding, USER_ID)
+    raw = paths.intent.read_bytes()
+    return paths, raw, decode_intent(raw)
+
+
+@POSIX
+def test_commit_and_each_read_repeat_completion_barriers(replica, monkeypatch):
+    binding, _ = replica
+    result = refresh.commit_generation_refresh(_bootstrap(binding))
+    assert result.read_file("state.md") == "fresh state\n"
+    paths, raw, intent = _active(binding)
+    assert encode_intent(intent) == raw
+    calls = []
+    original = refresh.sync_file
+
+    def sync(paths, path):
+        calls.append(path)
+        original(paths, path)
+
+    monkeypatch.setattr(refresh, "sync_file", sync)
+    for _ in range(2):
+        assert (
+            refresh.admit_generation_store(binding, actor=USER_ID).read_file("state.md")
+            == "fresh state\n"
+        )
+        assert paths.pointer in calls and paths.carrier in calls and paths.intent in calls
+        calls.clear()
+    with pytest.raises(RefreshRequiredError):
+        read_installed_generation(
+            binding,
+            active_user_id=USER_ID,
+            active_projection_scope_id=json.loads(intent.target_authorization_json)[
+                "projection_scope_id"
+            ],
+        )
+    with pytest.raises(RefreshRequiredError):
+        installation.publish_generation_control(installation.install_generation_root(_target()))
+
+
+@POSIX
+@pytest.mark.parametrize("state", ["base_present", "carrier_published", "target_present"])
+def test_revoked_scope_reconciles_each_partial_state_and_preserves_evidence(
+    replica, monkeypatch, state
+):
+    binding, current = replica
+    prepared = _bootstrap(binding)
+    original = refresh.durable_replace
+
+    def fail(paths, path, raw):
+        if (state == "base_present" and path == paths.carrier) or (
+            state == "carrier_published" and path == paths.pointer
+        ):
+            raise OSError("disk full")
+        original(paths, path, raw)
+        if state == "target_present" and path == paths.pointer:
+            raise OSError("final barrier uncertain")
+
+    monkeypatch.setattr(refresh, "durable_replace", fail)
+    with pytest.raises(refresh.GenerationRefreshDurabilityError):
+        refresh.commit_generation_refresh(prepared)
+    paths, old_raw, old_intent = _active(binding)
+    assert (
+        old_intent.classify(
+            paths.marker.read_bytes(), paths.pointer.read_bytes(), paths.carrier.read_bytes()
+        )
+        == state
+    )
+    observed = paths.pointer.read_bytes(), paths.carrier.read_bytes()
+    current[0] = _target("01K77777777777777777777777", "c" * 64)
+    with pytest.raises(RefreshRequiredError):
+        refresh.admit_generation_store(binding, actor=USER_ID)
+    monkeypatch.setattr(refresh, "durable_replace", original)
+    assert (
+        refresh.recover_generation_refresh(binding, actor=USER_ID).read_file("state.md")
+        == "fresh state\n"
+    )
+    _, new_raw, successor = _active(binding)
+    assert successor.kind == "reconcile"
+    assert successor.predecessor_digest == hashlib.sha256(old_raw).hexdigest()
+    assert (paths.history / f"{successor.predecessor_digest}.json").read_bytes() == old_raw
+    assert (
+        successor.base_pointer_json.encode(),
+        successor.base_authorization_json.encode(),
+    ) == observed
+    assert new_raw != old_raw
+
+
+@POSIX
+def test_repeated_reconciliation_preserves_each_predecessor(replica, monkeypatch):
+    binding, current = replica
+    original = refresh.durable_replace
+
+    def fail(paths, path, raw):
+        original(paths, path, raw)
+        if path == paths.carrier:
+            raise OSError("lost process")
+
+    monkeypatch.setattr(refresh, "durable_replace", fail)
+    with pytest.raises(refresh.GenerationRefreshDurabilityError):
+        refresh.commit_generation_refresh(_bootstrap(binding))
+    first = _active(binding)[1]
+    current[0] = _target("01K77777777777777777777777", "c" * 64)
+    with pytest.raises(refresh.GenerationRefreshDurabilityError):
+        refresh.recover_generation_refresh(binding, actor=USER_ID)
+    second = _active(binding)[1]
+    current[0] = _target("01K88888888888888888888888", "d" * 64)
+    monkeypatch.setattr(refresh, "durable_replace", original)
+    refresh.recover_generation_refresh(binding, actor=USER_ID)
+    paths, _, _ = _active(binding)
+    for raw in (first, second):
+        assert (paths.history / f"{hashlib.sha256(raw).hexdigest()}.json").read_bytes() == raw
+
+
+@POSIX
+@pytest.mark.parametrize("file", ["marker", "intent", "pointer", "carrier"])
+def test_target_present_is_not_admitted_after_barrier_failure(replica, monkeypatch, file):
+    binding, _ = replica
+    refresh.commit_generation_refresh(_bootstrap(binding))
+    paths, before, _ = _active(binding)
+    original = refresh.sync_file
+
+    def fail(paths, path):
+        if path == getattr(paths, file):
+            raise OSError("barrier failed")
+        original(paths, path)
+
+    monkeypatch.setattr(refresh, "sync_file", fail)
+    with pytest.raises(refresh.GenerationRefreshDurabilityError):
+        refresh.admit_generation_store(binding, actor=USER_ID)
+    assert paths.intent.read_bytes() == before
+    monkeypatch.setattr(refresh, "sync_file", original)
+    assert (
+        refresh.admit_generation_store(binding, actor=USER_ID).read_file("state.md")
+        == "fresh state\n"
+    )
+
+
+@POSIX
+def test_authorization_failure_and_changed_account_deny_without_mutation(replica, monkeypatch):
+    binding, _ = replica
+    refresh.commit_generation_refresh(_bootstrap(binding))
+    paths, before, _ = _active(binding)
+
+    def revoked(*args, **kwargs):
+        raise RefreshRequiredError("revoked")
+
+    monkeypatch.setattr(refresh, "check_generation_projection", revoked)
+    with pytest.raises(RefreshRequiredError):
+        refresh.admit_generation_store(binding, actor=USER_ID)
+    monkeypatch.setattr(installation, "read_active_user_id", lambda: "01K88888888888888888888888")
+    with pytest.raises(ReplicaActorMismatchError):
+        refresh.recover_generation_refresh(binding, actor=USER_ID)
+    assert paths.intent.read_bytes() == before
+
+
+@POSIX
+def test_stale_preparation_and_missing_intent_refuse(replica):
+    binding, _ = replica
+    with pytest.raises(RefreshRequiredError):
+        refresh.prepare_generation_refresh(binding, actor=USER_ID)
+    one, two = _bootstrap(binding), _bootstrap(binding)
+    refresh.commit_generation_refresh(one)
+    with pytest.raises(GenerationRefreshEvidenceError):
+        refresh.commit_generation_refresh(two)
+
+
+@POSIX
+@pytest.mark.parametrize("boundary", ["intent", "carrier", "pointer"])
+def test_process_loss_after_replacement_recovers_from_exact_evidence(replica, boundary):
+    binding, _ = replica
+    script = """
+import os
+from nauro.store import generation_installation as installation
+from nauro.sync import generation_refresh as refresh
+from tests.test_generation_refresh import _target
+from tests.test_generation_installation import USER_ID
+installation.read_active_user_id = lambda: USER_ID
+projection = _target()
+refresh.acquire_generation_projection = lambda *a, **k: projection
+refresh.check_generation_projection = lambda *a, **k: projection.target
+original = refresh.durable_replace
+def stop(paths, path, raw):
+    original(paths, path, raw)
+    if path == getattr(paths, os.environ["REFRESH_STOP"]):
+        os._exit(73)
+refresh.durable_replace = stop
+prepared = refresh.prepare_initial_generation_refresh(projection.target.binding, actor=USER_ID)
+refresh.commit_generation_refresh(prepared)
+"""
+    env = dict(os.environ, REFRESH_STOP=boundary)
+    env["PYTHONPATH"] = str(__import__("pathlib").Path(__file__).parent.parent)
+    result = subprocess.run(
+        [sys.executable, "-c", script], env=env, capture_output=True, timeout=30
+    )
+    assert result.returncode == 73, result.stderr.decode()
+    old = _active(binding)[1]
+    assert (
+        refresh.recover_generation_refresh(binding, actor=USER_ID).read_file("state.md")
+        == "fresh state\n"
+    )
+    assert _active(binding)[1] == old
+
+
+@POSIX
+@pytest.mark.parametrize("failure", ["archive_barrier", "archive_corrupt", "archive_missing"])
+def test_predecessor_failures_refuse_without_replacing_active_intent(replica, monkeypatch, failure):
+    binding, current = replica
+    refresh.commit_generation_refresh(_bootstrap(binding))
+    paths, before, _ = _active(binding)
+    current[0] = _target("01K77777777777777777777777", "c" * 64)
+    prepared = refresh.prepare_generation_refresh(binding, actor=USER_ID)
+    archive = paths.history / f"{hashlib.sha256(before).hexdigest()}.json"
+    if failure == "archive_barrier":
+        original = durable.sync_file
+
+        def fail(paths, path):
+            if path == archive:
+                raise OSError("archive barrier")
+            original(paths, path)
+
+        monkeypatch.setattr(durable, "sync_file", fail)
+        expected = refresh.GenerationRefreshDurabilityError
+    elif failure == "archive_corrupt":
+        paths.history.mkdir()
+        archive.write_bytes(b"corrupt")
+        expected = GenerationRefreshEvidenceError
+    else:
+        refresh.commit_generation_refresh(prepared)
+        archive.unlink()
+        with pytest.raises(GenerationRefreshEvidenceError):
+            refresh.admit_generation_store(binding, actor=USER_ID)
+        return
+    with pytest.raises(expected):
+        refresh.commit_generation_refresh(prepared)
+    assert paths.intent.read_bytes() == before
+
+
+@POSIX
+def test_final_authorization_change_prevents_disclosure(replica, monkeypatch):
+    binding, current = replica
+    refresh.commit_generation_refresh(_bootstrap(binding))
+    calls = []
+
+    def changing(*args, **kwargs):
+        calls.append(1)
+        if len(calls) == 3:
+            return _target("01K77777777777777777777777", "c" * 64).target
+        return current[0].target
+
+    monkeypatch.setattr(refresh, "check_generation_projection", changing)
+    with pytest.raises(RefreshRequiredError):
+        refresh.admit_generation_store(binding, actor=USER_ID)
+    assert len(calls) == 3
+
+
+@POSIX
+@pytest.mark.parametrize("boundary", ["manifest", "artifact", "directory"])
+def test_target_data_and_directory_barrier_failures_deny_admission(replica, monkeypatch, boundary):
+    binding, _ = replica
+    refresh.commit_generation_refresh(_bootstrap(binding))
+    original_file = refresh.sync_file
+    original_parents = refresh.sync_parents
+
+    def file_sync(paths, path):
+        if (boundary == "manifest" and path.name == "manifest.json") or (
+            boundary == "artifact" and path.name == "state.md"
+        ):
+            raise OSError("data barrier failed")
+        original_file(paths, path)
+
+    def directories(paths, path):
+        if boundary == "directory":
+            raise OSError("directory barrier failed")
+        original_parents(paths, path)
+
+    monkeypatch.setattr(refresh, "sync_file", file_sync)
+    monkeypatch.setattr(refresh, "sync_parents", directories)
+    with pytest.raises(refresh.GenerationRefreshDurabilityError):
+        refresh.admit_generation_store(binding, actor=USER_ID)
+
+
+def test_unsupported_directory_barrier_stops_before_intent_or_control_mutation(
+    replica, monkeypatch
+):
+    binding, _ = replica
+    paths = durable.refresh_paths(binding, USER_ID)
+    before = paths.pointer.read_bytes(), paths.carrier.read_bytes()
+
+    def unsupported(*args):
+        raise OSError("directory durability unavailable")
+
+    monkeypatch.setattr(refresh, "sync_parents", unsupported)
+    with pytest.raises(refresh.GenerationRefreshDurabilityError):
+        refresh.commit_generation_refresh(_bootstrap(binding))
+    assert (paths.pointer.read_bytes(), paths.carrier.read_bytes()) == before
+    assert not paths.intent.exists()
+
+
+@POSIX
+@pytest.mark.parametrize("boundary", ["archive", "archive_link", "intent", "carrier", "pointer"])
+def test_process_loss_during_reconciliation_keeps_predecessor_and_resumes(replica, boundary):
+    binding, current = replica
+    refresh.commit_generation_refresh(_bootstrap(binding))
+    predecessor = _active(binding)[1]
+    script = """
+import os
+from nauro.store import generation_installation as installation
+from nauro.sync import generation_refresh as refresh
+from tests.test_generation_refresh import _target
+from tests.test_generation_installation import USER_ID
+installation.read_active_user_id = lambda: USER_ID
+projection = _target('01K77777777777777777777777', 'c' * 64)
+refresh.acquire_generation_projection = lambda *a, **k: projection
+refresh.check_generation_projection = lambda *a, **k: projection.target
+original = refresh.durable_replace
+archive = refresh.preserve_predecessor
+link = os.link
+def linked(source, destination):
+    link(source, destination)
+    if os.environ['REFRESH_STOP'] == 'archive_link':
+        os._exit(73)
+os.link = linked
+def save(paths, digest, raw):
+    archive(paths, digest, raw)
+    if os.environ['REFRESH_STOP'] == 'archive':
+        os._exit(73)
+def stop(paths, path, raw):
+    original(paths, path, raw)
+    boundary = os.environ['REFRESH_STOP']
+    if boundary not in ('archive', 'archive_link') and path == getattr(paths, boundary):
+        os._exit(73)
+refresh.durable_replace = stop
+refresh.preserve_predecessor = save
+refresh.recover_generation_refresh(projection.target.binding, actor=USER_ID)
+"""
+    env = dict(os.environ, REFRESH_STOP=boundary)
+    env["PYTHONPATH"] = str(__import__("pathlib").Path(__file__).parent.parent)
+    process = subprocess.run(
+        [sys.executable, "-c", script], env=env, capture_output=True, timeout=30
+    )
+    assert process.returncode == 73, process.stderr.decode()
+    current[0] = _target("01K77777777777777777777777", "c" * 64)
+    assert (
+        refresh.recover_generation_refresh(binding, actor=USER_ID).read_file("state.md")
+        == "fresh state\n"
+    )
+    paths, _, _ = _active(binding)
+    assert (
+        paths.history / f"{hashlib.sha256(predecessor).hexdigest()}.json"
+    ).read_bytes() == predecessor
+
+
+def test_intent_codec_round_trip_and_integrity(replica):
+    binding, _ = replica
+    intent = refresh._new_intent(_bootstrap(binding))
+    raw = encode_intent(intent)
+    assert decode_intent(raw) == intent
+    assert encode_intent(decode_intent(raw)) == raw
+    envelope = json.loads(raw)
+    envelope["digest"] = "0" * 64
+    with pytest.raises(GenerationRefreshEvidenceError):
+        decode_intent(json.dumps(envelope, sort_keys=True, separators=(",", ":")).encode())
+    with pytest.raises(GenerationRefreshEvidenceError):
+        decode_intent(raw + b"\n")
+    with pytest.raises(GenerationRefreshEvidenceError):
+        decode_intent(b'{"payload":{},"payload":{},"digest":"x"}')
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("schema_version", True),
+        ("schema_version", 2),
+        ("predecessor_digest", "invalid"),
+        ("kind", "rollback"),
+    ],
+)
+def test_intent_rejects_invalid_schema(replica, field, value):
+    from pydantic import ValidationError
+
+    from nauro.store.generation_refresh_intent import RefreshIntent
+
+    binding, _ = replica
+    facts = refresh._new_intent(_bootstrap(binding)).model_dump()
+    facts[field] = value
+    with pytest.raises(ValidationError):
+        RefreshIntent.model_validate(facts)
+
+
+@POSIX
+@pytest.mark.parametrize("boundary", ["intent", "carrier", "pointer"])
+@pytest.mark.parametrize("phase", ["before", "after"])
+def test_process_exit_around_replacement_directory_barrier(replica, boundary, phase):
+    binding, _ = replica
+    script = """
+import os
+from nauro.store import generation_installation as installation
+from nauro.store import generation_refresh_io as durable
+from nauro.sync import generation_refresh as refresh
+from tests.test_generation_refresh import _target
+from tests.test_generation_installation import USER_ID
+installation.read_active_user_id = lambda: USER_ID
+projection = _target()
+refresh.acquire_generation_projection = lambda *a, **k: projection
+refresh.check_generation_projection = lambda *a, **k: projection.target
+paths = durable.refresh_paths(projection.target.binding, USER_ID)
+replace = durable.os.replace
+barrier = durable.sync_directory
+armed = False
+def install(source, destination):
+    global armed
+    replace(source, destination)
+    if destination == getattr(paths, os.environ['REFRESH_STOP']):
+        armed = True
+def sync(paths, directory):
+    if armed and os.environ['REFRESH_PHASE'] == 'before':
+        os._exit(73)
+    barrier(paths, directory)
+    if armed and os.environ['REFRESH_PHASE'] == 'after':
+        os._exit(73)
+durable.os.replace = install
+durable.sync_directory = sync
+prepared = refresh.prepare_initial_generation_refresh(projection.target.binding, actor=USER_ID)
+refresh.commit_generation_refresh(prepared)
+"""
+    env = dict(os.environ, REFRESH_STOP=boundary, REFRESH_PHASE=phase)
+    env["PYTHONPATH"] = str(__import__("pathlib").Path(__file__).parent.parent)
+    result = subprocess.run(
+        [sys.executable, "-c", script], env=env, capture_output=True, timeout=30
+    )
+    assert result.returncode == 73, result.stderr.decode()
+    assert (
+        refresh.recover_generation_refresh(binding, actor=USER_ID).read_file("state.md")
+        == "fresh state\n"
+    )
+
+
+def test_refresh_executor_has_no_runtime_consumer():
+    import ast
+    from pathlib import Path
+
+    root = Path(refresh.__file__).parents[1]
+    consumers = []
+    for path in root.rglob("*.py"):
+        for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
+            if isinstance(node, ast.ImportFrom) and node.module == "nauro.sync.generation_refresh":
+                consumers.append(path.relative_to(root).as_posix())
+            elif isinstance(node, ast.Import):
+                consumers.extend(
+                    a.name for a in node.names if a.name == "nauro.sync.generation_refresh"
+                )
+    assert consumers == []

--- a/packages/nauro/tests/test_generation_refresh_state.py
+++ b/packages/nauro/tests/test_generation_refresh_state.py
@@ -128,3 +128,43 @@ def test_changed_marker_conflicts(transition):
         )
         == "conflict"
     )
+
+
+@pytest.mark.parametrize("scope", ["b" * 64, "c" * 64])
+@pytest.mark.parametrize("state", ["base_present", "carrier_published", "target_present"])
+def test_changed_scope_target_keeps_byte_state_separate_from_permission(transition, scope, state):
+    projection = _projection()
+    changes = {
+        "projection_scope_id": scope,
+        "installed_state_id": "01K99999999999999999999999",
+    }
+    target = RefreshControlPair(
+        _pointer_bytes(projection, **changes), _authorization_bytes(projection, **changes)
+    )
+    changed = replace(transition, target=target)
+    pointer = target.pointer_json if state == "target_present" else changed.base.pointer_json
+    carrier = (
+        changed.base.authorization_json if state == "base_present" else target.authorization_json
+    )
+    assert (
+        classify_refresh_control(
+            changed,
+            marker_json=changed.marker_json,
+            pointer_json=pointer,
+            authorization_json=carrier,
+        )
+        == state
+    )
+
+
+def test_repeated_target_observation_does_not_become_completion(transition):
+    observed = dict(
+        marker_json=transition.marker_json,
+        pointer_json=transition.target.pointer_json,
+        authorization_json=transition.target.authorization_json,
+    )
+    assert [classify_refresh_control(transition, **observed) for _ in range(3)] == [
+        "target_present",
+        "target_present",
+        "target_present",
+    ]

--- a/packages/nauro/tests/test_generation_refresh_state.py
+++ b/packages/nauro/tests/test_generation_refresh_state.py
@@ -1,0 +1,130 @@
+from dataclasses import replace
+from itertools import product
+
+import pytest
+
+from nauro.store.generation_authority import GenerationAuthorityError, GenerationAuthorityMarker
+from nauro.store.generation_refresh_state import (
+    GenerationRefreshEvidenceError,
+    RefreshControlPair,
+    RefreshControlTransition,
+    classify_refresh_control,
+)
+from tests.test_generation_installation import (
+    PROJECT_ID,
+    _authorization_bytes,
+    _pointer_bytes,
+    _projection,
+)
+
+
+@pytest.fixture
+def transition():
+    projection = _projection()
+    base = RefreshControlPair(_pointer_bytes(projection), _authorization_bytes(projection))
+    changes = {
+        "installed_state_id": "01K55555555555555555555555",
+        "generation_id": "01K66666666666666666666666",
+    }
+    target = RefreshControlPair(
+        _pointer_bytes(projection, **changes), _authorization_bytes(projection, **changes)
+    )
+    marker = GenerationAuthorityMarker(
+        schema_version=1, authority="generation", project_id=PROJECT_ID, store_format_version=1
+    ).canonical_bytes()
+    return RefreshControlTransition(marker, base, target)
+
+
+@pytest.mark.parametrize("pointer,carrier", list(product(["base", "target", "other"], repeat=2)))
+def test_classify_all_pair_interleavings(transition, pointer, carrier):
+    other = _projection()
+    pointers = {
+        "base": transition.base.pointer_json,
+        "target": transition.target.pointer_json,
+        "other": _pointer_bytes(other, installed_state_id="01K77777777777777777777777"),
+    }
+    carriers = {
+        "base": transition.base.authorization_json,
+        "target": transition.target.authorization_json,
+        "other": _authorization_bytes(other, installed_state_id="01K77777777777777777777777"),
+    }
+    expected = {
+        ("base", "base"): "base_present",
+        ("base", "target"): "carrier_published",
+        ("target", "target"): "target_present",
+    }.get((pointer, carrier), "conflict")
+    assert (
+        classify_refresh_control(
+            transition,
+            marker_json=transition.marker_json,
+            pointer_json=pointers[pointer],
+            authorization_json=carriers[carrier],
+        )
+        == expected
+    )
+
+
+@pytest.mark.parametrize("field", ["pointer_json", "authorization_json", "marker_json"])
+@pytest.mark.parametrize("raw", [None, b"", b"{}", b"x" * (16 * 1024 + 1)])
+def test_invalid_observation_is_not_absence_or_success(transition, field, raw):
+    observation = {
+        "pointer_json": transition.target.pointer_json,
+        "authorization_json": transition.target.authorization_json,
+        "marker_json": transition.marker_json,
+    }
+    observation[field] = raw
+    with pytest.raises(GenerationAuthorityError):
+        classify_refresh_control(transition, **observation)
+
+
+def test_noncanonical_observation_refuses(transition):
+    with pytest.raises(GenerationRefreshEvidenceError):
+        classify_refresh_control(
+            transition,
+            marker_json=transition.marker_json,
+            pointer_json=transition.base.pointer_json + b"\n",
+            authorization_json=transition.base.authorization_json,
+        )
+
+
+def test_transition_requires_complete_pairs_and_new_install_identity(transition):
+    with pytest.raises(GenerationRefreshEvidenceError):
+        RefreshControlPair(transition.base.pointer_json, transition.target.authorization_json)
+    with pytest.raises(GenerationRefreshEvidenceError):
+        replace(transition, target=transition.base)
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("project_id", "01K88888888888888888888888"),
+        ("installed_for_user_id", "01K88888888888888888888888"),
+        ("store_format_version", 2),
+    ],
+)
+def test_transition_cannot_cross_binding(transition, field, value):
+    projection = _projection()
+    changes = {field: value, "installed_state_id": "01K99999999999999999999999"}
+    target = RefreshControlPair(
+        _pointer_bytes(projection, **changes), _authorization_bytes(projection, **changes)
+    )
+    with pytest.raises(GenerationRefreshEvidenceError):
+        replace(transition, target=target)
+
+
+def test_changed_marker_conflicts(transition):
+    marker = GenerationAuthorityMarker(
+        schema_version=1,
+        authority="generation",
+        project_id="01K88888888888888888888888",
+        store_format_version=1,
+    )
+    assert (
+        classify_refresh_control(
+            transition,
+            marker_json=marker.canonical_bytes(),
+            pointer_json=transition.target.pointer_json,
+            authorization_json=transition.target.authorization_json,
+        )
+        == "conflict"
+    )

--- a/packages/nauro/tests/test_generation_store.py
+++ b/packages/nauro/tests/test_generation_store.py
@@ -129,7 +129,7 @@ def test_capture_composition_survives_removed_disk_root(projection, monkeypatch)
     assert store.read_file("context/brief.md") == "Context\n"
 
 
-def test_store_has_no_runtime_consumers():
+def test_store_has_only_the_dormant_refresh_consumer():
     root = Path(generation_store.__file__).parents[1]
     consumers = []
     for path in root.rglob("*.py"):
@@ -142,4 +142,4 @@ def test_store_has_no_runtime_consumers():
                     for alias in node.names
                     if alias.name == "nauro.store.generation_store"
                 )
-    assert consumers == []
+    assert consumers == ["sync/generation_refresh.py"]

--- a/packages/nauro/tests/test_sync/test_generation_acquisition.py
+++ b/packages/nauro/tests/test_sync/test_generation_acquisition.py
@@ -491,3 +491,17 @@ def test_acquisition_touches_no_disk_control_state_or_sync_state(monkeypatch) ->
         elif isinstance(node, ast.Import):
             imported.update(alias.name for alias in node.names)
     assert not {name for name in imported if name.rsplit(".", 1)[-1] in EXCLUDED_MODULES}
+
+
+def test_projection_authorization_check_fetches_each_time_without_downloading():
+    server = FakeServer()
+    first = acquisition.check_generation_projection(
+        BINDING, active_user_id=USER_ID, session=server.session
+    )
+    server.generation_id = "01K77777777777777777777777"
+    second = acquisition.check_generation_projection(
+        BINDING, active_user_id=USER_ID, session=server.session
+    )
+    assert first.identity.generation_id == GENERATION_ID
+    assert second.identity.generation_id == "01K77777777777777777777777"
+    assert server.counts == {"projection": 2, "presign": 0, "object": 0}


### PR DESCRIPTION
## Why

An interrupted refresh can leave the generation pointer and authorization view at different states. A scope change must not strand recovery or permit access through the old scope. Exact target files alone also do not prove that the final durability barriers succeeded.

## What changed

- Add a canonical refresh intent that binds exact base and target control bytes. Preserve each predecessor before publishing a successor, including reconciliation from a recognized mixed state.
- Recheck the authenticated server projection and active account before publication and disclosure. Reconcile forward to a newly authorized projection without marking the old target complete or rolling back.
- Require fresh target verification, file and directory barriers, and exact control readback for every read admission. Keep explicit bootstrap separate from recovery; prevent older capture and initial-publication helpers from bypassing an existing intent.
- Keep the coordinator dormant and retain existing roots and recovery evidence. Extend targeted typing and the three-platform test job.

## Test plan

835 affected generation tests passed, with 77 platform-specific skips. All three explicit cross-repository recovery and alias checks passed without skips. Lint, formatting, seven-module strict typing, source-risk, single-source, and docstring checks passed.

The refresh suite includes 14 real subprocess termination cases across intent/view/pointer replacement, predecessor archive publication, interrupted archive linking, and replacement-directory barriers. Further tests cover changed scope, repeated reconciliation, stale preparation, missing/corrupt archives, final authorization changes, and read refusal after failed completion barriers.

## Risk / what to review

Review archive-before-successor ordering, exact observed-base fencing, carrier durability before pointer replacement, repeated read-admission barriers, and fresh authorization checks. A write exception remains unresolved until recovery; target-present is only a byte observation.

The durability implementation uses POSIX file and directory fsync. Unsupported barriers refuse before control mutation; Windows refresh support is not claimed. Process termination does not establish physical power-loss behavior on every filesystem. Repeated verification, barriers, and online authorization checks have unmeasured runtime cost. An authorization response cannot guarantee detection of a later remote revocation.

## Deferred

Concurrent writing remains incomplete. CLI/MCP runtime routing, hosted reads, worker recovery integration, remaining mutation families, and production timing remain open. There is no runtime consumer, automatic startup recovery, or root cleanup. Production activation and deployment are unchanged.
