### PR TITLE
Preserve binding diagnostics in dormant local read dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
           packages/nauro/src/nauro/store/generation_store.py
           packages/nauro/src/nauro/mcp/generation_reads.py
           packages/nauro/src/nauro/mcp/generation_responses.py
+          packages/nauro/src/nauro/mcp/resolution_errors.py
           packages/nauro/src/nauro/mcp/read_dispatch.py
           packages/nauro/src/nauro/store/read_authority.py
           packages/nauro/src/nauro/store/generation_refresh_state.py

--- a/packages/nauro/src/nauro/mcp/read_dispatch.py
+++ b/packages/nauro/src/nauro/mcp/read_dispatch.py
@@ -13,10 +13,13 @@ from nauro.auth import ActiveUserReadError, read_active_user_id
 from nauro.mcp import generation_responses as generation
 from nauro.mcp import tools as legacy
 from nauro.mcp.rendering import resolve_renderer_kwargs, try_render_envelope
+from nauro.mcp.resolution_errors import resolution_error_envelope
 from nauro.store.config import resolve_embeddings_flag
 from nauro.store.generation_authority import GenerationAuthorityError
 from nauro.store.read_authority import observe_generation_marker
 from nauro.store.resolution import (
+    DisconnectedProjectError,
+    NoProjectError,
     ResolvedProjectBinding,
     StoreResolutionError,
     resolve_project_binding,
@@ -40,7 +43,7 @@ def _unavailable() -> CallToolResult:
 
 
 def _legacy_result(
-    name: str, envelope: dict[str, object], options: dict[str, object], path: Path
+    name: str, envelope: dict[str, object], options: dict[str, object], path: Path | None
 ) -> CallToolResult:
     rendered = try_render_envelope(name, envelope, resolve_renderer_kwargs(name, options, path))
     if rendered.failure is not None:
@@ -68,6 +71,11 @@ def _read(
 ) -> CallToolResult:
     try:
         binding = resolve_project_binding(project_id, cwd)
+    except (NoProjectError, DisconnectedProjectError) as exc:
+        return _legacy_result(name, resolution_error_envelope(exc), options or {}, None)
+    except (StoreResolutionError, OSError):
+        return _unavailable()
+    try:
         marker = observe_generation_marker(binding)
         if marker is not None:
             actor = read_active_user_id()

--- a/packages/nauro/src/nauro/mcp/resolution_errors.py
+++ b/packages/nauro/src/nauro/mcp/resolution_errors.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from nauro_core.operations import ErrorPayload
+
+from nauro.onboarding import WELCOME_NO_PROJECT
+from nauro.store.resolution import (
+    DisconnectedProjectError,
+    NoProjectError,
+    StoreResolutionError,
+)
+
+
+def resolution_error_envelope(error: StoreResolutionError) -> dict[str, object]:
+    if isinstance(error, NoProjectError):
+        return {"store": "local", "status": "error", "guidance": WELCOME_NO_PROJECT}
+    if isinstance(error, DisconnectedProjectError):
+        state = error.state
+        return {
+            "store": "local",
+            "status": "error",
+            "error": ErrorPayload(kind="error", reason=state.guidance).model_dump(
+                exclude_none=True
+            ),
+            "guidance": state.guidance,
+            "project_id": state.project_id,
+            "project_name": state.display_name,
+            "project_mode": state.mode,
+            "reason_code": state.reason_code,
+            "recovery_actions": list(state.recovery_actions),
+        }
+    return {"store": "local", "status": "error", "guidance": str(error)}

--- a/packages/nauro/src/nauro/mcp/stdio_server.py
+++ b/packages/nauro/src/nauro/mcp/stdio_server.py
@@ -25,12 +25,12 @@ from mcp.server.fastmcp import Context
 from mcp.types import CallToolResult, TextContent, ToolAnnotations
 from nauro_core.constants import MCP_INSTRUCTIONS_STATIC
 from nauro_core.mcp_tools import ToolSpec, get_tool_spec
-from nauro_core.operations import ErrorPayload
 from nauro_core.renderers import disconnected_reason_code
 from pydantic import Field
 
 from nauro import __version__
 from nauro.mcp.rendering import resolve_renderer_kwargs, try_render_envelope
+from nauro.mcp.resolution_errors import resolution_error_envelope
 from nauro.mcp.tools import (
     tool_check_decision,
     tool_diff_since_last_session,
@@ -44,12 +44,10 @@ from nauro.mcp.tools import (
     tool_update_state,
 )
 from nauro.mcp.write_status import render_write_status
-from nauro.onboarding import WELCOME_NO_PROJECT
 from nauro.store.journal import OriginDescriptor
 from nauro.store.read_authority import observe_generation_marker
 from nauro.store.repo_head import resolve_repo_head
 from nauro.store.resolution import (
-    DisconnectedProjectError,
     NoProjectError,
     StoreResolutionError,
     resolve_project_binding,
@@ -118,25 +116,8 @@ def _resolve_or_error(project_id, cwd) -> tuple[Path | None, dict | None]:
     """
     try:
         return resolve_store(project_id, cwd), None
-    except NoProjectError:
-        return None, {"store": "local", "status": "error", "guidance": WELCOME_NO_PROJECT}
-    except DisconnectedProjectError as exc:
-        state = exc.state
-        return None, {
-            "store": "local",
-            "status": "error",
-            "error": ErrorPayload(kind="error", reason=state.guidance).model_dump(
-                exclude_none=True
-            ),
-            "guidance": state.guidance,
-            "project_id": state.project_id,
-            "project_name": state.display_name,
-            "project_mode": state.mode,
-            "reason_code": state.reason_code,
-            "recovery_actions": list(state.recovery_actions),
-        }
     except StoreResolutionError as exc:
-        return None, {"store": "local", "status": "error", "guidance": str(exc)}
+        return None, resolution_error_envelope(exc)
 
 
 def _origin_from_ctx(mcp_ctx: Context | None) -> OriginDescriptor | None:

--- a/packages/nauro/tests/test_read_dispatch_diagnostics.py
+++ b/packages/nauro/tests/test_read_dispatch_diagnostics.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+
+from nauro.mcp import read_dispatch as dispatch
+from nauro.mcp import stdio_server
+from nauro.store.registry import register_project_v2, save_registry_v2
+from nauro.store.repo_config import save_repo_config
+from nauro.store.resolution import (
+    DisconnectedProject,
+    DisconnectedProjectError,
+    NoProjectError,
+    resolve_project_binding,
+)
+
+CASES = (
+    [("get_context", {"level": level}) for level in ("L0", "L1", "L2")]
+    + [("get_decision", {"number": 1, "mode": mode}) for mode in ("header", "full")]
+    + [
+        ("get_raw_file", {"path": "state.md"}),
+        ("list_decisions", {}),
+        ("search_decisions", {"query": "diagnostics"}),
+        ("check_decision", {"proposed_approach": "Preserve diagnostics"}),
+        ("diff_since_last_session", {}),
+    ]
+)
+PID = "01KQ6AZGNA0B3QBF67NBXP3S45"
+
+
+@pytest.fixture(autouse=True)
+def isolated(tmp_path, monkeypatch):
+    monkeypatch.setenv("NAURO_HOME", str(tmp_path / "home"))
+    monkeypatch.chdir(tmp_path)
+
+
+def forbidden(*args, **kwargs):
+    pytest.fail("A binding diagnostic must not access project content")
+
+
+@pytest.mark.parametrize("name,kwargs", CASES)
+@pytest.mark.parametrize("mode", [None, "local", "cloud"])
+def test_binding_diagnostic_matches_live_result(tmp_path, monkeypatch, name, kwargs, mode):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    if mode is not None:
+        config = {"mode": mode, "id": PID, "name": "Diagnostic Project"}
+        if mode == "cloud":
+            config["server_url"] = "https://example.test"
+        save_repo_config(repo, config)
+    expected = getattr(stdio_server, name)(cwd=str(repo), **kwargs)
+    monkeypatch.setattr(dispatch, "observe_generation_marker", forbidden)
+    monkeypatch.setattr(dispatch, "read_active_user_id", forbidden)
+    monkeypatch.setattr(dispatch.legacy, f"tool_{name}", forbidden)
+    monkeypatch.setattr(dispatch.generation, name, forbidden)
+    actual = getattr(dispatch, name)(cwd=str(repo), **kwargs)
+    assert actual == expected
+    assert actual.isError is False
+    if mode is None:
+        assert actual.structuredContent is None
+    else:
+        assert actual.structuredContent["project_id"] == PID
+        assert actual.structuredContent["project_mode"] == mode
+        assert actual.structuredContent["reason_code"] == "not_connected_on_this_machine"
+        assert actual.structuredContent["recovery_actions"] == (
+            ["locate", "restore", "continue"] if mode == "cloud" else ["locate", "continue"]
+        )
+        assert actual.content[0].text == actual.structuredContent["guidance"]
+
+
+@pytest.mark.parametrize("defect", ["registry", "config", "unknown_project"])
+def test_invalid_binding_does_not_become_onboarding(tmp_path, monkeypatch, defect):
+    if defect == "registry":
+        home = tmp_path / "home"
+        home.mkdir()
+        (home / "registry.json").write_text("PRIVATE CORRUPT REGISTRY")
+    elif defect == "config":
+        config = tmp_path / ".nauro"
+        config.mkdir()
+        (config / "config.json").write_text("PRIVATE CORRUPT CONFIG")
+    monkeypatch.setattr(dispatch, "observe_generation_marker", forbidden)
+    monkeypatch.setattr(dispatch.legacy, "tool_get_context", forbidden)
+    result = dispatch.get_context(project_id=PID if defect == "unknown_project" else None)
+    assert result.isError is True
+    assert result.structuredContent is None
+    assert result.content[0].text == "Error: Project read authority is unavailable."
+
+
+@pytest.mark.parametrize("phase", ["marker", "generation"])
+@pytest.mark.parametrize("kind", ["no_project", "disconnected"])
+def test_post_binding_error_never_becomes_diagnostic(tmp_path, monkeypatch, phase, kind):
+    pid, store = register_project_v2("Bound", [])
+    store.mkdir(parents=True, exist_ok=True)
+    binding = resolve_project_binding(pid, None)
+    if kind == "no_project":
+        error = NoProjectError("PRIVATE FAILURE")
+    else:
+        error = DisconnectedProjectError(
+            DisconnectedProject(
+                store_path=store,
+                project_id=pid,
+                display_name="PRIVATE LABEL",
+                mode="cloud",
+                reason_code="connected_record_missing",
+                recovery_actions=("locate", "restore", "continue"),
+                guidance="PRIVATE GUIDANCE",
+            )
+        )
+    monkeypatch.setattr(dispatch, "resolve_project_binding", lambda *args: binding)
+    monkeypatch.setattr(dispatch.legacy, "tool_get_context", forbidden)
+    monkeypatch.setattr(dispatch, "_legacy_result", forbidden)
+    if phase == "marker":
+        monkeypatch.setattr(dispatch, "observe_generation_marker", Mock(side_effect=error))
+    else:
+        monkeypatch.setattr(dispatch, "observe_generation_marker", lambda *args: b"marker")
+        monkeypatch.setattr(dispatch, "read_active_user_id", lambda: "actor")
+        monkeypatch.setattr(dispatch.generation, "get_context", Mock(side_effect=error))
+    result = dispatch.get_context(project_id=pid)
+    assert result.isError is True
+    assert result.structuredContent is None
+    assert result.content[0].text == "Error: Project read authority is unavailable."
+
+
+@pytest.mark.parametrize("name,kwargs", CASES)
+@pytest.mark.parametrize("mode", ["local", "cloud"])
+@pytest.mark.parametrize(
+    "reason", ["connected_record_missing", "connected_record_invalid", "connected_binding_conflict"]
+)
+def test_existing_connection_diagnostics_match_live(
+    tmp_path, monkeypatch, name, kwargs, mode, reason
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    config = {"mode": mode, "id": PID, "name": "Diagnostic Project"}
+    entry = {"mode": mode, "name": "Diagnostic Project", "repo_paths": [str(repo)]}
+    if mode == "cloud":
+        config["server_url"] = "https://example.test"
+        entry["server_url"] = "https://example.test"
+    if reason == "connected_record_invalid":
+        external = tmp_path / "external" / PID
+        external.mkdir(parents=True)
+        entry["store_path"] = str(external)
+    elif reason == "connected_binding_conflict":
+        entry["name"] = "Conflicting Label"
+    save_registry_v2({"schema_version": 2, "projects": {PID: entry}})
+    save_repo_config(repo, config)
+    expected = getattr(stdio_server, name)(cwd=str(repo), **kwargs)
+    monkeypatch.setattr(dispatch, "observe_generation_marker", forbidden)
+    monkeypatch.setattr(dispatch.legacy, f"tool_{name}", forbidden)
+    actual = getattr(dispatch, name)(cwd=str(repo), **kwargs)
+    assert actual == expected
+    assert actual.isError is False
+    assert actual.structuredContent["reason_code"] == reason
+    assert actual.structuredContent["project_id"] == PID
+    assert actual.structuredContent["recovery_actions"] == (
+        ["locate", "restore", "continue"]
+        if mode == "cloud" and reason == "connected_record_missing"
+        else ["locate", "continue"]
+    )


### PR DESCRIPTION
## Why

The dormant local read dispatcher drops the existing welcome message and disconnected-project recovery details. This prevents it from preserving current diagnostics when routing is later enabled.

## What changed

Share the existing stdio resolution-error formatter and preserve those diagnostics only during strict binding resolution. Failures after binding remain bounded authority errors. Keep live stdio output and dormant route registration unchanged.

## Test plan

295 client tests and four explicit cross-repository checks passed with no skips. Lint, formatting, targeted typing, public contracts and the unchanged risk gate passed. Tests cover exact local/cloud recovery results and errors before and after binding.

## Risk / what to review

Only the two named binding diagnostics use the existing response format. Other strict binding errors remain fail-closed. Concurrent writing remains incomplete; production activation is unchanged. Hosted diagnostic compatibility and migration coordination remain open.
