### PR TITLE
Add authenticated client history reads and dormant composition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,8 @@ jobs:
           packages/nauro/src/nauro/sync/generation_acquisition.py
           packages/nauro/src/nauro/store/submission_records.py
           packages/nauro/src/nauro/sync/judgment_submission.py
+          packages/nauro/src/nauro/sync/history_contract.py
+          packages/nauro/src/nauro/sync/history_transport.py
           packages/nauro/src/nauro/sync/judgment_transport.py
           packages/nauro/src/nauro/auth.py
           packages/nauro/src/nauro/sync/merge.py
@@ -100,6 +102,8 @@ jobs:
           packages/nauro/tests/test_generation_store.py
           packages/nauro/tests/test_generation_reads.py
           packages/nauro/tests/test_generation_responses.py
+          packages/nauro/tests/test_history_transport.py
+          packages/nauro/tests/test_history_composition.py
           packages/nauro/tests/test_read_dispatch.py
           packages/nauro/tests/test_generation_refresh_state.py
           packages/nauro/tests/test_generation_refresh.py

--- a/packages/nauro/src/nauro/mcp/generation_responses.py
+++ b/packages/nauro/src/nauro/mcp/generation_responses.py
@@ -8,14 +8,16 @@ from nauro_core.protected_generation_membership import (
     validate_protected_generation_path,
 )
 
+from nauro.auth import ActiveUserReadError
 from nauro.mcp import generation_reads as reads
 from nauro.mcp.generation_reads import GenerationReadResult, _Result
 from nauro.mcp.rendering import try_render_envelope
 from nauro.store.generation_authority import GenerationAuthorityError
 from nauro.store.generation_projection import GenerationProjectionTarget
 from nauro.store.resolution import ResolvedProjectBinding
-from nauro.sync.generation_refresh import _authorize
-from nauro.sync.remote import TransferBoundaryError, TransferSession
+from nauro.sync.generation_refresh import _authorize, admit_generation_store
+from nauro.sync.history_transport import HttpHistoryTransport
+from nauro.sync.remote import TransferBoundaryError, TransferSession, resolve_api_url
 
 _READ_FAILURES = (GenerationAuthorityError, TransferBoundaryError)
 
