### PR TITLE
Guard stdio startup pulls with verified project authority

### DIFF
--- a/packages/nauro/src/nauro/mcp/stdio_server.py
+++ b/packages/nauro/src/nauro/mcp/stdio_server.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 from pathlib import Path
 from typing import Annotated, Any, Literal
 
@@ -47,14 +46,13 @@ from nauro.mcp.tools import (
 from nauro.mcp.write_status import render_write_status
 from nauro.onboarding import WELCOME_NO_PROJECT
 from nauro.store.journal import OriginDescriptor
+from nauro.store.read_authority import observe_generation_marker
 from nauro.store.repo_head import resolve_repo_head
 from nauro.store.resolution import (
-    DisconnectedProject,
     DisconnectedProjectError,
     NoProjectError,
-    RepoResolution,
     StoreResolutionError,
-    resolve_from_cwd,
+    resolve_project_binding,
     resolve_store,
 )
 
@@ -466,15 +464,11 @@ def _pull_on_startup() -> None:
     Never raises: a failed pull is logged and the server starts on local state.
     """
     try:
-        resolution = resolve_from_cwd(Path(os.getcwd()))
-        if resolution is None or isinstance(resolution, DisconnectedProject):
-            logger.debug("session-start pull: no project found in cwd, skipping")
+        binding = resolve_project_binding(None, Path.cwd())
+        if observe_generation_marker(binding) is not None:
+            logger.debug("session-start pull: generation authority, skipping")
             return
-        assert isinstance(resolution, RepoResolution)
-        project_key, store_path = resolution.project_id, resolution.store_path
-        if not store_path.exists():
-            logger.debug("session-start pull: store not found for %s, skipping", project_key)
-            return
+        project_key, store_path = binding.project_id, binding.store_path
 
         from nauro.sync.hooks import pull_before_session
 
@@ -483,8 +477,10 @@ def _pull_on_startup() -> None:
             logger.info("session-start pull: pulled %d file(s) for %s", pulled, project_key)
         else:
             logger.debug("session-start pull: nothing to do for %s", project_key)
-    except Exception as e:
-        logger.warning("session-start pull: failed, continuing with local state: %s", e)
+    except NoProjectError:
+        logger.debug("session-start pull: no project found in cwd, skipping")
+    except Exception:
+        logger.warning("session-start pull: unavailable, continuing with local state")
 
 
 def run_stdio() -> None:

--- a/packages/nauro/tests/test_stdio_server.py
+++ b/packages/nauro/tests/test_stdio_server.py
@@ -760,13 +760,8 @@ class TestContentSizeLimits:
 
 
 class TestPullOnStartup:
-    """Auth and cloud-mode gating moved into hooks.py; stdio_server only
-    resolves the project from cwd and delegates. These tests cover the
-    resolution flow — silent-no-op-when-not-authenticated and
-    silent-no-op-for-non-cloud are exercised in test_sync/test_hooks.py."""
-
     def test_calls_pull_when_project_resolves(self, store: Path, monkeypatch, tmp_path):
-        """pull_before_session is invoked unconditionally when a project resolves."""
+        """A legacy store with verified marker absence reaches the pull hook."""
         repo_dir = tmp_path / "repo"
         repo_dir.mkdir(exist_ok=True)
         monkeypatch.chdir(repo_dir)

--- a/packages/nauro/tests/test_stdio_startup_authority.py
+++ b/packages/nauro/tests/test_stdio_startup_authority.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from nauro.mcp import stdio_server
+from nauro.store import read_authority
+from nauro.store.registry import register_project_v2
+
+
+@pytest.fixture
+def startup(tmp_path, monkeypatch):
+    monkeypatch.setenv("NAURO_HOME", str(tmp_path / "home"))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.chdir(repo)
+    pid, store = register_project_v2(
+        "Startup", [repo], mode="cloud", server_url="https://example.test"
+    )
+    store.mkdir(parents=True, exist_ok=True)
+    pull = Mock(return_value=0)
+    monkeypatch.setattr("nauro.sync.hooks.pull_before_session", pull)
+    return pid, store, pull
+
+
+def marker_bytes(pid: str, version: int = 1) -> bytes:
+    return json.dumps(
+        {
+            "schema_version": 1,
+            "authority": "generation",
+            "project_id": pid,
+            "store_format_version": version,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
+
+
+@pytest.mark.parametrize("empty_control", [False, True])
+def test_cloud_legacy_reaches_existing_pull(startup, empty_control):
+    pid, store, pull = startup
+    if empty_control:
+        (store / ".replica").mkdir()
+    stdio_server._pull_on_startup()
+    pull.assert_called_once_with(pid, store)
+
+
+@pytest.mark.parametrize("case", ["valid", "corrupt", "wrong_project", "unsupported", "directory"])
+def test_marker_prevents_startup_pull(startup, case):
+    pid, store, pull = startup
+    control = store / ".replica"
+    control.mkdir()
+    marker = control / "authority.json"
+    if case == "directory":
+        marker.mkdir()
+    else:
+        payload = marker_bytes(pid)
+        if case == "corrupt":
+            payload = b"PRIVATE CORRUPT CONTROL"
+        elif case == "wrong_project":
+            payload = marker_bytes("01K33333333333333333333333")
+        elif case == "unsupported":
+            payload = marker_bytes(pid, 2)
+        marker.write_bytes(payload)
+    stdio_server._pull_on_startup()
+    pull.assert_not_called()
+
+
+@pytest.mark.parametrize("error", [PermissionError, OSError])
+def test_unreadable_control_prevents_pull_without_logging_payload(
+    startup, monkeypatch, caplog, error
+):
+    _, _, pull = startup
+
+    def unavailable(path: Path) -> bytes | None:
+        raise error("PRIVATE CONTROL DETAIL")
+
+    monkeypatch.setattr(read_authority, "_read_optional_file", unavailable)
+    stdio_server._pull_on_startup()
+    pull.assert_not_called()
+    assert "session-start pull: unavailable, continuing with local state" in caplog.text
+    assert "PRIVATE" not in caplog.text
+
+
+def test_missing_store_prevents_pull(startup):
+    _, store, pull = startup
+    store.rmdir()
+    stdio_server._pull_on_startup()
+    pull.assert_not_called()
+
+
+@pytest.mark.parametrize("location", ["marker", "parent"])
+def test_linked_control_prevents_pull(startup, tmp_path, location):
+    pid, store, pull = startup
+    target = tmp_path / "target"
+    target.mkdir()
+    (target / "authority.json").write_bytes(marker_bytes(pid))
+    control = store / ".replica"
+    try:
+        if location == "parent":
+            control.symlink_to(target, target_is_directory=True)
+        else:
+            control.mkdir()
+            (control / "authority.json").symlink_to(target / "authority.json")
+    except OSError:
+        pytest.skip("Symlink creation is unavailable on this platform")
+    stdio_server._pull_on_startup()
+    pull.assert_not_called()
+
+
+def test_invalid_registry_prevents_pull(startup, tmp_path):
+    _, _, pull = startup
+    registry = tmp_path / "home" / "registry.json"
+    assert registry.is_file()
+    registry.write_bytes(b"PRIVATE INVALID REGISTRY")
+    stdio_server._pull_on_startup()
+    pull.assert_not_called()
+
+
+def test_hardlinked_marker_prevents_pull(startup, tmp_path):
+    pid, store, pull = startup
+    target = tmp_path / "marker"
+    target.write_bytes(marker_bytes(pid))
+    control = store / ".replica"
+    control.mkdir()
+    (control / "authority.json").hardlink_to(target)
+    stdio_server._pull_on_startup()
+    pull.assert_not_called()


### PR DESCRIPTION
## Why

Stdio startup can enter the legacy pull hook before checking generation authority. This can select a legacy mutation path for a generation store.

## What changed

Resolve a strict project binding and require verified marker absence before calling the startup pull hook. Skip generation stores and unavailable or invalid authority evidence. Preserve startup continuation and the existing legacy hook checks.

## Test plan

190 client tests and four explicit cross-repository checks passed with no skips. Lint, formatting, contract checks, the unchanged source-risk gate and targeted authority/binding typing passed. Full stdio typing retains two errors reproduced on the base revision.

## Risk / what to review

The authority check is not an atomic migration fence. Invalid legacy binding evidence now prevents startup pulls. Concurrent writing remains incomplete; production activation is unchanged. Generation routing, migration coordination and other write entry points remain deferred.
