### PR TITLE
Add dormant authority-aware local read dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
           packages/nauro/src/nauro/store/generation_store.py
           packages/nauro/src/nauro/mcp/generation_reads.py
           packages/nauro/src/nauro/mcp/generation_responses.py
+          packages/nauro/src/nauro/mcp/read_dispatch.py
+          packages/nauro/src/nauro/store/read_authority.py
           packages/nauro/src/nauro/store/generation_refresh_state.py
           packages/nauro/src/nauro/store/generation_refresh_intent.py
           packages/nauro/src/nauro/store/generation_refresh_io.py
@@ -97,6 +99,7 @@ jobs:
           packages/nauro/tests/test_generation_store.py
           packages/nauro/tests/test_generation_reads.py
           packages/nauro/tests/test_generation_responses.py
+          packages/nauro/tests/test_read_dispatch.py
           packages/nauro/tests/test_generation_refresh_state.py
           packages/nauro/tests/test_generation_refresh.py
           packages/nauro/tests/test_replica_control.py

--- a/packages/nauro/src/nauro/mcp/read_dispatch.py
+++ b/packages/nauro/src/nauro/mcp/read_dispatch.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Callable
+from pathlib import Path
+from typing import Literal
+
+from mcp.types import CallToolResult, TextContent
+from nauro_core.renderers import disconnected_reason_code
+
+from nauro.auth import ActiveUserReadError, read_active_user_id
+from nauro.mcp import generation_responses as generation
+from nauro.mcp import tools as legacy
+from nauro.mcp.rendering import resolve_renderer_kwargs, try_render_envelope
+from nauro.store.config import resolve_embeddings_flag
+from nauro.store.generation_authority import GenerationAuthorityError
+from nauro.store.read_authority import observe_generation_marker
+from nauro.store.resolution import (
+    ResolvedProjectBinding,
+    StoreResolutionError,
+    resolve_project_binding,
+)
+from nauro.sync.remote import TransferBoundaryError
+
+logger = logging.getLogger(__name__)
+
+
+def _prepared(response: generation.GenerationToolResponse) -> CallToolResult:
+    return CallToolResult(
+        content=[TextContent(type="text", text=response.text)], isError=response.is_error
+    )
+
+
+def _unavailable() -> CallToolResult:
+    return CallToolResult(
+        content=[TextContent(type="text", text="Error: Project read authority is unavailable.")],
+        isError=True,
+    )
+
+
+def _legacy_result(
+    name: str, envelope: dict[str, object], options: dict[str, object], path: Path
+) -> CallToolResult:
+    rendered = try_render_envelope(name, envelope, resolve_renderer_kwargs(name, options, path))
+    if rendered.failure is not None:
+        logger.error(
+            "renderer failed for tool=%s; falling back to JSON-only",
+            name,
+            exc_info=rendered.failure,
+        )
+    text = rendered.text
+    if text is None:
+        text = json.dumps(envelope, indent=2, default=str)
+    return CallToolResult(
+        content=[TextContent(type="text", text=text)],
+        structuredContent=envelope if disconnected_reason_code(envelope) is not None else None,
+    )
+
+
+def _read(
+    name: str,
+    project_id: str | None,
+    cwd: str | None,
+    flat: Callable[[Path], dict[str, object]],
+    projected: Callable[[ResolvedProjectBinding, str], generation.GenerationToolResponse],
+    options: dict[str, object] | None = None,
+) -> CallToolResult:
+    try:
+        binding = resolve_project_binding(project_id, cwd)
+        marker = observe_generation_marker(binding)
+        if marker is not None:
+            actor = read_active_user_id()
+            response = projected(binding, actor)
+            if read_active_user_id() != actor or observe_generation_marker(binding) != marker:
+                return _unavailable()
+            return _prepared(response)
+        result = _legacy_result(name, flat(binding.store_path), options or {}, binding.store_path)
+        if observe_generation_marker(binding) is not None:
+            return _unavailable()
+        return result
+    except (
+        StoreResolutionError,
+        GenerationAuthorityError,
+        ActiveUserReadError,
+        TransferBoundaryError,
+        OSError,
+    ):
+        return _unavailable()
+
+
+def get_context(
+    project_id: str | None = None, cwd: str | None = None, level: int | str = "L0"
+) -> CallToolResult:
+    return _read(
+        "get_context",
+        project_id,
+        cwd,
+        lambda p: legacy.tool_get_context(p, level),
+        lambda b, a: generation.get_context(b, level, actor=a),
+        {"level": level},
+    )
+
+
+def get_raw_file(
+    path: str, project_id: str | None = None, cwd: str | None = None
+) -> CallToolResult:
+    return _read(
+        "get_raw_file",
+        project_id,
+        cwd,
+        lambda p: legacy.tool_get_raw_file(p, path),
+        lambda b, a: generation.get_raw_file(b, path, actor=a),
+        {"path": path},
+    )
+
+
+def list_decisions(
+    project_id: str | None = None,
+    cwd: str | None = None,
+    limit: int = 20,
+    include_superseded: bool = False,
+) -> CallToolResult:
+    return _read(
+        "list_decisions",
+        project_id,
+        cwd,
+        lambda p: legacy.tool_list_decisions(p, limit, include_superseded),
+        lambda b, a: generation.list_decisions(b, limit, include_superseded, actor=a),
+    )
+
+
+def get_decision(
+    number: int,
+    mode: Literal["header", "full"] = "full",
+    project_id: str | None = None,
+    cwd: str | None = None,
+) -> CallToolResult:
+    return _read(
+        "get_decision",
+        project_id,
+        cwd,
+        lambda p: legacy.tool_get_decision(p, number, mode),
+        lambda b, a: generation.get_decision(b, number, mode, actor=a),
+        {"mode": mode},
+    )
+
+
+def search_decisions(
+    query: str,
+    limit: int = 10,
+    include_superseded: bool = False,
+    project_id: str | None = None,
+    cwd: str | None = None,
+) -> CallToolResult:
+    return _read(
+        "search_decisions",
+        project_id,
+        cwd,
+        lambda p: legacy.tool_search_decisions(p, query, limit, include_superseded),
+        lambda b, a: generation.search_decisions(
+            b,
+            query,
+            limit,
+            include_superseded,
+            actor=a,
+            use_embeddings=resolve_embeddings_flag(),
+        ),
+        {"query": query},
+    )
+
+
+def check_decision(
+    proposed_approach: str,
+    context: str | None = None,
+    project_id: str | None = None,
+    cwd: str | None = None,
+) -> CallToolResult:
+    return _read(
+        "check_decision",
+        project_id,
+        cwd,
+        lambda p: legacy.tool_check_decision(p, proposed_approach, context),
+        lambda b, a: generation.check_decision(
+            b, proposed_approach, context, actor=a, use_embeddings=resolve_embeddings_flag()
+        ),
+    )
+
+
+def diff_since_last_session(
+    project_id: str | None = None, cwd: str | None = None, days: int | None = None
+) -> CallToolResult:
+    return _read(
+        "diff_since_last_session",
+        project_id,
+        cwd,
+        lambda p: legacy.tool_diff_since_last_session(p, days),
+        lambda b, a: generation.diff_since_last_session(),
+    )