@@ -206,7 +208,34 @@ def check_decision(
         return _unavailable()
 
 
-def diff_since_last_session() -> GenerationToolResponse:
-    return _error(
-        "Generation session history is unavailable until authorized history is supported."
-    )
+def diff_since_last_session(
+    binding: ResolvedProjectBinding,
+    days: int | None = None,
+    *,
+    actor: str,
+    transport: HttpHistoryTransport | None = None,
+    session: TransferSession | None = None,
+) -> GenerationToolResponse:
+    if transport is None:
+        return _error("Generation history requires an explicit authenticated transport.")
+    if days is not None and type(days) is not int:
+        return _error("History days must be an integer.", kind="rejected")
+    try:
+        transport.require_binding(binding, resolve_api_url())
+        store = admit_generation_store(binding, actor=actor, session=session)
+        result = transport.fetch(store.target, days)
+        identity = store.target.identity
+        envelope: dict[str, object] = {
+            "store": "local",
+            "diff": result.diff,
+            "project": {"id": identity.project_id, "name": identity.project_id},
+            "read_authority": result.read_authority.model_dump(mode="json"),
+        }
+        if result.cutoff_date_used is not None:
+            envelope["cutoff_date_used"] = result.cutoff_date_used
+        final = admit_generation_store(binding, actor=actor, session=session)
+        if final.target != store.target:
+            return _unavailable()
+        return GenerationToolResponse(envelope, result.text, False)
+    except (GenerationAuthorityError, TransferBoundaryError, ActiveUserReadError, OSError):
+        return _unavailable()

--- a/packages/nauro/src/nauro/mcp/read_dispatch.py
+++ b/packages/nauro/src/nauro/mcp/read_dispatch.py
@@ -24,6 +24,7 @@ from nauro.store.resolution import (
     StoreResolutionError,
     resolve_project_binding,
 )
+from nauro.sync.history_transport import HttpHistoryTransport
 from nauro.sync.remote import TransferBoundaryError
 
 logger = logging.getLogger(__name__)
@@ -195,13 +196,31 @@ def check_decision(
     )
 
 
-def diff_since_last_session(
-    project_id: str | None = None, cwd: str | None = None, days: int | None = None
+def _history_diff(
+    project_id: str | None,
+    cwd: str | None,
+    days: int | None,
+    transport: HttpHistoryTransport | None,
 ) -> CallToolResult:
     return _read(
         "diff_since_last_session",
         project_id,
         cwd,
         lambda p: legacy.tool_diff_since_last_session(p, days),
-        lambda b, a: generation.diff_since_last_session(),
+        lambda b, a: generation.diff_since_last_session(b, days, actor=a, transport=transport),
     )
+
+
+def diff_since_last_session(
+    project_id: str | None = None, cwd: str | None = None, days: int | None = None
+) -> CallToolResult:
+    return _history_diff(project_id, cwd, days, None)
+
+
+def history_dispatch(transport: HttpHistoryTransport) -> Callable[..., CallToolResult]:
+    def diff_since_last_session(
+        project_id: str | None = None, cwd: str | None = None, days: int | None = None
+    ) -> CallToolResult:
+        return _history_diff(project_id, cwd, days, transport)
+
+    return diff_since_last_session

--- a/packages/nauro/src/nauro/sync/history_contract.py
+++ b/packages/nauro/src/nauro/sync/history_contract.py
@@ -1,0 +1,119 @@
+"""Closed hosted history response verified against an installed projection."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Literal
+
+from nauro_core.identifiers import IdentifierKind, validate_identifier
+from nauro_core.provenance import validate_utc_timestamp
+from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, field_validator, model_validator
+
+from nauro.store.generation_projection import GenerationProjectionIdentity, _digest
+
+SelectionKind = Literal["root", "latest_two", "cutoff", "oldest_fallback"]
+
+MAX_DIFF_CHARS = 12000
+MAX_TEXT_CHARS = 13000
+MAX_RESPONSE_BYTES = 170000
+
+
+class _ClosedModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True, hide_input_in_errors=True)
+
+    @field_validator("*", mode="before")
+    @classmethod
+    def _scalar(cls, value: object, info: ValidationInfo) -> object:
+        name = info.field_name
+        if name == "version" and type(value) is not int:
+            raise ValueError("Version must be an integer.")
+        if name in {
+            "project_id",
+            "authenticated_user_id",
+            "generation_id",
+        }:
+            return validate_identifier(IdentifierKind.ulid, value, field=name)
+        if name in {
+            "manifest_digest",
+            "projection_scope_id",
+        }:
+            return _digest(value) if isinstance(value, str) else _bad_digest()
+        if name == "committed_at":
+            return validate_utc_timestamp(value, field=name)
+        return value
+
+
+class HistoryStamp(_ClosedModel):
+    generation_id: str
+    committed_at: str
+
+
+class HistoryAuthority(HistoryStamp):
+    kind: Literal["generation"]
+    project_id: str
+    manifest_digest: str
+    freshness: Literal["authorized_at_read"]
+
+
+class HistoryResponse(_ClosedModel):
+    version: int = Field(ge=1, le=1)
+    store: Literal["remote"]
+    authenticated_user_id: str
+    projection_class: Literal["viewer", "contributor_plus"]
+    projection_scope_id: str
+    read_authority: HistoryAuthority
+    baseline: HistoryStamp | None
+    selection: SelectionKind
+    requested_days: int | None
+    cutoff_date_used: str | None
+    diff: str = Field(max_length=MAX_DIFF_CHARS)
+    text: str = Field(max_length=MAX_TEXT_CHARS)
+
+    @field_validator("cutoff_date_used")
+    @classmethod
+    def _cutoff(cls, value: str | None) -> str | None:
+        if value is not None:
+            parsed = datetime.fromisoformat(value)
+            if len(value) > 40 or parsed.tzinfo != timezone.utc or parsed.isoformat() != value:
+                raise ValueError("History cutoff is not canonical UTC.")
+        return value
+
+    @model_validator(mode="after")
+    def _selection(self) -> HistoryResponse:
+        if (self.selection == "root") != (self.baseline is None):
+            raise ValueError("History baseline and selection disagree.")
+        if (self.selection in {"cutoff", "oldest_fallback"}) != (self.cutoff_date_used is not None):
+            raise ValueError("History cutoff and selection disagree.")
+        if (self.requested_days is None) != (self.cutoff_date_used is None):
+            raise ValueError("History days and cutoff disagree.")
+        if (
+            self.selection == "latest_two"
+            and self.baseline is not None
+            and self.baseline.generation_id == self.read_authority.generation_id
+        ):
+            raise ValueError("Latest-two history needs distinct generations.")
+        if (
+            self.selection == "cutoff"
+            and self.baseline is not None
+            and self.cutoff_date_used is not None
+            and datetime.fromisoformat(self.baseline.committed_at.replace("Z", "+00:00"))
+            > datetime.fromisoformat(self.cutoff_date_used)
+        ):
+            raise ValueError("History baseline exceeds the cutoff.")
+        return self
+
+    def matches(self, identity: GenerationProjectionIdentity, days: int | None) -> bool:
+        return (
+            self.authenticated_user_id == identity.installed_for_user_id
+            and self.read_authority.project_id == identity.project_id
+            and self.read_authority.generation_id == identity.generation_id
+            and self.read_authority.manifest_digest == identity.manifest_digest
+            and self.read_authority.committed_at == identity.committed_at
+            and self.projection_class == identity.projection_class
+            and self.projection_scope_id == identity.projection_scope_id
+            and self.requested_days == days
+        )
+
+
+def _bad_digest() -> str:
+    raise ValueError("History digest must be text.")

--- a/packages/nauro/src/nauro/sync/history_transport.py
+++ b/packages/nauro/src/nauro/sync/history_transport.py
@@ -1,0 +1,140 @@
+"""Explicit authenticated history reads with bounded response verification."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+
+from nauro.auth import read_active_credentials
+from nauro.store.generation_authority import GenerationAuthorityError
+from nauro.store.generation_projection import GenerationProjectionTarget, _target_parts
+from nauro.store.resolution import ResolvedProjectBinding
+from nauro.sync.history_contract import MAX_RESPONSE_BYTES, HistoryResponse
+
+
+class HistoryTransportError(GenerationAuthorityError):
+    code = "generation_history_unavailable"
+
+
+def _origin(value: str) -> str:
+    try:
+        url = httpx.URL(value)
+    except httpx.InvalidURL as exc:
+        raise HistoryTransportError("History requires a trusted HTTPS origin.") from exc
+    if (
+        url.scheme != "https"
+        or not url.host
+        or url.userinfo
+        or url.query
+        or url.fragment
+        or url.path not in {"", "/"}
+    ):
+        raise HistoryTransportError("History requires a trusted HTTPS origin.")
+    return str(url).rstrip("/")
+
+
+def _unique(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result = dict(pairs)
+    if len(result) != len(pairs):
+        raise ValueError("Duplicate JSON key.")
+    return result
+
+
+def _frame(response: HistoryResponse) -> str:
+    baseline = response.baseline
+    frame = (
+        f"Baseline: {baseline.generation_id}. Committed: {baseline.committed_at}.\n"
+        if baseline
+        else "Baseline: none (committed root).\n"
+    )
+    head = response.read_authority
+    return frame + (
+        f"Generation: {head.generation_id}. Committed: {head.committed_at}.\n"
+        "Authorization checked for this read."
+    )
+
+
+def verify_history_response(
+    raw: bytes, target: GenerationProjectionTarget, days: int | None
+) -> HistoryResponse:
+    _, identity = _target_parts(target)
+    try:
+        if days is not None and type(days) is not int:
+            raise ValueError("History days must be an integer.")
+        if type(raw) is not bytes or len(raw) > MAX_RESPONSE_BYTES:
+            raise ValueError("History response exceeds the byte limit.")
+        response = HistoryResponse.model_validate(
+            json.loads(raw.decode("utf-8"), object_pairs_hook=_unique)
+        )
+        if not response.matches(identity, days):
+            raise ValueError("History response binding differs.")
+        if response.text != response.diff + "\n\n" + _frame(response):
+            raise ValueError("History response framing differs.")
+        if (
+            response.baseline is not None
+            and response.baseline.generation_id == identity.generation_id
+            and response.baseline.committed_at != identity.committed_at
+        ):
+            raise ValueError("History head and baseline disagree.")
+        return response
+    except (ValueError, TypeError, RecursionError) as exc:
+        raise HistoryTransportError("The server history response did not verify.") from exc
+
+
+class HttpHistoryTransport:
+    """Use a caller-owned HTTP client without redirects or automatic resends."""
+
+    def __init__(self, base_url: str, client: httpx.Client) -> None:
+        self._origin = _origin(base_url)
+        self._client = client
+
+    def require_binding(self, binding: ResolvedProjectBinding, api_url: str | None = None) -> None:
+        if (
+            binding.mode != "cloud"
+            or binding.server_url is None
+            or _origin(binding.server_url) != self._origin
+        ):
+            raise HistoryTransportError("History server differs from the project binding.")
+        if api_url is not None and _origin(api_url) != self._origin:
+            raise HistoryTransportError("Projection server differs from the history server.")
+
+    def fetch(self, target: GenerationProjectionTarget, days: int | None = None) -> HistoryResponse:
+        binding, identity = _target_parts(target)
+        self.require_binding(binding)
+        if days is not None and type(days) is not int:
+            raise HistoryTransportError("History days must be an integer.")
+        credentials = read_active_credentials()
+        if credentials.user_id != identity.installed_for_user_id:
+            raise HistoryTransportError("The active account differs from the installed projection.")
+        body = {
+            "version": 1,
+            "project_id": identity.project_id,
+            "expected_user_id": identity.installed_for_user_id,
+            "expected_generation_id": identity.generation_id,
+            "expected_manifest_digest": identity.manifest_digest,
+            "expected_projection_scope_id": identity.projection_scope_id,
+            "days": days,
+        }
+        try:
+            with self._client.stream(
+                "POST",
+                self._origin + "/generations/history",
+                json=body,
+                headers={"Authorization": f"Bearer {credentials.access_token}"},
+                timeout=25,
+                follow_redirects=False,
+            ) as response:
+                if response.status_code != 200:
+                    raise HistoryTransportError("Authorized history is unavailable.")
+                raw = bytearray()
+                for chunk in response.iter_bytes():
+                    if len(raw) + len(chunk) > MAX_RESPONSE_BYTES:
+                        raise HistoryTransportError("The history response exceeds the byte limit.")
+                    raw.extend(chunk)
+        except (httpx.HTTPError, ValueError) as exc:
+            raise HistoryTransportError("Authorized history is unavailable.") from exc
+        result = verify_history_response(bytes(raw), target, days)
+        if read_active_credentials().user_id != identity.installed_for_user_id:
+            raise HistoryTransportError("The active account changed during the history read.")
+        return result

--- a/packages/nauro/tests/history_server_probe.py
+++ b/packages/nauro/tests/history_server_probe.py
@@ -1,0 +1,76 @@
+"""Emit real authenticated server history responses for paired client verification."""
+
+from __future__ import annotations
+
+import base64
+import json
+import sys
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from tests.conftest import s3_bucket
+from tests.test_generation_history_selection import LIMITS, publish_chain
+from tests.test_generation_history_service import FILES, TIMES, request_for
+from tests.test_generation_reads import USER_ID, _member, _table
+
+
+def main():
+    import jwt
+    from cryptography.hazmat.primitives.asymmetric import rsa
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from mcp_server import auth
+    from mcp_server.authz import Role
+    from mcp_server.generation_history_transport import history_router
+    from mcp_server.generation_projection import serve_projection
+
+    days, role_name, root, request_body = json.loads(sys.stdin.read())
+    with contextmanager(s3_bucket.__wrapped__)():
+        pointers = publish_chain(TIMES[:1] if root else TIMES, FILES[:1] if root else FILES)
+        pointer = pointers[-1]
+        role = Role(role_name)
+        _member(role_name)
+        _table().put_item(
+            Item={"pk": "IDENTITY#history-paired", "sk": "IDENTITY", "user_id": USER_ID}
+        )
+        key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        token = jwt.encode(
+            {
+                "sub": "history-paired",
+                "scope": "read:context",
+                "aud": auth.AUTH0_AUDIENCE,
+                "iss": f"https://{auth.AUTH0_DOMAIN}/",
+                "exp": datetime.now(timezone.utc) + timedelta(minutes=5),
+            },
+            key,
+            algorithm="RS256",
+        )
+        jwks = SimpleNamespace(
+            get_signing_key_from_jwt=lambda token: SimpleNamespace(key=key.public_key())
+        )
+        app = FastAPI()
+        app.include_router(history_router(limits=LIMITS))
+        with patch.object(auth, "get_jwks_client", return_value=jwks), TestClient(app) as client:
+            response = client.post(
+                "/generations/history",
+                json=request_for(pointer, role, days).model_dump()
+                if request_body is None
+                else request_body,
+                headers={"Authorization": f"Bearer {token}"},
+            )
+        assert response.status_code == 200, response.text
+        served = serve_projection(pointer.project_id, pointer, user_id=USER_ID, role=role)
+        print(
+            json.dumps(
+                {
+                    "identity": served.identity,
+                    "response": base64.b64encode(response.content).decode(),
+                }
+            )
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/nauro/tests/test_generation_responses.py
+++ b/packages/nauro/tests/test_generation_responses.py
@@ -175,15 +175,13 @@ def test_context_limit_keeps_authority_frame(admitted):
 
 
 def test_history_refusal_is_explicit():
-    result = responses.diff_since_last_session()
+    result = responses.diff_since_last_session(_projection().target.binding, actor=USER_ID)
     assert result.is_error is True
     assert result.envelope == {
         "store": "local",
         "error": {
             "kind": "error",
-            "reason": (
-                "Generation session history is unavailable until authorized history is supported."
-            ),
+            "reason": "Generation history requires an explicit authenticated transport.",
         },
     }
 

--- a/packages/nauro/tests/test_history_composition.py
+++ b/packages/nauro/tests/test_history_composition.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import ast
+import inspect
+from pathlib import Path
+
+import httpx
+import pytest
+
+from nauro.auth import ActiveCredentials
+from nauro.mcp import generation_responses as responses
+from nauro.mcp import read_dispatch as dispatch
+from nauro.store import generation_installation as installation
+from nauro.sync import generation_refresh as refresh
+from nauro.sync import history_transport as transport
+from tests.test_generation_installation import USER_ID
+from tests.test_generation_reads import POSIX
+from tests.test_generation_reads import admitted as admitted
+from tests.test_history_transport import OTHER, response_body
+from tests.test_read_dispatch import cloud as cloud
+from tests.test_read_dispatch import isolated_home as isolated_home
+
+
+@POSIX
+def test_response_and_dispatch_keep_authority_without_private_wire_fields(cloud, monkeypatch):
+    binding, current, _ = cloud
+    target = current[0].target
+    monkeypatch.setattr(
+        transport, "read_active_credentials", lambda: ActiveCredentials(USER_ID, "token")
+    )
+
+    def handler(request):
+        return httpx.Response(200, json=response_body(target, 7))
+
+    snapshots = binding.store_path / "snapshots"
+    snapshots.mkdir()
+    (snapshots / "001.json").write_text("POISON HISTORY")
+    before = {
+        p.relative_to(binding.store_path): p.read_bytes()
+        for p in binding.store_path.rglob("*")
+        if p.is_file()
+    }
+    monkeypatch.setattr(
+        dispatch.legacy,
+        "tool_diff_since_last_session",
+        lambda *a, **k: pytest.fail("Flat history read"),
+    )
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        adapter = transport.HttpHistoryTransport(binding.server_url, client)
+        result = responses.diff_since_last_session(binding, 7, actor=USER_ID, transport=adapter)
+        composed = dispatch.history_dispatch(adapter)
+        actual = composed(project_id=binding.project_id, days=7)
+    assert result.is_error is False
+    assert result.envelope == {
+        "store": "local",
+        "project": {"id": binding.project_id, "name": binding.project_id},
+        "diff": response_body(target, 7)["diff"],
+        "read_authority": response_body(target, 7)["read_authority"],
+        "cutoff_date_used": "2026-09-01T00:00:00+00:00",
+    }
+    assert actual.isError is False
+    assert actual.content[0].text == result.text
+    assert actual.structuredContent is None
+    assert USER_ID not in repr(result)
+    assert target.identity.projection_scope_id not in repr(result)
+    assert "POISON" not in repr(result)
+    assert {
+        p.relative_to(binding.store_path): p.read_bytes()
+        for p in binding.store_path.rglob("*")
+        if p.is_file()
+    } == before
+    assert inspect.signature(composed) == inspect.signature(dispatch.diff_since_last_session)
+
+
+@POSIX
+@pytest.mark.parametrize(
+    "fault", ["scope", "advance", "account", "pointer", "intent", "barrier", "network"]
+)
+def test_changes_during_history_discard_result(admitted, monkeypatch, fault):
+    binding, current, _ = admitted
+    target = current[0].target
+    monkeypatch.setattr(
+        transport, "read_active_credentials", lambda: ActiveCredentials(USER_ID, "token")
+    )
+
+    def handler(request):
+        if fault == "scope":
+            identity = target.identity.model_copy(update={"projection_scope_id": "b" * 64})
+            monkeypatch.setattr(
+                refresh,
+                "check_generation_projection",
+                lambda *a, **k: transport.GenerationProjectionTarget(binding, identity),
+            )
+        elif fault == "advance":
+            from tests.test_generation_refresh import _target
+
+            current[0] = _target()
+            refresh.recover_generation_refresh(binding, actor=USER_ID)
+        elif fault == "account":
+            monkeypatch.setattr(installation, "read_active_user_id", lambda: OTHER)
+        elif fault == "pointer":
+            paths = refresh.refresh_paths(binding, USER_ID)
+            paths.pointer.write_bytes(b"corrupt")
+        elif fault == "intent":
+            refresh.refresh_paths(binding, USER_ID).intent.unlink()
+        elif fault == "barrier":
+
+            def fail(*a, **k):
+                raise OSError("PRIVATE")
+
+            monkeypatch.setattr(refresh, "sync_file", fail)
+        else:
+            raise httpx.ReadError("PRIVATE")
+        return httpx.Response(200, json=response_body(target))
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        result = responses.diff_since_last_session(
+            binding,
+            actor=USER_ID,
+            transport=transport.HttpHistoryTransport(binding.server_url, client),
+        )
+    assert result.is_error is True
+    assert set(result.envelope) == {"store", "error"}
+    assert "Removed file" not in result.text
+    assert "PRIVATE" not in result.text
+
+
+@POSIX
+@pytest.mark.parametrize("fault", ["stale", "intent", "origin", "days"])
+def test_failed_admission_never_requests_or_repairs(admitted, monkeypatch, fault):
+    binding, current, _ = admitted
+    if fault == "stale":
+        identity = current[0].target.identity.model_copy(update={"generation_id": OTHER})
+        monkeypatch.setattr(
+            refresh,
+            "check_generation_projection",
+            lambda *a, **k: transport.GenerationProjectionTarget(binding, identity),
+        )
+    elif fault == "intent":
+        refresh.refresh_paths(binding, USER_ID).intent.unlink()
+    elif fault == "origin":
+        monkeypatch.setattr(responses, "resolve_api_url", lambda: "https://other.example")
+
+    def forbidden(*a, **k):
+        pytest.fail("Unexpected history request or refresh")
+
+    monkeypatch.setattr(refresh, "recover_generation_refresh", forbidden)
+    monkeypatch.setattr(refresh, "commit_generation_refresh", forbidden)
+    with httpx.Client(transport=httpx.MockTransport(forbidden)) as client:
+        result = responses.diff_since_last_session(
+            binding,
+            True if fault == "days" else None,
+            actor=USER_ID,
+            transport=transport.HttpHistoryTransport(binding.server_url, client),
+        )
+    assert result.is_error is True
+
+
+def test_history_adapter_has_only_dormant_consumers():
+    root = Path(dispatch.__file__).parents[1]
+    consumers = set()
+    for path in root.rglob("*.py"):
+        for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
+            if isinstance(node, ast.ImportFrom) and node.module == "nauro.sync.history_transport":
+                consumers.add(path.relative_to(root).as_posix())
+            if isinstance(node, ast.Import):
+                assert all(a.name != "nauro.sync.history_transport" for a in node.names)
+            if isinstance(node, ast.ImportFrom) and node.module == "nauro.sync":
+                assert all(a.name != "history_transport" for a in node.names)
+    assert consumers == {"mcp/generation_responses.py", "mcp/read_dispatch.py"}

--- a/packages/nauro/tests/test_history_paired.py
+++ b/packages/nauro/tests/test_history_paired.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import base64
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import httpx
+import pytest
+
+from nauro.auth import ActiveCredentials
+from nauro.store.generation_projection import (
+    GenerationProjectionIdentity,
+    GenerationProjectionTarget,
+)
+from nauro.store.resolution import ResolvedProjectBinding
+from nauro.sync import history_transport as transport
+
+
+@pytest.mark.parametrize(
+    "days,role,root",
+    [
+        (None, "owner", False),
+        (None, "viewer", False),
+        (None, "viewer", True),
+        (0, "viewer", True),
+        (0, "contributor", False),
+        (-1, "maintainer", False),
+        (2000, "owner", False),
+    ],
+)
+def test_installed_server_history_contract(tmp_path, monkeypatch, days, role, root):
+    python = os.environ.get("NAURO_SERVER_PYTHON")
+    if not python:
+        pytest.skip("NAURO_SERVER_PYTHON is required for the paired server check")
+    server = Path(os.environ.get("NAURO_SERVER_ROOT", str(Path(python).absolute().parents[2])))
+    script = Path(__file__).with_name("history_server_probe.py").read_text()
+    completed = subprocess.run(
+        [python, "-c", script],
+        cwd=server,
+        env={**os.environ, "AWS_DEFAULT_REGION": "us-east-1"},
+        input=json.dumps([days, role, root, None]),
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert completed.returncode == 0, completed.stderr
+    wire = json.loads(completed.stdout)
+    identity = GenerationProjectionIdentity.model_validate(wire["identity"])
+    binding = ResolvedProjectBinding(
+        tmp_path, identity.project_id, "Paired", "cloud", "https://mcp.nauro.ai"
+    )
+    target = GenerationProjectionTarget(binding, identity)
+    monkeypatch.setattr(
+        transport,
+        "read_active_credentials",
+        lambda: ActiveCredentials(identity.installed_for_user_id, "test-token"),
+    )
+    requests = []
+
+    def handler(request):
+        requests.append(json.loads(request.content))
+        sent = subprocess.run(
+            [python, "-c", script],
+            cwd=server,
+            env={**os.environ, "AWS_DEFAULT_REGION": "us-east-1"},
+            input=json.dumps([days, role, root, requests[-1]]),
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert sent.returncode == 0, sent.stderr
+        received = json.loads(sent.stdout)
+        assert received["identity"] == wire["identity"]
+        return httpx.Response(200, content=base64.b64decode(received["response"], validate=True))
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        result = transport.HttpHistoryTransport(binding.server_url, client).fetch(target, days)
+    assert len(requests) == 1
+    assert result.matches(identity, days) is True
+    if role == "viewer":
+        assert "questions-provenance.json" not in result.text
+    if root and days is None:
+        assert result.diff == "Not enough snapshots for diff."
+    elif root:
+        assert result.baseline.generation_id == identity.generation_id
+    elif days is None:
+        assert "Removed file: decisions/001-deleted.md" in result.diff
+    if days == 2000:
+        assert result.selection == "oldest_fallback"

--- a/packages/nauro/tests/test_history_transport.py
+++ b/packages/nauro/tests/test_history_transport.py
@@ -100,7 +100,7 @@ def test_exact_request_and_bound_response(target, days):
         ("cutoff_date_used", "invalid"),
         ("archive", {}),
         ("text", "forged frame"),
-        ("diff", "x" * 12001),
+        pytest.param("diff", "x" * 12001, id="oversized-diff"),
     ],
 )
 def test_malformed_or_unbound_response_is_refused(target, field, value):
@@ -153,7 +153,15 @@ def test_all_response_fields_are_required(target, field):
 
 
 @pytest.mark.parametrize(
-    "raw", [b"null", b"[]", b"NaN", b"\xff", b'{"version":1,"version":1}', b"x" * 170001]
+    "raw",
+    [
+        b"null",
+        b"[]",
+        b"NaN",
+        b"\xff",
+        b'{"version":1,"version":1}',
+        pytest.param(b"x" * 170001, id="oversized-response"),
+    ],
 )
 def test_strict_bounded_json(target, raw):
     with pytest.raises(transport.HistoryTransportError):

--- a/packages/nauro/tests/test_history_transport.py
+++ b/packages/nauro/tests/test_history_transport.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+
+import httpx
+import pytest
+
+from nauro.auth import ActiveCredentials
+from nauro.store.generation_projection import GenerationProjectionTarget
+from nauro.sync import history_transport as transport
+from tests.test_generation_installation import USER_ID, _projection
+
+OTHER = "01K44444444444444444444444"
+
+
+def response_body(target, days=None):
+    identity = target.identity
+    baseline = {"generation_id": OTHER, "committed_at": "2020-01-01T00:00:00.000000Z"}
+    diff = "  - Removed file: decisions/001-deleted.md"
+    return {
+        "version": 1,
+        "store": "remote",
+        "authenticated_user_id": USER_ID,
+        "projection_class": identity.projection_class,
+        "projection_scope_id": identity.projection_scope_id,
+        "read_authority": {
+            "kind": "generation",
+            "project_id": identity.project_id,
+            "generation_id": identity.generation_id,
+            "manifest_digest": identity.manifest_digest,
+            "committed_at": identity.committed_at,
+            "freshness": "authorized_at_read",
+        },
+        "baseline": baseline,
+        "selection": "latest_two" if days is None else "cutoff",
+        "requested_days": days,
+        "cutoff_date_used": None if days is None else "2026-09-01T00:00:00+00:00",
+        "diff": diff,
+        "text": diff + f"\n\nBaseline: {OTHER}. Committed: {baseline['committed_at']}.\n"
+        f"Generation: {identity.generation_id}. Committed: {identity.committed_at}.\n"
+        "Authorization checked for this read.",
+    }
+
+
+@pytest.fixture
+def target(monkeypatch):
+    monkeypatch.setattr(
+        transport, "read_active_credentials", lambda: ActiveCredentials(USER_ID, "synthetic-token")
+    )
+    return _projection().target
+
+
+def verify(body, target, days=None):
+    return transport.verify_history_response(json.dumps(body).encode(), target, days)
+
+
+@pytest.mark.parametrize("days", [None, 0, -1, 7])
+def test_exact_request_and_bound_response(target, days):
+    requests = []
+    body = response_body(target, days)
+
+    def handle(request):
+        requests.append(request)
+        return httpx.Response(200, json=body)
+
+    with httpx.Client(transport=httpx.MockTransport(handle)) as client:
+        result = transport.HttpHistoryTransport(target.binding.server_url, client).fetch(
+            target, days
+        )
+    assert result.model_dump() == body
+    assert len(requests) == 1
+    assert str(requests[0].url) == "https://mcp.nauro.ai/generations/history"
+    assert requests[0].headers["Authorization"] == "Bearer synthetic-token"
+    identity = target.identity
+    assert json.loads(requests[0].content) == {
+        "version": 1,
+        "project_id": identity.project_id,
+        "expected_user_id": USER_ID,
+        "expected_generation_id": identity.generation_id,
+        "expected_manifest_digest": identity.manifest_digest,
+        "expected_projection_scope_id": identity.projection_scope_id,
+        "days": days,
+    }
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("version", True),
+        ("version", 2),
+        ("store", "local"),
+        ("authenticated_user_id", OTHER),
+        ("projection_class", "viewer"),
+        ("projection_scope_id", "b" * 64),
+        ("requested_days", 1),
+        ("requested_days", True),
+        ("selection", "approximate"),
+        ("baseline", None),
+        ("cutoff_date_used", "invalid"),
+        ("archive", {}),
+        ("text", "forged frame"),
+        ("diff", "x" * 12001),
+    ],
+)
+def test_malformed_or_unbound_response_is_refused(target, field, value):
+    body = response_body(target)
+    body[field] = value
+    with pytest.raises(transport.HistoryTransportError):
+        verify(body, target)
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("project_id", OTHER),
+        ("generation_id", OTHER),
+        ("manifest_digest", "b" * 64),
+        ("committed_at", "2020-01-01T00:00:00.000000Z"),
+        ("freshness", "cached"),
+        ("kind", "legacy"),
+    ],
+)
+def test_authority_facts_must_match(target, field, value):
+    body = response_body(target)
+    body["read_authority"][field] = value
+    with pytest.raises(transport.HistoryTransportError):
+        verify(body, target)
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "version",
+        "store",
+        "authenticated_user_id",
+        "projection_class",
+        "projection_scope_id",
+        "read_authority",
+        "baseline",
+        "selection",
+        "requested_days",
+        "cutoff_date_used",
+        "diff",
+        "text",
+    ],
+)
+def test_all_response_fields_are_required(target, field):
+    body = response_body(target)
+    del body[field]
+    with pytest.raises(transport.HistoryTransportError):
+        verify(body, target)
+
+
+@pytest.mark.parametrize(
+    "raw", [b"null", b"[]", b"NaN", b"\xff", b'{"version":1,"version":1}', b"x" * 170001]
+)
+def test_strict_bounded_json(target, raw):
+    with pytest.raises(transport.HistoryTransportError):
+        transport.verify_history_response(raw, target, None)
+
+
+@pytest.mark.parametrize("status", [301, 302, 307, 308, 401, 403, 409, 429, 500, 503])
+def test_no_redirect_or_automatic_resend(target, status):
+    requests = []
+
+    def handle(request):
+        requests.append(request)
+        return httpx.Response(status, headers={"Location": "https://other.example/history"})
+
+    with httpx.Client(transport=httpx.MockTransport(handle), follow_redirects=True) as client:
+        with pytest.raises(transport.HistoryTransportError):
+            transport.HttpHistoryTransport(target.binding.server_url, client).fetch(target)
+    assert len(requests) == 1
+
+
+@pytest.mark.parametrize("fault", ["read", "timeout", "overflow", "account"])
+def test_failed_or_interrupted_response_never_escapes(target, monkeypatch, fault):
+    calls = []
+
+    def handle(request):
+        calls.append(request)
+        if fault == "read":
+            raise httpx.ReadError("PRIVATE")
+        if fault == "timeout":
+            raise httpx.ReadTimeout("PRIVATE")
+        if fault == "overflow":
+            return httpx.Response(200, content=b"x" * 170001)
+        monkeypatch.setattr(
+            transport, "read_active_credentials", lambda: ActiveCredentials(OTHER, "other-token")
+        )
+        return httpx.Response(200, json=response_body(target))
+
+    with httpx.Client(transport=httpx.MockTransport(handle)) as client:
+        with pytest.raises(transport.HistoryTransportError) as caught:
+            transport.HttpHistoryTransport(target.binding.server_url, client).fetch(target)
+    assert "PRIVATE" not in str(caught.value)
+    assert len(calls) == 1
+
+
+@pytest.mark.parametrize("fault", ["actor", "binding", "days"])
+def test_local_mismatch_precedes_any_request(target, monkeypatch, fault):
+    if fault == "actor":
+        monkeypatch.setattr(
+            transport, "read_active_credentials", lambda: ActiveCredentials(OTHER, "other-token")
+        )
+    elif fault == "binding":
+        target = GenerationProjectionTarget(
+            replace(target.binding, server_url="https://other.example"), target.identity
+        )
+    with httpx.Client(
+        transport=httpx.MockTransport(lambda request: pytest.fail("Unexpected request"))
+    ) as client:
+        with pytest.raises(transport.HistoryTransportError):
+            transport.HttpHistoryTransport("https://mcp.nauro.ai", client).fetch(
+                target, True if fault == "days" else None
+            )
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://mcp.nauro.ai",
+        "https://user:pass@mcp.nauro.ai",
+        "https://mcp.nauro.ai/x",
+        "https://mcp.nauro.ai?x=1",
+        "https://mcp.nauro.ai#x",
+    ],
+)
+def test_origin_is_exact_https(url):
+    with httpx.Client() as client:
+        with pytest.raises(transport.HistoryTransportError):
+            transport.HttpHistoryTransport(url, client)
+
+
+@pytest.mark.parametrize("days", [True, "1", 1.0])
+def test_verifier_rejects_coerced_request_days(target, days):
+    with pytest.raises(transport.HistoryTransportError):
+        verify(response_body(target, 1), target, days)

