### PR TITLE
Frame generation read responses with verified authority

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
           packages/nauro/src/nauro/store/generation_read.py
           packages/nauro/src/nauro/store/generation_store.py
           packages/nauro/src/nauro/mcp/generation_reads.py
+          packages/nauro/src/nauro/mcp/generation_responses.py
           packages/nauro/src/nauro/store/generation_refresh_state.py
           packages/nauro/src/nauro/store/generation_refresh_intent.py
           packages/nauro/src/nauro/store/generation_refresh_io.py
@@ -95,6 +96,7 @@ jobs:
           packages/nauro/tests/test_generation_read.py
           packages/nauro/tests/test_generation_store.py
           packages/nauro/tests/test_generation_reads.py
+          packages/nauro/tests/test_generation_responses.py
           packages/nauro/tests/test_generation_refresh_state.py
           packages/nauro/tests/test_generation_refresh.py
           packages/nauro/tests/test_replica_control.py

--- a/packages/nauro/src/nauro/mcp/generation_responses.py
+++ b/packages/nauro/src/nauro/mcp/generation_responses.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from nauro_core.protected_generation_membership import (
+    InvalidGenerationPath,
+    validate_protected_generation_path,
+)
+
+from nauro.mcp import generation_reads as reads
+from nauro.mcp.generation_reads import GenerationReadResult, _Result
+from nauro.mcp.rendering import try_render_envelope
+from nauro.store.generation_authority import GenerationAuthorityError
+from nauro.store.generation_projection import GenerationProjectionTarget
+from nauro.store.resolution import ResolvedProjectBinding
+from nauro.sync.generation_refresh import _authorize
+from nauro.sync.remote import TransferBoundaryError, TransferSession
+
+_READ_FAILURES = (GenerationAuthorityError, TransferBoundaryError)
+
+
+@dataclass(frozen=True)
+class GenerationToolResponse:
+    envelope: dict[str, object]
+    text: str
+    is_error: bool
+
+
+def _error(reason: str, *, kind: str = "error") -> GenerationToolResponse:
+    bounded = reason[:600]
+    return GenerationToolResponse(
+        {"store": "local", "error": {"kind": kind, "reason": bounded}},
+        f"Error: {bounded}",
+        True,
+    )
+
+
+def _unavailable() -> GenerationToolResponse:
+    return _error("Generation read unavailable. Check authorization and explicit replica recovery.")
+
+
+def _finish(
+    binding: ResolvedProjectBinding,
+    read: GenerationReadResult[_Result],
+    tool_name: str,
+    session: TransferSession | None,
+    renderer_kwargs: dict[str, object] | None = None,
+) -> GenerationToolResponse:
+    payload = read.result.model_dump(mode="json", exclude_none=True)
+    failure = payload.get("error")
+    if isinstance(failure, dict):
+        return _error(
+            str(failure.get("reason", "Read failed.")), kind=str(failure.get("kind", "error"))
+        )
+    identity = read.projection
+    target = GenerationProjectionTarget(binding, identity)
+    envelope: dict[str, object] = {
+        "store": "local",
+        **payload,
+        "project": {"id": identity.project_id, "name": identity.project_id},
+        "read_authority": {
+            "kind": "generation",
+            "project_id": identity.project_id,
+            "generation_id": identity.generation_id,
+            "manifest_digest": identity.manifest_digest,
+            "committed_at": identity.committed_at,
+            "freshness": "authorized_at_read",
+        },
+    }
+    rendered = try_render_envelope(tool_name, envelope, renderer_kwargs)
+    if rendered.failure is not None or rendered.text is None:
+        return _error("Generation response could not be rendered.")
+    text = rendered.text
+    _authorize(target, session)
+    frame = (
+        f"Generation: {identity.generation_id}. Committed: {identity.committed_at}.\n"
+        "Authorization checked for this read."
+    )
+    return GenerationToolResponse(envelope, f"{text}\n\n{frame}" if text else frame, False)
+
+
+def _raw_path(path: str) -> str:
+    if not path or path.startswith("/") or "\\" in path or ".." in path.split("/"):
+        raise InvalidGenerationPath("Invalid generation path.")
+    canonical = "/".join(part for part in path.split("/") if part not in ("", "."))
+    canonical = validate_protected_generation_path(canonical)
+    if canonical == "questions-provenance.json":
+        raise InvalidGenerationPath("Generic provenance access is unavailable.")
+    return canonical
+
+
+def get_context(
+    binding: ResolvedProjectBinding,
+    level: int | str = "L0",
+    *,
+    actor: str,
+    session: TransferSession | None = None,
+) -> GenerationToolResponse:
+    if isinstance(level, str):
+        level = {"L0": 0, "L1": 1, "L2": 2}.get(level.upper(), -1)
+    if type(level) is not int or level not in (0, 1, 2):
+        return _error("Invalid level. Use L0, L1 or L2.", kind="rejected")
+    try:
+        read = reads.get_context(binding, level, actor=actor, session=session)
+        return _finish(binding, read, "get_context", session, {"level": level})
+    except _READ_FAILURES:
+        return _unavailable()
+
+
+def get_decision(
+    binding: ResolvedProjectBinding,
+    number: int,
+    mode: Literal["header", "full"] = "full",
+    *,
+    actor: str,
+    session: TransferSession | None = None,
+) -> GenerationToolResponse:
+    try:
+        read = reads.get_decision(binding, number, mode, actor=actor, session=session)
+        return _finish(binding, read, "get_decision", session, {"mode": mode})
+    except _READ_FAILURES:
+        return _unavailable()
+
+
+def get_raw_file(
+    binding: ResolvedProjectBinding,
+    path: str,
+    *,
+    actor: str,
+    session: TransferSession | None = None,
+) -> GenerationToolResponse:
+    try:
+        canonical = _raw_path(path)
+    except InvalidGenerationPath:
+        return _error("Invalid or unavailable generation path.", kind="rejected")
+    try:
+        read = reads.get_raw_file(binding, canonical, actor=actor, session=session)
+        return _finish(binding, read, "get_raw_file", session, {"path": canonical})
+    except _READ_FAILURES:
+        return _unavailable()
+
+
+def list_decisions(
+    binding: ResolvedProjectBinding,
+    limit: int = 20,
+    include_superseded: bool = False,
+    *,
+    actor: str,
+    session: TransferSession | None = None,
+) -> GenerationToolResponse:
+    try:
+        read = reads.list_decisions(
+            binding, limit, include_superseded, actor=actor, session=session
+        )
+        return _finish(binding, read, "list_decisions", session)
+    except _READ_FAILURES:
+        return _unavailable()
+
+
+def search_decisions(
+    binding: ResolvedProjectBinding,
+    query: str,
+    limit: int = 10,
+    include_superseded: bool = False,
+    *,
+    actor: str,
+    use_embeddings: bool = False,
+    session: TransferSession | None = None,
+) -> GenerationToolResponse:
+    try:
+        read = reads.search_decisions(
+            binding,
+            query,
+            limit,
+            include_superseded,
+            actor=actor,
+            use_embeddings=use_embeddings,
+            session=session,
+        )
+        return _finish(binding, read, "search_decisions", session, {"query": query})
+    except _READ_FAILURES:
+        return _unavailable()
+
+
+def check_decision(
+    binding: ResolvedProjectBinding,
+    proposed_approach: str,
+    context: str | None = None,
+    *,
+    actor: str,
+    use_embeddings: bool = False,
+    session: TransferSession | None = None,
+) -> GenerationToolResponse:
+    try:
+        read = reads.check_decision(
+            binding,
+            proposed_approach,
+            context,
+            actor=actor,
+            use_embeddings=use_embeddings,
+            session=session,
+        )
+        return _finish(binding, read, "check_decision", session)
+    except _READ_FAILURES:
+        return _unavailable()
+
+
+def diff_since_last_session() -> GenerationToolResponse:
+    return _error(
+        "Generation session history is unavailable until authorized history is supported."
+    )