--- a/packages/nauro/src/nauro/store/read_authority.py
+++ b/packages/nauro/src/nauro/store/read_authority.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from nauro_core.constants import HOSTED_STORE_FORMAT_VERSION
+
+from nauro.store.generation_authority import (
+    ClientUpgradeRequiredError,
+    GenerationControlCorruptError,
+    _parse_marker,
+)
+from nauro.store.replica_control import (
+    _read_optional_file,
+    _validate_managed_path,
+    _validate_store_path,
+)
+from nauro.store.resolution import ResolvedProjectBinding
+
+
+def observe_generation_marker(binding: ResolvedProjectBinding) -> bytes | None:
+    store = _validate_store_path(binding)
+    path = store / ".replica" / "authority.json"
+    _validate_managed_path(store, path)
+    raw = _read_optional_file(path)
+    _validate_store_path(binding)
+    _validate_managed_path(store, path)
+    if raw is None:
+        return None
+    marker = _parse_marker(raw)
+    if (
+        binding.mode != "cloud"
+        or marker.project_id != binding.project_id
+        or marker.canonical_bytes() != raw
+    ):
+        raise GenerationControlCorruptError("The generation authority marker is invalid.")
+    if marker.store_format_version != HOSTED_STORE_FORMAT_VERSION:
+        raise ClientUpgradeRequiredError(
+            "This hosted store format requires another client version."
+        )
+    return raw