--- a/packages/nauro/tests/test_read_dispatch.py
+++ b/packages/nauro/tests/test_read_dispatch.py
@@ -172,7 +172,7 @@ def test_generation_history_never_reads_flat_snapshots(cloud, monkeypatch):
     binding, _, _ = cloud
     monkeypatch.setattr(dispatch.legacy, "tool_diff_since_last_session", forbidden)
     result = dispatch.diff_since_last_session(project_id=binding.project_id)
-    assert result == dispatch._prepared(generation.diff_since_last_session())
+    assert result == dispatch._prepared(generation.diff_since_last_session(binding, actor=USER_ID))
     assert result.isError is True
 
 


### PR DESCRIPTION
## Why

Local generation reads need an authenticated history result. Retained roots and old flat snapshots cannot establish currently authorized committed history. Depends on the server history service merged in Nauro-AI/mcp-server#189 and its inventory correction in Nauro-AI/mcp-server#190.

Use the server's versioned history service and verify its response against the active account, project binding and installed projection. Admit the local generation before the request and again before disclosure so account, scope, head or durability changes discard the result.

## What changed

Add a bounded HTTPS history adapter, strict response verification and dormant response/dispatch composition. Preserve the public diff arguments and existing local result fields. Refuse redirects, malformed responses and stale heads without an automatic resend or refresh.

## Risk / what to review

Review origin and identity binding, required response fields, baseline/head framing and final admission together. The explicit dispatcher factory preserves the tool signature. Production registration remains unchanged.

## Deferred

Concurrent writing remains incomplete. Live history registration, remaining hosted dispatch composition, production limits, hosted timing and Windows durability remain open. History does not reconstruct content omitted from archived snapshots. Production activation is unchanged.

## Test plan

452 affected tests passed on Python 3.12 and all 87 new history tests passed on Python 3.10, with seven paired server checks enabled and zero skips. Four retained server-to-client checks passed explicitly. Full lint/formatting, 23-file typing, consumer contracts and unchanged risk/docstring guards passed. The paired bridge uses a real server route with synthetic storage and local signing keys; it is not deployed transport or latency proof.

The first Windows run exposed a pytest test-ID length limit. Large cases now use short IDs with unchanged inputs and assertions. All 67 transport tests pass locally after that correction.

All 17 CI jobs passed on the final candidate, including Windows generation control and the full Python 3.10 through 3.14 suites.