--- a/packages/nauro/tests/test_generation_reads.py
+++ b/packages/nauro/tests/test_generation_reads.py
@@ -203,7 +203,7 @@ def test_adapter_has_no_production_consumer():
                 consumers.extend(
                     a.name for a in node.names if a.name == "nauro.mcp.generation_reads"
                 )
-    assert consumers == []
+    assert sorted(set(consumers)) == ["mcp/generation_responses.py"]
 
 
 @POSIX

--- a/packages/nauro/tests/test_generation_refresh.py
+++ b/packages/nauro/tests/test_generation_refresh.py
@@ -512,4 +512,4 @@ def test_refresh_executor_has_no_runtime_consumer():
                 consumers.extend(
                     a.name for a in node.names if a.name == "nauro.sync.generation_refresh"
                 )
-    assert consumers == ["mcp/generation_reads.py"]
+    assert sorted(consumers) == ["mcp/generation_reads.py", "mcp/generation_responses.py"]

--- a/packages/nauro/tests/test_generation_responses.py
+++ b/packages/nauro/tests/test_generation_responses.py
@@ -1,0 +1,319 @@
+from __future__ import annotations
+
+import ast
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+from nauro_core import renderers
+from nauro_core.renderers import L2_CHAR_BUDGET
+
+from nauro.mcp import generation_responses as responses
+from nauro.store import generation_installation as installation
+from nauro.store.generation_authority import RefreshRequiredError
+from nauro.sync import generation_refresh as refresh
+from tests.test_generation_installation import USER_ID, _projection
+from tests.test_generation_reads import CASES, POSIX
+from tests.test_generation_reads import admitted as admitted
+from tests.test_generation_refresh import _target
+
+
+@POSIX
+@pytest.mark.parametrize("name,args,kwargs", CASES)
+def test_response_content_and_metadata_use_one_generation(admitted, name, args, kwargs):
+    binding, current, checks = admitted
+    (binding.store_path / "state.md").write_text("**Last synced:** POISON")
+    (binding.store_path / "project.md").write_text("POISON")
+    snapshots = binding.store_path / "snapshots"
+    snapshots.mkdir()
+    (snapshots / "001.json").write_text("POISON")
+    binding = replace(binding, display_name="POISON REGISTRY LABEL")
+    # The authenticated response uses this operation's validated binding.
+    current[0] = replace_projection_binding(current[0], binding)
+    for _ in range(2):
+        result = getattr(responses, name)(binding, *args, actor=USER_ID, **kwargs)
+        identity = current[0].target.identity
+        assert result.is_error is False
+        assert result.envelope["project"] == {"id": binding.project_id, "name": binding.project_id}
+        assert result.envelope["read_authority"] == {
+            "kind": "generation",
+            "project_id": identity.project_id,
+            "generation_id": identity.generation_id,
+            "manifest_digest": identity.manifest_digest,
+            "committed_at": identity.committed_at,
+            "freshness": "authorized_at_read",
+        }
+        assert result.text.endswith(
+            f"Generation: {identity.generation_id}. Committed: {identity.committed_at}.\n"
+            "Authorization checked for this read."
+        )
+        assert "POISON" not in repr(result)
+        assert USER_ID not in repr(result)
+        assert identity.projection_scope_id not in repr(result)
+        assert len(checks) == 5
+        checks.clear()
+
+
+def replace_projection_binding(projection, binding):
+    from nauro.store.generation_projection import (
+        GenerationProjectionTarget,
+        verify_generation_projection,
+    )
+
+    return verify_generation_projection(
+        GenerationProjectionTarget(binding, projection.target.identity),
+        manifest_json=projection.manifest_json,
+        artifacts=tuple((a.path, a.content) for a in projection.artifacts),
+    )
+
+
+@POSIX
+@pytest.mark.parametrize("name,args,kwargs", CASES)
+@pytest.mark.parametrize("failure", ["scope", "account", "renderer"])
+def test_no_payload_escapes_a_failure_during_rendering(
+    admitted, monkeypatch, name, args, kwargs, failure
+):
+    binding, current, _ = admitted
+    original = renderers.RENDERERS[name]
+
+    def interrupt(*a, **k):
+        if failure == "scope":
+            current[0] = _target()
+        elif failure == "account":
+            monkeypatch.setattr(
+                installation, "read_active_user_id", lambda: "01K44444444444444444444444"
+            )
+        else:
+            raise RuntimeError("PRIVATE CAPTURED CONTENT")
+        return original(*a, **k)
+
+    monkeypatch.setitem(renderers.RENDERERS, name, interrupt)
+    result = getattr(responses, name)(binding, *args, actor=USER_ID, **kwargs)
+    assert result.is_error is True
+    assert set(result.envelope) == {"store", "error"}
+    assert "Verified generation state" not in repr(result)
+    assert "Require durability" not in repr(result)
+    assert "PRIVATE" not in repr(result)
+    assert len(result.text) < 150
+
+
+@POSIX
+@pytest.mark.parametrize("path", ["./state.md", "state.md", ".//state.md"])
+def test_raw_path_normalization_is_lexical(admitted, path):
+    binding, _, _ = admitted
+    result = responses.get_raw_file(binding, path, actor=USER_ID)
+    assert result.is_error is False
+    assert result.envelope["content"] == "# State\n\nVerified generation state.\n"
+
+
+@POSIX
+@pytest.mark.parametrize(
+    "path",
+    [
+        "../state.md",
+        "context/../state.md",
+        "/state.md",
+        "context\\brief.md",
+        ".replica/authority.json",
+        "questions-provenance.json",
+        "./questions-provenance.json",
+        "",
+        "snapshots/001.json",
+    ],
+)
+def test_raw_exclusions_refuse_before_read(admitted, monkeypatch, path):
+    binding, _, checks = admitted
+
+    def forbidden(*a, **k):
+        pytest.fail("Invalid generic path reached generation admission.")
+
+    monkeypatch.setattr(responses.reads, "get_raw_file", forbidden)
+    result = responses.get_raw_file(binding, path, actor=USER_ID)
+    assert result.envelope == {
+        "store": "local",
+        "error": {"kind": "rejected", "reason": "Invalid or unavailable generation path."},
+    }
+    assert result.is_error is True
+    assert checks == []
+
+
+@POSIX
+def test_missing_intent_never_becomes_onboarding(admitted):
+    binding, _, _ = admitted
+    refresh.refresh_paths(binding, USER_ID).intent.unlink()
+    result = responses.get_context(binding, actor=USER_ID)
+    assert result.is_error is True
+    assert set(result.envelope) == {"store", "error"}
+    assert "welcome" not in result.text.lower()
+    assert "read_authority" not in result.envelope
+
+
+@POSIX
+def test_missing_file_has_no_flat_store_hints(admitted):
+    binding, _, _ = admitted
+    (binding.store_path / "stack.md").write_text("SECRET FLAT STACK")
+    result = responses.get_raw_file(binding, "stack.md", actor=USER_ID)
+    assert result.envelope == {
+        "store": "local",
+        "error": {"kind": "error", "reason": "File not found: stack.md"},
+    }
+    assert result.is_error is True
+
+
+@POSIX
+def test_context_limit_keeps_authority_frame(admitted):
+    binding, current, _ = admitted
+    current[0] = fresh_projection(
+        {"project.md": ("# Project\n" + "x" * (L2_CHAR_BUDGET + 100)).encode()}
+    )
+    refresh.recover_generation_refresh(binding, actor=USER_ID)
+    result = responses.get_context(binding, "L2", actor=USER_ID)
+    assert result.is_error is False
+    assert "x" * 100 not in result.text
+    assert "Authorization checked for this read." in result.text
+    assert len(result.text) < 2000
+
+
+def test_history_refusal_is_explicit():
+    result = responses.diff_since_last_session()
+    assert result.is_error is True
+    assert result.envelope == {
+        "store": "local",
+        "error": {
+            "kind": "error",
+            "reason": (
+                "Generation session history is unavailable until authorized history is supported."
+            ),
+        },
+    }
+
+
+@POSIX
+def test_authority_exception_text_is_not_returned(admitted, monkeypatch):
+    binding, _, _ = admitted
+
+    def fail(*a, **k):
+        raise RefreshRequiredError("PRIVATE PATH OR CREDENTIAL")
+
+    monkeypatch.setattr(responses.reads, "get_context", fail)
+    result = responses.get_context(binding, actor=USER_ID)
+    assert result.is_error is True
+    assert "PRIVATE" not in repr(result)
+
+
+def test_response_module_has_no_runtime_consumer():
+    root = Path(responses.__file__).parents[1]
+    consumers = []
+    for path in root.rglob("*.py"):
+        for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
+            if isinstance(node, ast.ImportFrom) and (
+                node.module == "nauro.mcp.generation_responses"
+                or node.module == "nauro.mcp"
+                and any(a.name == "generation_responses" for a in node.names)
+            ):
+                consumers.append(path.relative_to(root).as_posix())
+            elif isinstance(node, ast.Import):
+                consumers.extend(
+                    a.name for a in node.names if a.name == "nauro.mcp.generation_responses"
+                )
+    assert consumers == []
+
+
+def fresh_projection(artifacts):
+    import hashlib
+    import json
+
+    from nauro.store.generation_projection import (
+        GenerationProjectionIdentity,
+        GenerationProjectionTarget,
+        verify_generation_projection,
+    )
+
+    seed = _projection(artifacts)
+    manifest = json.loads(seed.manifest_json)
+    manifest["generation_id"] = "01K77777777777777777777777"
+    raw = json.dumps(manifest, sort_keys=True, separators=(",", ":")).encode()
+    fields = seed.target.identity.model_dump()
+    fields.update(
+        generation_id=manifest["generation_id"], manifest_digest=hashlib.sha256(raw).hexdigest()
+    )
+    return verify_generation_projection(
+        GenerationProjectionTarget(seed.target.binding, GenerationProjectionIdentity(**fields)),
+        manifest_json=raw,
+        artifacts=tuple(artifacts.items()),
+    )
+
+
+@POSIX
+def test_empty_authorized_projection_is_not_onboarding(admitted):
+    binding, current, _ = admitted
+    current[0] = fresh_projection({})
+    refresh.recover_generation_refresh(binding, actor=USER_ID)
+    result = responses.get_context(binding, actor=USER_ID)
+    assert result.is_error is False
+    assert "read_authority" in result.envelope
+    assert "guidance" not in result.envelope
+    assert "nauro init" not in result.text
+    assert "welcome" not in result.text.lower()
+
+
+@POSIX
+def test_raw_content_budget_and_frame_are_separate(admitted):
+    from nauro_core.constants import RAW_FILE_CHAR_BUDGET
+
+    binding, current, _ = admitted
+    content = "A" * (RAW_FILE_CHAR_BUDGET + 1000)
+    current[0] = fresh_projection({"stack.md": content.encode()})
+    refresh.recover_generation_refresh(binding, actor=USER_ID)
+    result = responses.get_raw_file(binding, "./stack.md", actor=USER_ID)
+    assert result.is_error is False
+    assert result.envelope["content"] == content
+    assert result.text.count("A") == RAW_FILE_CHAR_BUDGET + 1
+    assert result.text.endswith("Authorization checked for this read.")
+    assert len(result.text) < RAW_FILE_CHAR_BUDGET + 1000
+
+
+@POSIX
+@pytest.mark.parametrize("failure", ["marker", "barrier", "network"])
+def test_admission_errors_never_release_metadata(admitted, monkeypatch, failure):
+    binding, _, _ = admitted
+    if failure == "marker":
+        refresh.refresh_paths(binding, USER_ID).marker.write_text("CORRUPT")
+    elif failure == "barrier":
+
+        def fail(*a, **k):
+            raise OSError("PRIVATE disk path")
+
+        monkeypatch.setattr(refresh, "sync_file", fail)
+    else:
+
+        def fail(*a, **k):
+            raise RefreshRequiredError("PRIVATE network detail")
+
+        monkeypatch.setattr(refresh, "check_generation_projection", fail)
+    result = responses.get_context(binding, actor=USER_ID)
+    assert result.is_error is True
+    assert set(result.envelope) == {"store", "error"}
+    assert "PRIVATE" not in repr(result)
+
+
+@POSIX
+def test_missing_renderer_does_not_fall_back_to_json(admitted, monkeypatch):
+    binding, _, _ = admitted
+    monkeypatch.delitem(renderers.RENDERERS, "get_raw_file")
+    result = responses.get_raw_file(binding, "state.md", actor=USER_ID)
+    assert result.envelope == {
+        "store": "local",
+        "error": {"kind": "error", "reason": "Generation response could not be rendered."},
+    }
+    assert result.is_error is True
+
+
+@pytest.mark.parametrize("level", ["L3", -1, True])
+def test_invalid_context_level_has_bounded_refusal(level):
+    result = responses.get_context(_projection().target.binding, level, actor=USER_ID)
+    assert result.envelope == {
+        "store": "local",
+        "error": {"kind": "rejected", "reason": "Invalid level. Use L0, L1 or L2."},
+    }
+    assert result.is_error is True


### PR DESCRIPTION
## Why

Generation read responses need visible provenance without mixing in flat-store metadata or releasing captured content after authorization changes.

## What changed

Add dormant local response builders for six reads. They derive generation metadata from the verified snapshot, preserve existing content limits, append an authority frame after rendering, and recheck authorization before returning. Generic raw-file reads enforce path and provenance exclusions. Renderer failures return bounded errors without a full-content fallback. Generation session history remains explicitly unavailable.

## Test plan

1,115 affected generation, contract, legacy and rendering tests passed, with 77 platform skips. All three explicit cross-repository checks passed without skips. Changed-file lint, formatting, targeted typing, risk, single-source and docstring checks passed.

## Risk / what to review

Review the final authorization boundary, raw-file exclusions and renderer failure behavior. Successful local responses make five projection checks. Windows refresh durability and production latency remain unproven. Future text transports must use the bounded text result, not the full JSON envelope as an alternate fallback.

## Deferred

Concurrent writing remains incomplete. Hosted response construction, authority dispatch, transport registration and authorized session history still need work. No production caller is registered, and production activation is unchanged.