--- a/packages/nauro/tests/test_generation_responses.py
+++ b/packages/nauro/tests/test_generation_responses.py
@@ -216,7 +216,7 @@ def test_response_module_has_no_runtime_consumer():
                 consumers.extend(
                     a.name for a in node.names if a.name == "nauro.mcp.generation_responses"
                 )
-    assert consumers == []
+    assert consumers == ["mcp/read_dispatch.py"]
 
 
 def fresh_projection(artifacts):

--- a/packages/nauro/tests/test_read_dispatch.py
+++ b/packages/nauro/tests/test_read_dispatch.py
@@ -239,7 +239,7 @@ def test_resolution_failure_never_calls_legacy(monkeypatch):
 def test_dispatch_is_dormant_and_keeps_public_arguments():
     root = Path(dispatch.__file__).parents[1]
     for path in root.rglob("*.py"):
-        for node in ast.walk(ast.parse(path.read_text())):
+        for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
             if isinstance(node, ast.Import):
                 assert all(a.name != "nauro.mcp.read_dispatch" for a in node.names)
             elif isinstance(node, ast.ImportFrom):

--- a/packages/nauro/tests/test_read_dispatch.py
+++ b/packages/nauro/tests/test_read_dispatch.py
@@ -1,0 +1,339 @@
+from __future__ import annotations
+
+import ast
+import inspect
+import json
+from pathlib import Path
+
+import pytest
+from mcp.types import CallToolResult, TextContent
+
+from nauro.mcp import generation_responses as generation
+from nauro.mcp import read_dispatch as dispatch
+from nauro.mcp import stdio_server
+from nauro.store import read_authority
+from nauro.store.config import save_config
+from nauro.store.registry import register_project_v2
+from nauro.store.resolution import resolve_project_binding
+from tests.test_generation_installation import USER_ID
+from tests.test_generation_reads import POSIX
+from tests.test_generation_reads import admitted as admitted
+
+CASES = [("get_context", {"level": level}) for level in ("L0", "L1", "L2")] + [
+    ("get_decision", {"number": 1, "mode": "full"}),
+    ("get_decision", {"number": 1, "mode": "header"}),
+    ("get_raw_file", {"path": "state.md"}),
+    ("list_decisions", {"limit": 1, "include_superseded": True}),
+    ("search_decisions", {"query": "durability", "limit": 1}),
+    ("check_decision", {"proposed_approach": "durability", "context": "refresh"}),
+]
+ERROR = CallToolResult(
+    content=[TextContent(type="text", text="Error: Project read authority is unavailable.")],
+    isError=True,
+)
+
+
+@pytest.fixture(autouse=True)
+def isolated_home(tmp_path, monkeypatch):
+    home = tmp_path / "account-home"
+    home.mkdir()
+    monkeypatch.setenv("NAURO_HOME", str(home))
+
+
+@pytest.fixture
+def cloud(admitted):
+    binding, current, checks = admitted
+    register_project_v2(
+        binding.display_name,
+        [],
+        mode="cloud",
+        project_id=binding.project_id,
+        server_url=binding.server_url,
+    )
+    save_config({"auth": {"user_id": USER_ID, "access_token": "synthetic"}})
+    return binding, current, checks
+
+
+@pytest.fixture
+def flat():
+    pid, path = register_project_v2("Flat", [])
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "state.md").write_text("Flat state")
+    (path / "project.md").write_text("# Flat Project")
+    return resolve_project_binding(pid, None)
+
+
+def forbidden(*args, **kwargs):
+    pytest.fail("Wrong authority path executed")
+
+
+@POSIX
+@pytest.mark.parametrize("name,kwargs", CASES)
+def test_generation_uses_prepared_text_without_legacy_render(cloud, monkeypatch, name, kwargs):
+    binding, _, checks = cloud
+    assert resolve_project_binding(binding.project_id, None) == binding
+    assert read_authority.observe_generation_marker(binding) is not None
+    assert dispatch.read_active_user_id() == USER_ID
+    expected = getattr(generation, name)(binding, **kwargs, actor=USER_ID)
+    assert expected.is_error is False
+    monkeypatch.setattr(dispatch, "_legacy_result", forbidden)
+    monkeypatch.setattr(dispatch.legacy, f"tool_{name}", forbidden)
+    checks.clear()
+    actual = getattr(dispatch, name)(project_id=binding.project_id, **kwargs)
+    assert actual == CallToolResult(
+        content=[TextContent(type="text", text=expected.text)], isError=False
+    )
+    assert actual.structuredContent is None
+    assert len(checks) == 5
+
+
+@pytest.mark.parametrize("name,kwargs", CASES + [("diff_since_last_session", {})])
+def test_flat_matches_live_stdio_without_credentials(flat, monkeypatch, name, kwargs):
+    monkeypatch.setattr(dispatch, "read_active_user_id", forbidden)
+    expected = getattr(stdio_server, name)(project_id=flat.project_id, **kwargs)
+    actual = getattr(dispatch, name)(project_id=flat.project_id, **kwargs)
+    assert actual == expected
+
+
+@pytest.mark.parametrize("phase", ["handler", "renderer"])
+def test_flat_cutover_discards_response(flat, monkeypatch, phase):
+    def cutover():
+        root = flat.store_path / ".replica"
+        root.mkdir()
+        (root / "authority.json").write_text("CORRUPT NEW AUTHORITY")
+
+    if phase == "handler":
+        original = dispatch.legacy.tool_get_raw_file
+
+        def changed(*a, **k):
+            result = original(*a, **k)
+            cutover()
+            return result
+
+        monkeypatch.setattr(dispatch.legacy, "tool_get_raw_file", changed)
+    else:
+        original = dispatch.try_render_envelope
+
+        def changed(*a, **k):
+            result = original(*a, **k)
+            cutover()
+            return result
+
+        monkeypatch.setattr(dispatch, "try_render_envelope", changed)
+    assert dispatch.get_raw_file("state.md", project_id=flat.project_id) == ERROR
+
+
+@POSIX
+@pytest.mark.parametrize(
+    "defect",
+    ["corrupt", "missing_intent", "credentials", "account_change", "marker_change", "renderer"],
+)
+def test_generation_failures_never_fall_back(cloud, monkeypatch, defect):
+    binding, _, _ = cloud
+    marker = binding.store_path / ".replica/authority.json"
+    if defect == "corrupt":
+        marker.write_text("PRIVATE")
+    elif defect == "missing_intent":
+        (binding.store_path / f".replica/v1/actors/{USER_ID}/refresh-intent.json").unlink()
+    elif defect == "credentials":
+        save_config({})
+    else:
+        original = generation.get_raw_file
+
+        def changed(*a, **k):
+            result = original(*a, **k)
+            if defect == "account_change":
+                save_config(
+                    {"auth": {"user_id": "01K44444444444444444444444", "access_token": "changed"}}
+                )
+            elif defect == "marker_change":
+                marker.unlink()
+            return result
+
+        monkeypatch.setattr(generation, "get_raw_file", changed)
+        if defect == "renderer":
+            from nauro_core.renderers import RENDERERS
+
+            def fail(*a, **k):
+                raise RuntimeError("PRIVATE CONTENT")
+
+            monkeypatch.setitem(RENDERERS, "get_raw_file", fail)
+    monkeypatch.setattr(dispatch.legacy, "tool_get_raw_file", forbidden)
+    result = dispatch.get_raw_file("state.md", project_id=binding.project_id)
+    assert result.isError is True
+    assert result.structuredContent is None
+    assert len(result.content) == 1
+    assert "Verified generation state" not in str(result)
+    assert "PRIVATE" not in str(result)
+
+
+@POSIX
+def test_generation_history_never_reads_flat_snapshots(cloud, monkeypatch):
+    binding, _, _ = cloud
+    monkeypatch.setattr(dispatch.legacy, "tool_diff_since_last_session", forbidden)
+    result = dispatch.diff_since_last_session(project_id=binding.project_id)
+    assert result == dispatch._prepared(generation.diff_since_last_session())
+    assert result.isError is True
+
+
+@pytest.mark.parametrize(
+    "defect",
+    [
+        "directory",
+        pytest.param("symlink", marks=POSIX),
+        "hardlink",
+        "large",
+        "local_marker",
+        "noncanonical",
+        "wrong_project",
+        "unsupported",
+        "denied",
+    ],
+)
+def test_marker_observation_refuses_unsafe_evidence(flat, monkeypatch, defect):
+    root = flat.store_path / ".replica"
+    root.mkdir()
+    path = root / "authority.json"
+    marker = {
+        "schema_version": 1,
+        "authority": "generation",
+        "project_id": flat.project_id,
+        "store_format_version": 1,
+    }
+    if defect == "directory":
+        path.mkdir()
+    elif defect in ("symlink", "hardlink"):
+        target = flat.store_path / "target"
+        target.write_text("{}")
+        if defect == "symlink":
+            path.symlink_to(target)
+        else:
+            path.hardlink_to(target)
+    elif defect == "large":
+        path.write_bytes(b"x" * 20000)
+    elif defect == "denied":
+
+        def denied(*a, **k):
+            raise PermissionError("PRIVATE")
+
+        monkeypatch.setattr(read_authority, "_read_optional_file", denied)
+    else:
+        if defect == "wrong_project":
+            marker["project_id"] = "01K33333333333333333333333"
+        elif defect == "unsupported":
+            marker["store_format_version"] = 2
+        path.write_text(
+            json.dumps(
+                marker, sort_keys=True, separators=None if defect == "noncanonical" else (",", ":")
+            )
+        )
+    monkeypatch.setattr(dispatch.legacy, "tool_get_raw_file", forbidden)
+    assert dispatch.get_raw_file("state.md", project_id=flat.project_id) == ERROR
+
+
+def test_resolution_failure_never_calls_legacy(monkeypatch):
+    monkeypatch.setattr(dispatch.legacy, "tool_get_context", forbidden)
+    assert dispatch.get_context(project_id="missing") == ERROR
+
+
+def test_dispatch_is_dormant_and_keeps_public_arguments():
+    root = Path(dispatch.__file__).parents[1]
+    for path in root.rglob("*.py"):
+        for node in ast.walk(ast.parse(path.read_text())):
+            if isinstance(node, ast.Import):
+                assert all(a.name != "nauro.mcp.read_dispatch" for a in node.names)
+            elif isinstance(node, ast.ImportFrom):
+                assert node.module != "nauro.mcp.read_dispatch"
+                if node.module == "nauro.mcp":
+                    assert all(a.name != "read_dispatch" for a in node.names)
+    for name, _ in CASES + [("diff_since_last_session", {})]:
+        live = inspect.signature(getattr(stdio_server, name)).parameters
+        new = inspect.signature(getattr(dispatch, name)).parameters
+        assert list(new) == list(live)
+        assert [p.default for p in new.values()] == [p.default for p in live.values()]
+
+
+@POSIX
+@pytest.mark.parametrize("defect", ["none", "noncanonical", "wrong_project", "unsupported"])
+def test_cloud_marker_validation_before_generation_admission(cloud, monkeypatch, defect):
+    from nauro.store.generation_authority import (
+        ClientUpgradeRequiredError,
+        GenerationControlCorruptError,
+    )
+
+    binding, _, _ = cloud
+    path = binding.store_path / ".replica/authority.json"
+    original = path.read_bytes()
+    marker = json.loads(original)
+    if defect == "none":
+        assert read_authority.observe_generation_marker(binding) == original
+        return
+    if defect == "wrong_project":
+        marker["project_id"] = "01K44444444444444444444444"
+    elif defect == "unsupported":
+        marker["store_format_version"] = 2
+    path.write_text(
+        json.dumps(
+            marker, sort_keys=True, separators=None if defect == "noncanonical" else (",", ":")
+        )
+    )
+    error = ClientUpgradeRequiredError if defect == "unsupported" else GenerationControlCorruptError
+    with pytest.raises(error):
+        read_authority.observe_generation_marker(binding)
+    monkeypatch.setattr(generation, "get_context", forbidden)
+    assert dispatch.get_context(project_id=binding.project_id) == ERROR
+
+
+@POSIX
+@pytest.mark.parametrize(
+    "path",
+    [
+        "questions-provenance.json",
+        "./questions-provenance.json",
+        "../state.md",
+        ".replica/authority.json",
+    ],
+)
+def test_generation_raw_exclusions_survive_dispatch(cloud, path):
+    binding, _, checks = cloud
+    checks.clear()
+    result = dispatch.get_raw_file(path, project_id=binding.project_id)
+    assert result == dispatch._prepared(
+        generation._error("Invalid or unavailable generation path.", kind="rejected")
+    )
+    assert checks == []
+
+
+@pytest.mark.parametrize("phase", ["handler", "renderer"])
+def test_valid_generation_cutover_discards_legacy_bytes(flat, monkeypatch, phase):
+    from nauro.store.resolution import ResolvedProjectBinding
+
+    binding = ResolvedProjectBinding(
+        flat.store_path, flat.project_id, flat.display_name, "cloud", "https://example.test"
+    )
+    monkeypatch.setattr(dispatch, "resolve_project_binding", lambda *a: binding)
+    marker = {
+        "schema_version": 1,
+        "authority": "generation",
+        "project_id": binding.project_id,
+        "store_format_version": 1,
+    }
+
+    def cutover():
+        root = binding.store_path / ".replica"
+        root.mkdir()
+        (root / "authority.json").write_text(
+            json.dumps(marker, sort_keys=True, separators=(",", ":"))
+        )
+
+    owner = dispatch.legacy if phase == "handler" else dispatch
+    name = "tool_get_raw_file" if phase == "handler" else "try_render_envelope"
+    original = getattr(owner, name)
+
+    def changed(*a, **k):
+        result = original(*a, **k)
+        cutover()
+        return result
+
+    monkeypatch.setattr(owner, name, changed)
+    assert dispatch.get_raw_file("state.md", project_id=binding.project_id) == ERROR


### PR DESCRIPTION
## Why

Local generation reads need authority selection before any legacy store read or rendering. Verified generation responses already contain bounded text and must reach MCP without being rendered again.

## What changed

Add a dormant dispatcher for the existing read arguments. It validates the local authority marker, derives the active account for generation reads, and returns prepared MCP text with the correct error flag. Legacy reads keep existing results and discard them if authority changes during execution or rendering.

Add boundary tests, an exact consumer guard, and typing coverage. Live stdio and CLI registration remain unchanged.

## Test plan

1,099 affected, legacy, and contract tests passed, with 77 platform-specific skips. All four cross-repository checks passed explicitly without skips. Repository lint and formatting, targeted typing, and the unchanged source-risk baseline pass.

## Risk / what to review

Review marker absence versus unreadable evidence, account changes, legacy cutover checks, and direct prepared-text conversion. Before/after observations do not establish atomic migration exclusion or protect old clients.

## Deferred

Concurrent writing remains incomplete, and production activation is unchanged. Hosted dispatch, startup-pull protection, disconnected/onboarding diagnostic integration, authorized history, migration coordination, Windows durability, and production timing remain open.
