### PR TITLE
Add dormant question submission and receipt recovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,10 @@ jobs:
           packages/nauro/src/nauro/store/state_records.py
           packages/nauro/src/nauro/sync/state_submission.py
           packages/nauro/src/nauro/sync/state_transport.py
+          packages/nauro/src/nauro/store/question_contract.py
+          packages/nauro/src/nauro/store/question_records.py
+          packages/nauro/src/nauro/sync/question_submission.py
+          packages/nauro/src/nauro/sync/question_transport.py
           packages/nauro/src/nauro/sync/judgment_submission.py
           packages/nauro/src/nauro/sync/history_contract.py
           packages/nauro/src/nauro/sync/history_transport.py

--- a/packages/nauro/src/nauro/store/question_contract.py
+++ b/packages/nauro/src/nauro/store/question_contract.py
@@ -1,0 +1,329 @@
+"""Strict question payloads and authenticated receipt evidence."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Literal
+
+from nauro_core.constants import MAX_CONTEXT_LENGTH, MAX_QUESTION_LENGTH, POINTER_FLAG_PREFIXES
+from nauro_core.identifiers import IdentifierKind, validate_identifier
+from nauro_core.provenance import validate_utc_timestamp
+from nauro_core.questions import (
+    InvalidQuestionIdentifier,
+    format_question_id,
+    parse_question_id,
+    validate_legacy_question_id,
+    validate_question_id,
+)
+from nauro_core.validation import envelope_token_message
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    StrictInt,
+    StrictStr,
+    TypeAdapter,
+    field_validator,
+)
+
+from nauro.store.submission_records import Digest, SubmissionRecordError
+
+
+class QuestionTransportError(SubmissionRecordError):
+    """The question response did not establish bound evidence."""
+
+
+class ClosedModel(BaseModel):
+    model_config = ConfigDict(
+        frozen=True,
+        extra="forbid",
+        strict=True,
+        revalidate_instances="always",
+        hide_input_in_errors=True,
+    )
+
+
+def _target(value: str) -> str:
+    try:
+        return format_question_id(parse_question_id(value))
+    except InvalidQuestionIdentifier:
+        return validate_legacy_question_id(value)
+
+
+class QuestionScope(ClosedModel):
+    project_id: StrictStr
+    user_id: StrictStr
+    operation_kind: Literal["flag_question"] = "flag_question"
+    operation_id: StrictStr
+
+    @field_validator("project_id", "user_id")
+    @classmethod
+    def _ulid(cls, value: str) -> str:
+        return validate_identifier(IdentifierKind.ulid, value, field="question_scope")
+
+    @field_validator("operation_id")
+    @classmethod
+    def _operation(cls, value: str) -> str:
+        return validate_identifier(IdentifierKind.operation_id, value, field="operation_id")
+
+
+class AppendPayload(ClosedModel):
+    question: StrictStr
+    context: StrictStr | None
+    targets: tuple[StrictStr, ...]
+
+    @field_validator("question")
+    @classmethod
+    def _question(cls, value: str) -> str:
+        if not value.strip() or len(value) > MAX_QUESTION_LENGTH:
+            raise ValueError("invalid question length")
+        if value.lstrip().startswith(POINTER_FLAG_PREFIXES):
+            raise ValueError("discovery pointers require share_context")
+        return _line(value, "question")
+
+    @field_validator("context")
+    @classmethod
+    def _context(cls, value: str | None) -> str | None:
+        if value is not None:
+            if len(value) > MAX_CONTEXT_LENGTH:
+                raise ValueError("invalid context length")
+            _line(value, "context")
+        return value
+
+
+def _line(value: str, field: str) -> str:
+    if "\n" in value or "\r" in value or envelope_token_message(value, field) is not None:
+        raise ValueError("invalid question line")
+    return value
+
+
+class ResolutionPayload(ClosedModel):
+    action: Literal["resolve"]
+    resolved_by: StrictStr
+    targets: tuple[StrictStr, ...] = Field(max_length=64)
+
+
+QuestionPayload = AppendPayload | ResolutionPayload
+_PAYLOAD: TypeAdapter[QuestionPayload] = TypeAdapter(QuestionPayload)
+
+
+def _canonical(payload: QuestionPayload) -> bytes:
+    data = payload.model_dump(mode="json")
+    data["targets"] = [_target(value) for value in payload.targets]
+    raw = (
+        json.dumps(data, sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False)
+        + "\n"
+    ).encode("utf-8")
+    if isinstance(payload, ResolutionPayload) and len(raw) > 16_384:
+        raise ValueError("resolution payload exceeds byte limit")
+    return raw
+
+
+def question_payload(
+    question: str, context: str | None = None, targets: tuple[str, ...] = ()
+) -> bytes:
+    return _canonical(AppendPayload(question=question, context=context, targets=targets))
+
+
+def resolution_payload(targets: tuple[str, ...], resolved_by: str) -> bytes:
+    return _canonical(ResolutionPayload(action="resolve", targets=targets, resolved_by=resolved_by))
+
+
+def read_question_payload(raw: str) -> QuestionPayload:
+    payload = _PAYLOAD.validate_json(raw, strict=True)
+    if _canonical(payload) != raw.encode("utf-8"):
+        raise ValueError("question payload is not canonical")
+    return payload
+
+
+class _Response(ClosedModel):
+    version: StrictInt = Field(ge=1, le=1)
+    scope: QuestionScope
+    payload_digest: Digest
+    action: Literal["append", "resolve"]
+
+    @field_validator("unresolved", mode="before", check_fields=False)
+    @classmethod
+    def _boolean(cls, value: object) -> object:
+        if type(value) is not bool:
+            raise ValueError("unresolved must be a boolean")
+        return value
+
+
+class ResolutionDiagnostics(ClosedModel):
+    requested_question_ids: tuple[StrictStr, ...]
+    resolved_question_ids: tuple[StrictStr, ...]
+    resolved_by: StrictStr
+    relocated_ids: tuple[StrictStr, ...]
+    skipped_prose_ids: tuple[StrictStr, ...]
+
+    @field_validator(
+        "requested_question_ids", "resolved_question_ids", "relocated_ids", "skipped_prose_ids"
+    )
+    @classmethod
+    def _ids(cls, values: tuple[str, ...]) -> tuple[str, ...]:
+        if any(_target(value) != value for value in values):
+            raise ValueError("diagnostic identifier is not canonical")
+        return values
+
+
+class QuestionCommitted(_Response):
+    action: Literal["append"]
+    status: Literal["committed"]
+    unresolved: Literal[False]
+    receipt_json: StrictStr
+
+
+class ResolutionCommitted(_Response):
+    action: Literal["resolve"]
+    status: Literal["committed"]
+    unresolved: Literal[False]
+    receipt_json: StrictStr
+    diagnostics: ResolutionDiagnostics
+
+
+class QuestionAbsent(_Response):
+    status: Literal["absent"]
+    unresolved: Literal[True]
+
+
+class QuestionNoChange(_Response):
+    action: Literal["resolve"]
+    status: Literal["no_change_observed"]
+    unresolved: Literal[True]
+    diagnostics: ResolutionDiagnostics
+
+
+class QuestionUnavailable(_Response):
+    status: Literal["expired", "digest_conflict"]
+    unresolved: Literal[False]
+
+
+QuestionResult = (
+    QuestionCommitted
+    | ResolutionCommitted
+    | QuestionAbsent
+    | QuestionNoChange
+    | QuestionUnavailable
+)
+_RESPONSE: TypeAdapter[QuestionResult] = TypeAdapter(QuestionResult)
+
+
+class _SnapshotDetails(ClosedModel):
+    snapshot_key: StrictStr
+    snapshot_digest: Digest
+
+
+class _AppendDetails(_SnapshotDetails):
+    question_event_id: StrictStr
+    question_created_at: StrictStr
+
+
+class _ResolutionDetails(_SnapshotDetails):
+    resolution_row_digest: Digest
+
+
+class _Receipt(ClosedModel):
+    receipt_id: StrictStr
+    operation_kind: Literal["flag_question"]
+    operation_id: StrictStr
+    result: Literal["committed", "resolved"]
+    committed_at: StrictStr
+    artifact_digest: Digest
+    generation_id: StrictStr
+    target_kind: Literal["question", "question_resolution"]
+    target_id: StrictStr
+    details: _AppendDetails | _ResolutionDetails
+
+    @field_validator("receipt_id", "generation_id")
+    @classmethod
+    def _ulid(cls, value: str) -> str:
+        return validate_identifier(IdentifierKind.ulid, value, field="question_receipt")
+
+    @field_validator("committed_at")
+    @classmethod
+    def _timestamp(cls, value: str) -> str:
+        return validate_utc_timestamp(value, field="committed_at")
+
+
+def _verify_receipt(raw: str, scope: QuestionScope, payload: QuestionPayload) -> None:
+    limit = 8192 if isinstance(payload, AppendPayload) else 782
+    if len(raw.encode("utf-8")) > limit:
+        raise ValueError("question receipt exceeds byte limit")
+    receipt = _Receipt.model_validate_json(raw, strict=True)
+    canonical = json.dumps(
+        receipt.model_dump(mode="json"), sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    )
+    if raw != canonical or receipt.operation_id != scope.operation_id:
+        raise ValueError("receipt bytes or identity differ")
+    if (
+        receipt.details.snapshot_key
+        != f"generations/{scope.project_id}/{receipt.generation_id}/snapshot.json"
+    ):
+        raise ValueError("receipt snapshot differs")
+    if isinstance(payload, AppendPayload):
+        if (
+            receipt.result != "committed"
+            or receipt.target_kind != "question"
+            or not isinstance(receipt.details, _AppendDetails)
+        ):
+            raise ValueError("append receipt shape differs")
+        validate_question_id(receipt.target_id)
+        validate_identifier(
+            IdentifierKind.ulid, receipt.details.question_event_id, field="question_event_id"
+        )
+        if receipt.details.question_created_at != receipt.committed_at:
+            raise ValueError("question timestamp differs")
+    elif (
+        receipt.result != "resolved"
+        or receipt.target_kind != "question_resolution"
+        or not isinstance(receipt.details, _ResolutionDetails)
+    ):
+        raise ValueError("resolution receipt shape differs")
+    else:
+        validate_identifier(IdentifierKind.ulid, receipt.target_id, field="resolution_event_id")
+
+
+def _unique_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result = dict(pairs)
+    if len(result) != len(pairs):
+        raise ValueError("duplicate JSON key")
+    return result
+
+
+def verify_question_response(
+    raw: bytes, scope: QuestionScope, payload_json: str, *, lookup: bool = False
+) -> QuestionResult:
+    try:
+        scope = QuestionScope.model_validate(scope)
+        payload = read_question_payload(payload_json)
+        if len(raw) > 64 * 1024:
+            raise ValueError("response exceeds byte limit")
+        json.loads(raw.decode("utf-8"), object_pairs_hook=_unique_object)
+        result = _RESPONSE.validate_json(raw, strict=True)
+        action = "append" if isinstance(payload, AppendPayload) else "resolve"
+        if (
+            result.scope != scope
+            or result.payload_digest != hashlib.sha256(payload_json.encode()).hexdigest()
+            or result.action != action
+        ):
+            raise ValueError("question response binding differs")
+        if isinstance(result, (ResolutionCommitted, QuestionNoChange)):
+            if (
+                not isinstance(payload, ResolutionPayload)
+                or result.diagnostics.resolved_by != payload.resolved_by
+            ):
+                raise ValueError("resolution diagnostics differ from request")
+        if isinstance(result, QuestionNoChange):
+            if (
+                lookup
+                or result.diagnostics.resolved_question_ids
+                or result.diagnostics.relocated_ids
+            ):
+                raise ValueError("invalid no-change observation")
+        if isinstance(result, (QuestionCommitted, ResolutionCommitted)):
+            _verify_receipt(result.receipt_json, scope, payload)
+        return result
+    except (ValueError, TypeError, RecursionError) as exc:
+        raise QuestionTransportError("The question response did not verify.") from exc

--- a/packages/nauro/src/nauro/store/question_records.py
+++ b/packages/nauro/src/nauro/store/question_records.py
@@ -1,0 +1,229 @@
+"""Private durable question identities with recoverable no-write observations."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import stat
+import tempfile
+import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Literal
+
+from filelock import BaseFileLock, FileLock, UnixFileLock, WindowsFileLock
+from nauro_core.identifiers import IdentifierKind, validate_identifier
+from nauro_core.provenance import validate_utc_timestamp
+from pydantic import Field, StrictInt, StrictStr, ValidationError, field_validator, model_validator
+
+from nauro.store.home import nauro_home
+from nauro.store.question_contract import (
+    ClosedModel,
+    QuestionResult,
+    QuestionScope,
+    read_question_payload,
+    verify_question_response,
+)
+from nauro.store.submission_records import (
+    SUBMISSION_RECORDS_DIR,
+    Digest,
+    SubmissionRecordCorruptError,
+    SubmissionRecordError,
+    _directory_sync,
+    _ensure_directory,
+    require_submission_actor,
+)
+
+_MAX_BYTES = 2 * 1024 * 1024
+
+
+class QuestionSubmission(ClosedModel):
+    schema_version: StrictInt = Field(default=1, ge=1, le=1)
+    scope: QuestionScope
+    created_at: StrictStr
+    payload_json: StrictStr
+    payload_digest: Digest
+    phase: Literal["prepared", "uncertain", "resolved"]
+    result: QuestionResult | None = None
+
+    @field_validator("created_at")
+    @classmethod
+    def _timestamp(cls, value: str) -> str:
+        return validate_utc_timestamp(value, field="created_at")
+
+    @model_validator(mode="after")
+    def _bindings(self) -> QuestionSubmission:
+        read_question_payload(self.payload_json)
+        if hashlib.sha256(self.payload_json.encode("utf-8")).hexdigest() != self.payload_digest:
+            raise ValueError("question payload digest differs")
+        if self.result is not None:
+            verify_question_response(
+                self.result.model_dump_json().encode(), self.scope, self.payload_json
+            )
+        terminal = self.result is not None and not self.result.unresolved
+        if (self.phase == "resolved") != terminal:
+            raise ValueError("question phase and result disagree")
+        if self.phase == "prepared" and self.result is not None:
+            raise ValueError("prepared question cannot contain a response")
+        return self
+
+
+class _Stored(ClosedModel):
+    record: QuestionSubmission
+    digest: Digest
+
+    @model_validator(mode="after")
+    def _integrity(self) -> _Stored:
+        if hashlib.sha256(self.record.model_dump_json().encode()).hexdigest() != self.digest:
+            raise ValueError("question record checksum differs")
+        return self
+
+
+def _directory(project_id: str, user_id: str) -> Path:
+    validate_identifier(IdentifierKind.ulid, project_id, field="project_id")
+    validate_identifier(IdentifierKind.ulid, user_id, field="user_id")
+    return nauro_home() / SUBMISSION_RECORDS_DIR / "question" / project_id / user_id
+
+
+def _record_path(scope: QuestionScope) -> Path:
+    scope = QuestionScope.model_validate(scope)
+    key = hashlib.sha256(scope.model_dump_json().encode()).hexdigest()
+    return _directory(scope.project_id, scope.user_id) / f"{key}.json"
+
+
+def _read(path: Path) -> QuestionSubmission | None:
+    try:
+        fd = os.open(
+            path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+        )
+    except FileNotFoundError:
+        return None
+    try:
+        with os.fdopen(fd, "rb") as handle:
+            if not stat.S_ISREG(os.fstat(handle.fileno()).st_mode):
+                raise SubmissionRecordCorruptError("The question record is not a regular file.")
+            raw = handle.read(_MAX_BYTES + 1)
+        if len(raw) > _MAX_BYTES:
+            raise SubmissionRecordCorruptError("The question record exceeds its size limit.")
+        stored = _Stored.model_validate_json(raw, strict=True)
+        if stored.model_dump_json().encode() != raw:
+            raise SubmissionRecordCorruptError("The question record encoding differs.")
+        return stored.record
+    except (ValidationError, UnicodeError, SubmissionRecordError) as exc:
+        raise SubmissionRecordCorruptError("The question record did not verify.") from exc
+
+
+def read_question_submission(scope: QuestionScope) -> QuestionSubmission | None:
+    require_submission_actor(scope.user_id)
+    record = _read(_record_path(scope))
+    if record is not None and record.scope != scope:
+        raise SubmissionRecordCorruptError("The question record belongs to another scope.")
+    require_submission_actor(scope.user_id)
+    return record
+
+
+def list_question_submissions(project_id: str, user_id: str) -> tuple[QuestionSubmission, ...]:
+    require_submission_actor(user_id)
+    try:
+        entries = os.scandir(_directory(project_id, user_id))
+    except FileNotFoundError:
+        return ()
+    records = []
+    with entries:
+        for entry in entries:
+            if entry.name.endswith(".json"):
+                record = _read(Path(entry.path))
+                if (
+                    record is None
+                    or record.scope.project_id != project_id
+                    or record.scope.user_id != user_id
+                    or _record_path(record.scope) != Path(entry.path)
+                ):
+                    raise SubmissionRecordCorruptError(
+                        "The question record path differs from its scope."
+                    )
+                records.append(record)
+    require_submission_actor(user_id)
+    return tuple(sorted(records, key=lambda record: (record.created_at, record.scope.operation_id)))
+
+
+@contextmanager
+def question_submission_lock(scope: QuestionScope) -> Iterator[None]:
+    require_submission_actor(scope.user_id)
+    path = _record_path(scope)
+    _ensure_directory(path.parent)
+    lock: BaseFileLock = FileLock(str(path.with_suffix(".lock")), timeout=0, mode=0o600)
+    if type(lock) not in (UnixFileLock, WindowsFileLock):
+        raise SubmissionRecordError("Native question submission locking is unavailable.")
+    with lock:
+        if type(lock) not in (UnixFileLock, WindowsFileLock):
+            raise SubmissionRecordError("Native question submission locking is unavailable.")
+        _directory_sync(path.parent)
+        require_submission_actor(scope.user_id)
+        yield
+
+
+def _write(record: QuestionSubmission) -> None:
+    path = _record_path(record.scope)
+    stored = _Stored(
+        record=record, digest=hashlib.sha256(record.model_dump_json().encode()).hexdigest()
+    )
+    encoded = stored.model_dump_json().encode()
+    if len(encoded) > _MAX_BYTES:
+        raise SubmissionRecordError("The question record exceeds its size limit.")
+    fd, name = tempfile.mkstemp(prefix=".question-submission-", dir=path.parent)
+    temporary = Path(name)
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(encoded)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+        _directory_sync(path.parent)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def prepare_question_submission(
+    project_id: str, user_id: str, payload: bytes
+) -> QuestionSubmission:
+    require_submission_actor(user_id)
+    record = QuestionSubmission(
+        scope=QuestionScope(project_id=project_id, user_id=user_id, operation_id=uuid.uuid4().hex),
+        created_at=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+        payload_json=payload.decode("utf-8"),
+        payload_digest=hashlib.sha256(payload).hexdigest(),
+        phase="prepared",
+    )
+    with question_submission_lock(record.scope):
+        if read_question_submission(record.scope) is not None:
+            raise SubmissionRecordError("The generated question identity already exists.")
+        _write(record)
+        require_submission_actor(user_id)
+    return record
+
+
+def mark_question_uncertain(record: QuestionSubmission) -> QuestionSubmission:
+    if record.phase == "resolved" or read_question_submission(record.scope) != record:
+        raise SubmissionRecordError("The saved question submission cannot make this transition.")
+    updated = QuestionSubmission.model_validate({**record.model_dump(), "phase": "uncertain"})
+    _write(updated)
+    return updated
+
+
+def record_question_result(
+    record: QuestionSubmission, result: QuestionResult
+) -> QuestionSubmission:
+    if record.phase == "resolved" or read_question_submission(record.scope) != record:
+        raise SubmissionRecordError("The saved question submission cannot make this transition.")
+    updated = QuestionSubmission.model_validate(
+        {
+            **record.model_dump(),
+            "phase": "uncertain" if result.unresolved else "resolved",
+            "result": result,
+        }
+    )
+    _write(updated)
+    return updated

--- a/packages/nauro/src/nauro/sync/question_submission.py
+++ b/packages/nauro/src/nauro/sync/question_submission.py
@@ -1,0 +1,104 @@
+"""Explicit question submission and lookup-only recovery."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Protocol
+
+from nauro.store.question_contract import (
+    QuestionResult,
+    QuestionScope,
+    QuestionTransportError,
+    verify_question_response,
+)
+from nauro.store.question_records import (
+    QuestionSubmission,
+    mark_question_uncertain,
+    question_submission_lock,
+    read_question_submission,
+    record_question_result,
+)
+from nauro.store.submission_records import SubmissionRecordError, require_submission_actor
+
+
+class QuestionRecoveryRequiredError(SubmissionRecordError):
+    """The original question operation requires lookup before another send."""
+
+
+class QuestionRetryExpiredError(SubmissionRecordError):
+    """The original question operation is outside its resend horizon."""
+
+
+class QuestionTransport(Protocol):
+    def submit(self, record: QuestionSubmission) -> QuestionResult: ...
+
+    def lookup(self, record: QuestionSubmission) -> QuestionResult: ...
+
+
+def _load(scope: QuestionScope) -> QuestionSubmission:
+    record = read_question_submission(scope)
+    if record is None:
+        raise SubmissionRecordError("The saved question submission is missing.")
+    return record
+
+
+def _require_window(record: QuestionSubmission) -> None:
+    created = datetime.fromisoformat(record.created_at.replace("Z", "+00:00"))
+    elapsed = datetime.now(timezone.utc) - created
+    if not timedelta(0) <= elapsed <= timedelta(hours=24):
+        raise QuestionRetryExpiredError("The question submission is outside the resend horizon.")
+
+
+def _accept(record: QuestionSubmission, result: QuestionResult, *, lookup: bool) -> QuestionResult:
+    result = verify_question_response(
+        result.model_dump_json().encode(), record.scope, record.payload_json, lookup=lookup
+    )
+    require_submission_actor(record.scope.user_id)
+    record_question_result(record, result)
+    require_submission_actor(record.scope.user_id)
+    return result
+
+
+def _send(record: QuestionSubmission, transport: QuestionTransport) -> QuestionResult:
+    _require_window(record)
+    uncertain = mark_question_uncertain(record)
+    require_submission_actor(record.scope.user_id)
+    _require_window(uncertain)
+    result = transport.submit(uncertain)
+    if result.status == "absent":
+        raise QuestionTransportError("A question send cannot return an absent lookup result.")
+    return _accept(uncertain, result, lookup=False)
+
+
+def submit_question(scope: QuestionScope, transport: QuestionTransport) -> QuestionResult:
+    require_submission_actor(scope.user_id)
+    with question_submission_lock(scope):
+        record = _load(scope)
+        if record.result is not None and not record.result.unresolved:
+            return record.result
+        if record.phase != "prepared":
+            raise QuestionRecoveryRequiredError(
+                "Look up the original question operation before retrying."
+            )
+        return _send(record, transport)
+
+
+def recover_question(scope: QuestionScope, transport: QuestionTransport) -> QuestionResult:
+    require_submission_actor(scope.user_id)
+    with question_submission_lock(scope):
+        record = _load(scope)
+        if record.result is not None and not record.result.unresolved:
+            return record.result
+        return _accept(record, transport.lookup(record), lookup=True)
+
+
+def retry_question(scope: QuestionScope, transport: QuestionTransport) -> QuestionResult:
+    require_submission_actor(scope.user_id)
+    with question_submission_lock(scope):
+        record = _load(scope)
+        if record.result is not None and not record.result.unresolved:
+            return record.result
+        result = _accept(record, transport.lookup(record), lookup=True)
+        if result.status != "absent":
+            return result
+        return _send(_load(scope), transport)

--- a/packages/nauro/src/nauro/sync/question_transport.py
+++ b/packages/nauro/src/nauro/sync/question_transport.py
@@ -1,0 +1,79 @@
+"""Dormant HTTPS adapter for original question payloads and verified receipts."""
+
+from __future__ import annotations
+
+import httpx
+
+from nauro.auth import read_active_credentials
+from nauro.store.question_contract import (
+    QuestionResult,
+    QuestionTransportError,
+    verify_question_response,
+)
+from nauro.store.question_records import QuestionSubmission
+from nauro.store.submission_records import SubmissionActorMismatchError, require_submission_actor
+
+
+class HttpQuestionTransport:
+    def __init__(self, base_url: str, client: httpx.Client) -> None:
+        url = httpx.URL(base_url)
+        if (
+            url.scheme != "https"
+            or not url.host
+            or url.userinfo
+            or url.query
+            or url.fragment
+            or url.path not in {"", "/"}
+        ):
+            raise QuestionTransportError("Question transport requires a trusted HTTPS origin.")
+        self._base_url = str(url).rstrip("/")
+        self._client = client
+
+    def _request(self, record: QuestionSubmission, *, lookup: bool) -> QuestionResult:
+        record = QuestionSubmission.model_validate(record)
+        credentials = read_active_credentials()
+        if credentials.user_id != record.scope.user_id:
+            raise SubmissionActorMismatchError(
+                "The active account does not own this question submission."
+            )
+        body = {
+            "version": 1,
+            "project_id": record.scope.project_id,
+            "expected_user_id": record.scope.user_id,
+            "operation_id": record.scope.operation_id,
+            "payload_digest": record.payload_digest,
+            "payload_json": record.payload_json,
+        }
+        route = "/questions/lookup" if lookup else "/questions/submit"
+        try:
+            with self._client.stream(
+                "POST",
+                self._base_url + route,
+                json=body,
+                headers={"Authorization": f"Bearer {credentials.access_token}"},
+                timeout=25,
+                follow_redirects=False,
+            ) as response:
+                if response.status_code != 200:
+                    raise QuestionTransportError("The server did not return a question result.")
+                raw = bytearray()
+                for chunk in response.iter_bytes():
+                    raw.extend(chunk)
+                    if len(raw) > 64 * 1024:
+                        raise QuestionTransportError(
+                            "The question response exceeds its byte limit."
+                        )
+        except httpx.HTTPError as exc:
+            raise QuestionTransportError(
+                "The question outcome is unresolved. Look up its original identity."
+            ) from exc
+        require_submission_actor(record.scope.user_id)
+        return verify_question_response(
+            bytes(raw), record.scope, record.payload_json, lookup=lookup
+        )
+
+    def submit(self, record: QuestionSubmission) -> QuestionResult:
+        return self._request(record, lookup=False)
+
+    def lookup(self, record: QuestionSubmission) -> QuestionResult:
+        return self._request(record, lookup=True)

--- a/packages/nauro/tests/fixtures/question_transport_server.py
+++ b/packages/nauro/tests/fixtures/question_transport_server.py
@@ -1,0 +1,153 @@
+"""Real TLS and process restart against the paired dormant question server."""
+
+import json
+import os
+import socket
+import subprocess
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+from tests.test_authenticated_client_recovery import _tls_context
+from tests.test_judgment_staging import _object_inventory, _scan_table
+from tests.test_question_transport import USER_ID, _body, transport
+
+from tests.conftest import TEST_PROJECT_ID
+
+__all__ = ["transport"]
+
+_CLIENT = """
+import json, os, ssl, sys
+import httpx
+from nauro.store.question_contract import (
+    QuestionTransportError, question_payload, resolution_payload
+)
+from nauro.store.question_records import prepare_question_submission, list_question_submissions
+from nauro.sync.question_transport import HttpQuestionTransport
+from nauro.sync.question_submission import submit_question, recover_question, retry_question
+endpoint, certificate, project, user, action, mode = sys.argv[1:]
+with httpx.Client(verify=ssl.create_default_context(cafile=certificate), trust_env=False) as client:
+    transport=HttpQuestionTransport(endpoint,client)
+    if mode == 'send':
+        payload=(question_payload('Frozen question?') if action == 'append'
+                 else resolution_payload(('Q1',),'D42'))
+        record=prepare_question_submission(project,user,payload)
+        try:
+            result=submit_question(record.scope,transport)
+        except QuestionTransportError:
+            os._exit(17)
+    else:
+        record,=list_question_submissions(project,user)
+        result=(retry_question if mode == 'retry' else recover_question)(record.scope,transport)
+    print(result.model_dump_json())
+"""
+
+
+@pytest.mark.parametrize(
+    "scenario", ["append_drop", "resolve_drop", "no_change_drop", "no_change_saved"]
+)
+def test_question_client_restart_over_tls(transport, s3_bucket, tmp_path, scenario):
+    context, certificate = _tls_context(transport.key, tmp_path)
+    calls, receipts, failures = [], [], []
+    observation = scenario.startswith("no_change")
+    if observation:
+        first = transport.client.post(
+            "/questions/submit",
+            json=_body("resolve", operation_id="previous-resolution"),
+            headers={"Authorization": f"Bearer {transport.token}"},
+        )
+        assert first.status_code == 200, first.text
+
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, *_args):
+            pass
+
+        def do_POST(self):
+            try:
+                body = self.rfile.read(int(self.headers["Content-Length"]))
+                calls.append((self.path, json.loads(body)))
+                response = transport.client.post(
+                    self.path,
+                    content=body,
+                    headers={"Authorization": self.headers["Authorization"]},
+                )
+                assert response.status_code == 200, response.text
+                if response.json()["status"] == "committed":
+                    receipts.append(response.json()["receipt_json"])
+                if len(calls) == 1 and scenario.endswith("drop"):
+                    self.connection.shutdown(socket.SHUT_RDWR)
+                    self.connection.close()
+                    return
+                self.send_response(200)
+                self.send_header("Content-Length", str(len(response.content)))
+                self.end_headers()
+                self.wfile.write(response.content)
+            except Exception as exc:
+                failures.append(f"{type(exc).__name__}: {exc}")
+                self.send_error(500)
+
+    home = tmp_path / "question-client-home"
+    home.mkdir()
+    (home / "config.json").write_text(
+        json.dumps({"auth": {"user_id": USER_ID, "access_token": transport.token}})
+    )
+    env = {key: value for key, value in os.environ.items() if key != "PYTHONPATH"}
+    env["NAURO_HOME"] = str(home)
+    with HTTPServer(("127.0.0.1", 0), Handler) as server:
+        server.socket = context.wrap_socket(server.socket, server_side=True)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        command = [
+            os.environ["NAURO_CLIENT_PYTHON"],
+            "-c",
+            _CLIENT,
+            f"https://localhost:{server.server_port}",
+            str(certificate),
+            TEST_PROJECT_ID,
+            USER_ID,
+            "append" if scenario.startswith("append") else "resolve",
+        ]
+
+        def invoke(mode):
+            result = subprocess.run(command + [mode], env=env, capture_output=True, timeout=30)
+            assert failures == []
+            return result
+
+        try:
+            sent = invoke("send")
+            assert sent.returncode == (17 if scenario.endswith("drop") else 0), sent.stderr.decode()
+            if not scenario.endswith("drop"):
+                assert json.loads(sent.stdout)["status"] == "no_change_observed"
+            rows = _scan_table()
+            objects = _object_inventory(s3_bucket, f"generations/{TEST_PROJECT_ID}/")
+            recovered = invoke("recover")
+            assert recovered.returncode == 0, recovered.stderr.decode()
+            assert [path for path, _ in calls] == ["/questions/submit", "/questions/lookup"]
+            assert _scan_table() == rows
+            assert _object_inventory(s3_bucket, f"generations/{TEST_PROJECT_ID}/") == objects
+            if observation:
+                assert json.loads(recovered.stdout)["status"] == "absent"
+                assert json.loads(recovered.stdout)["unresolved"] is True
+                retry = invoke("retry")
+                assert retry.returncode == 0, retry.stderr.decode()
+                assert json.loads(retry.stdout)["status"] == "no_change_observed"
+                assert json.loads(retry.stdout)["unresolved"] is True
+                assert [path for path, _ in calls] == [
+                    "/questions/submit",
+                    "/questions/lookup",
+                    "/questions/lookup",
+                    "/questions/submit",
+                ]
+                assert _scan_table() == rows
+                assert _object_inventory(s3_bucket, f"generations/{TEST_PROJECT_ID}/") == objects
+            else:
+                assert json.loads(recovered.stdout)["receipt_json"] == receipts[0]
+                count = len(calls)
+                cached = invoke("recover")
+                assert cached.returncode == 0, cached.stderr.decode()
+                assert json.loads(cached.stdout) == json.loads(recovered.stdout)
+                assert len(calls) == count
+            assert len({json.dumps(body, sort_keys=True) for _, body in calls}) == 1
+        finally:
+            server.shutdown()
+            thread.join(timeout=5)

--- a/packages/nauro/tests/test_question_submission.py
+++ b/packages/nauro/tests/test_question_submission.py
@@ -1,0 +1,440 @@
+"""Question identities, strict receipts and durable recovery."""
+
+import ast
+import errno
+import json
+import stat
+from datetime import datetime, timedelta
+from pathlib import Path
+from unittest.mock import Mock
+
+import httpx
+import pytest
+from filelock import SoftFileLock, Timeout
+
+from nauro.store import question_records as records
+from nauro.store.question_contract import (
+    QuestionTransportError,
+    question_payload,
+    resolution_payload,
+    verify_question_response,
+)
+from nauro.store.state_records import list_state_submissions
+from nauro.store.submission_records import (
+    SubmissionRecordCorruptError,
+    SubmissionRecordError,
+    list_submissions,
+)
+from nauro.sync import question_submission as submission
+from nauro.sync.question_transport import HttpQuestionTransport
+from tests.test_judgment_submission import OTHER, PROJECT, USER, home
+
+__all__ = ["home"]
+GENERATION = "01K00000000000000000000004"
+
+
+def _prepared(action="append"):
+    payload = (
+        question_payload("Question?") if action == "append" else resolution_payload(("Q1",), "D42")
+    )
+    return records.prepare_question_submission(PROJECT, USER, payload)
+
+
+def _body(record, status="committed"):
+    action = "resolve" if "resolved_by" in json.loads(record.payload_json) else "append"
+    body = {
+        "version": 1,
+        "scope": record.scope.model_dump(),
+        "payload_digest": record.payload_digest,
+        "action": action,
+        "status": status,
+        "unresolved": status in {"absent", "no_change_observed"},
+    }
+    if status == "committed":
+        details = {
+            "snapshot_key": f"generations/{PROJECT}/{GENERATION}/snapshot.json",
+            "snapshot_digest": "c" * 64,
+        }
+        timestamp = "2026-09-06T00:00:00.000000Z"
+        details.update(
+            {"question_event_id": GENERATION, "question_created_at": timestamp}
+            if action == "append"
+            else {"resolution_row_digest": "a" * 64}
+        )
+        receipt = {
+            "receipt_id": GENERATION,
+            "operation_kind": "flag_question",
+            "operation_id": record.scope.operation_id,
+            "result": "committed" if action == "append" else "resolved",
+            "committed_at": timestamp,
+            "artifact_digest": "a" * 64,
+            "generation_id": GENERATION,
+            "target_kind": "question" if action == "append" else "question_resolution",
+            "target_id": "Q2" if action == "append" else GENERATION,
+            "details": details,
+        }
+        body["receipt_json"] = json.dumps(receipt, sort_keys=True, separators=(",", ":"))
+    if action == "resolve" and status in {"committed", "no_change_observed"}:
+        body["diagnostics"] = {
+            "requested_question_ids": ["Q1"],
+            "resolved_question_ids": ["Q1"] if status == "committed" else [],
+            "resolved_by": "D42",
+            "relocated_ids": [],
+            "skipped_prose_ids": [],
+        }
+    return body
+
+
+def _result(record, status="committed"):
+    return verify_question_response(
+        json.dumps(_body(record, status)).encode(), record.scope, record.payload_json
+    )
+
+
+def test_distinct_identities_and_separate_discovery(home):
+    first, second, resolution = _prepared(), _prepared(), _prepared("resolve")
+    assert (
+        len({first.scope.operation_id, second.scope.operation_id, resolution.scope.operation_id})
+        == 3
+    )
+    assert first.payload_json == second.payload_json
+    assert first.scope.operation_kind == resolution.scope.operation_kind == "flag_question"
+    assert records.list_question_submissions(PROJECT, USER) == (first, second, resolution)
+    assert list_submissions(PROJECT, USER) == ()
+    assert list_state_submissions(PROJECT, USER) == ()
+    assert records._record_path(first.scope).stat().st_mode & 0o777 == 0o600
+
+
+def test_observation_is_not_cached_as_completion(home):
+    record = _prepared("resolve")
+    transport = Mock(
+        submit=Mock(return_value=_result(record, "no_change_observed")),
+        lookup=Mock(return_value=_result(record)),
+    )
+    assert submission.submit_question(record.scope, transport).unresolved is True
+    assert records.read_question_submission(record.scope).phase == "uncertain"
+    with pytest.raises(submission.QuestionRecoveryRequiredError):
+        submission.submit_question(record.scope, transport)
+    committed = submission.recover_question(record.scope, transport)
+    assert committed.unresolved is False
+    assert submission.recover_question(record.scope, transport) == committed
+    transport.submit.assert_called_once()
+    transport.lookup.assert_called_once()
+
+
+@pytest.mark.parametrize("action", ["append", "resolve"])
+def test_retry_observes_absence_before_exact_resend(home, action):
+    record = _prepared(action)
+    events = []
+
+    def lookup(saved):
+        events.append("lookup")
+        return _result(record, "absent")
+
+    def send(saved):
+        events.append("submit")
+        assert saved.scope == record.scope
+        assert saved.payload_json == record.payload_json
+        assert saved.phase == "uncertain"
+        return _result(record)
+
+    result = submission.retry_question(record.scope, Mock(lookup=lookup, submit=send))
+    assert result.status == "committed"
+    assert events == ["lookup", "submit"]
+
+
+@pytest.mark.parametrize("seconds,allowed", [(-1, False), (0, True), (86400, True), (86401, False)])
+def test_resend_horizon_after_lookup(home, monkeypatch, seconds, allowed):
+    record = _prepared()
+    now = datetime.fromisoformat(record.created_at.replace("Z", "+00:00")) + timedelta(
+        seconds=seconds
+    )
+
+    class Clock(datetime):
+        @classmethod
+        def now(cls, tz):
+            return now
+
+    monkeypatch.setattr(submission, "datetime", Clock)
+    transport = Mock(
+        lookup=Mock(return_value=_result(record, "absent")),
+        submit=Mock(return_value=_result(record)),
+    )
+    if allowed:
+        assert submission.retry_question(record.scope, transport).status == "committed"
+    else:
+        with pytest.raises(submission.QuestionRetryExpiredError):
+            submission.retry_question(record.scope, transport)
+        transport.submit.assert_not_called()
+    transport.lookup.assert_called_once()
+
+
+@pytest.mark.parametrize("action", ["append", "resolve"])
+@pytest.mark.parametrize(
+    "field,value",
+    [("version", True), ("unresolved", 0), ("payload_digest", "0" * 64), ("extra", "unknown")],
+)
+def test_response_binding_and_closed_fields(home, action, field, value):
+    record = _prepared(action)
+    body = {**_body(record), field: value}
+    with pytest.raises(QuestionTransportError):
+        verify_question_response(json.dumps(body).encode(), record.scope, record.payload_json)
+
+
+@pytest.mark.parametrize("action", ["append", "resolve"])
+@pytest.mark.parametrize(
+    "mutation", ["operation", "target", "details", "timestamp", "snapshot", "canonical"]
+)
+def test_receipt_binding(home, action, mutation):
+    record = _prepared(action)
+    body = _body(record)
+    receipt = json.loads(body["receipt_json"])
+    if mutation == "operation":
+        receipt["operation_id"] = "wrong-operation"
+    elif mutation == "target":
+        receipt["target_kind"] = "curated_state"
+    elif mutation == "details":
+        receipt["details"]["unexpected"] = "extra"
+    elif mutation == "timestamp":
+        receipt["committed_at"] = "not-a-date"
+    elif mutation == "snapshot":
+        receipt["details"]["snapshot_key"] = "wrong/snapshot.json"
+    body["receipt_json"] = json.dumps(receipt, sort_keys=True, separators=(",", ":")) + (
+        " " if mutation == "canonical" else ""
+    )
+    with pytest.raises(QuestionTransportError):
+        verify_question_response(json.dumps(body).encode(), record.scope, record.payload_json)
+
+
+def test_action_diagnostics_and_lookup_observations_bind_request(home):
+    record = _prepared("resolve")
+    for mutation in ("action", "diagnostics", "effects", "lookup"):
+        body = _body(record, "no_change_observed")
+        if mutation == "action":
+            body["action"] = "append"
+        elif mutation == "diagnostics":
+            body["diagnostics"]["resolved_by"] = "D43"
+        elif mutation == "effects":
+            body["diagnostics"]["resolved_question_ids"] = ["Q1"]
+        with pytest.raises(QuestionTransportError):
+            verify_question_response(
+                json.dumps(body).encode(),
+                record.scope,
+                record.payload_json,
+                lookup=mutation == "lookup",
+            )
+
+
+@pytest.mark.parametrize("status", ["committed", "expired", "digest_conflict"])
+def test_terminal_lookup_prevents_retry(home, status):
+    record = _prepared()
+    transport = Mock(lookup=Mock(return_value=_result(record, status)))
+    assert submission.retry_question(record.scope, transport).status == status
+    transport.submit.assert_not_called()
+
+
+def test_transport_preserves_body_and_refuses_redirect(home):
+    record = _prepared()
+    seen = []
+
+    def handle(request):
+        seen.append(request)
+        return httpx.Response(200, json=_body(record, "absent"))
+
+    with httpx.Client(transport=httpx.MockTransport(handle)) as client:
+        adapter = HttpQuestionTransport("https://example.test", client)
+        assert adapter.lookup(record).status == "absent"
+    assert seen[0].url.path == "/questions/lookup"
+    assert json.loads(seen[0].content)["payload_json"] == record.payload_json
+    with httpx.Client(
+        transport=httpx.MockTransport(
+            lambda request: httpx.Response(307, headers={"Location": "https://other.test"})
+        )
+    ) as client:
+        with pytest.raises(QuestionTransportError):
+            HttpQuestionTransport("https://example.test", client).submit(record)
+
+
+def test_no_production_consumers():
+    root = Path(__file__).parents[1] / "src" / "nauro"
+    modules = {
+        "nauro.store.question_contract",
+        "nauro.store.question_records",
+        "nauro.sync.question_submission",
+        "nauro.sync.question_transport",
+    }
+    found = []
+    for path in root.rglob("*.py"):
+        own = "nauro." + ".".join(path.relative_to(root).with_suffix("").parts)
+        if own in modules:
+            continue
+        for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
+            if isinstance(node, ast.Import):
+                names = {a.name for a in node.names}
+            elif isinstance(node, ast.ImportFrom):
+                names = {node.module} | {f"{node.module}.{a.name}" for a in node.names}
+            else:
+                continue
+            if names & modules:
+                found.append(str(path.relative_to(root)))
+    assert found == []
+
+
+def test_file_barrier_failure_prevents_send(home, monkeypatch):
+    record = _prepared()
+    original = records.os.fsync
+
+    def fail(fd):
+        if stat.S_ISREG(records.os.fstat(fd).st_mode):
+            raise OSError(errno.ENOSPC, "synthetic full disk")
+        original(fd)
+
+    monkeypatch.setattr(records.os, "fsync", fail)
+    transport = Mock()
+    with pytest.raises(OSError) as error:
+        submission.submit_question(record.scope, transport)
+    assert error.value.errno == errno.ENOSPC
+    transport.submit.assert_not_called()
+    assert records.read_question_submission(record.scope) == record
+
+
+def test_failed_namespace_barrier_is_repeated_before_network(home, monkeypatch):
+    record = _prepared()
+    original_replace = records.os.replace
+    original_sync = records._directory_sync
+
+    def replace(source, target):
+        original_replace(source, target)
+        monkeypatch.setattr(
+            records, "_directory_sync", Mock(side_effect=OSError(errno.EIO, "sync"))
+        )
+
+    monkeypatch.setattr(records.os, "replace", replace)
+    transport = Mock()
+    with pytest.raises(OSError):
+        submission.submit_question(record.scope, transport)
+    with pytest.raises(OSError):
+        submission.recover_question(record.scope, transport)
+    transport.submit.assert_not_called()
+    transport.lookup.assert_not_called()
+    monkeypatch.setattr(records, "_directory_sync", original_sync)
+    monkeypatch.setattr(records.os, "replace", original_replace)
+    transport.lookup.return_value = _result(record, "absent")
+    assert submission.recover_question(record.scope, transport).status == "absent"
+    transport.submit.assert_not_called()
+
+
+def test_failed_receipt_persistence_leaves_recovery_available(home, monkeypatch):
+    record = _prepared()
+    original = records._write
+
+    def fail(saved):
+        if saved.phase == "resolved":
+            raise OSError(errno.EIO, "receipt persistence")
+        original(saved)
+
+    monkeypatch.setattr(records, "_write", fail)
+    transport = Mock(
+        submit=Mock(return_value=_result(record)), lookup=Mock(return_value=_result(record))
+    )
+    with pytest.raises(OSError):
+        submission.submit_question(record.scope, transport)
+    assert records.read_question_submission(record.scope).phase == "uncertain"
+    monkeypatch.setattr(records, "_write", original)
+    assert submission.recover_question(record.scope, transport).status == "committed"
+    transport.submit.assert_called_once()
+
+
+def test_native_lock_and_corruption_refuse_before_network(home, monkeypatch):
+    record = _prepared()
+    with records.question_submission_lock(record.scope):
+        with pytest.raises(Timeout):
+            with records.question_submission_lock(record.scope):
+                pass
+    monkeypatch.setattr(records, "FileLock", SoftFileLock)
+    with pytest.raises(SubmissionRecordError):
+        with records.question_submission_lock(record.scope):
+            pass
+    path = records._record_path(record.scope)
+    raw = json.loads(path.read_bytes())
+    raw["record"]["payload_json"] = "{}"
+    path.write_text(json.dumps(raw))
+    with pytest.raises(SubmissionRecordCorruptError):
+        records.read_question_submission(record.scope)
+
+
+def test_account_change_during_transport_preserves_uncertainty(home):
+    record = _prepared()
+
+    def switch(saved):
+        (home / "config.json").write_text(
+            json.dumps({"auth": {"user_id": OTHER, "access_token": "synthetic-test-token"}})
+        )
+        return _result(record)
+
+    with pytest.raises(SubmissionRecordError):
+        submission.submit_question(record.scope, Mock(submit=switch))
+    (home / "config.json").write_text(
+        json.dumps({"auth": {"user_id": USER, "access_token": "synthetic-test-token"}})
+    )
+    assert records.read_question_submission(record.scope).phase == "uncertain"
+
+
+@pytest.mark.parametrize("action", ["append", "resolve"])
+def test_lookup_observation_and_unbound_receipt_never_persist(home, action):
+    record = _prepared(action)
+    invalid = _result(record).model_copy(update={"receipt_json": "invalid"})
+    with pytest.raises(QuestionTransportError):
+        submission.recover_question(record.scope, Mock(lookup=Mock(return_value=invalid)))
+    assert records.read_question_submission(record.scope) == record
+
+
+@pytest.mark.parametrize(
+    "origin",
+    [
+        "http://example.test",
+        "https://user@example.test",
+        "https://example.test/path",
+        "https://example.test?query=1",
+    ],
+)
+def test_untrusted_origins_refuse(origin):
+    with httpx.Client() as client:
+        with pytest.raises(QuestionTransportError):
+            HttpQuestionTransport(origin, client)
+
+
+def test_duplicate_and_oversized_responses_refuse(home):
+    record = _prepared()
+    duplicate = json.dumps(_body(record))[:-1] + ',"version":1}'
+    for raw in (duplicate.encode(), b" " * (64 * 1024 + 1)):
+        with pytest.raises(QuestionTransportError):
+            verify_question_response(raw, record.scope, record.payload_json)
+
+
+def test_payload_normalization_preserves_order_and_duplicates():
+    assert question_payload("Question?", targets=("Q02", "Q1", "Q02")) == (
+        b'{"context":null,"question":"Question?","targets":["Q2","Q1","Q2"]}\n'
+    )
+    assert resolution_payload(("Q02", "Q1", "Q02"), "D42") == (
+        b'{"action":"resolve","resolved_by":"D42","targets":["Q2","Q1","Q2"]}\n'
+    )
+
+
+def test_missing_record_is_not_absence(home):
+    record = _prepared()
+    records._record_path(record.scope).unlink()
+    transport = Mock()
+    with pytest.raises(SubmissionRecordError):
+        submission.recover_question(record.scope, transport)
+    transport.lookup.assert_not_called()
+
+
+def test_terminal_record_cannot_be_reopened(home):
+    record = _prepared()
+    submission.submit_question(record.scope, Mock(submit=Mock(return_value=_result(record))))
+    saved = records.read_question_submission(record.scope)
+    with pytest.raises(SubmissionRecordError):
+        records.mark_question_uncertain(saved)
+    with pytest.raises(SubmissionRecordError):
+        records.record_question_result(saved, _result(record, "absent"))

--- a/packages/nauro/tests/test_question_transport_pair.py
+++ b/packages/nauro/tests/test_question_transport_pair.py
@@ -1,0 +1,49 @@
+"""Installed client TLS conformance against the paired server source."""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "scenario", ["append_drop", "resolve_drop", "no_change_drop", "no_change_saved"]
+)
+def test_paired_question_transport(scenario):
+    interpreter = os.environ.get("NAURO_SERVER_PYTHON")
+    source = os.environ.get("NAURO_SERVER_ROOT")
+    if not interpreter or not source:
+        pytest.skip("Set NAURO_SERVER_PYTHON and NAURO_SERVER_ROOT for paired question transport.")
+    root = Path(source).resolve()
+    probe = Path(__file__).parent / "fixtures" / "question_transport_server.py"
+    env = {
+        **os.environ,
+        "PYTHONPATH": os.pathsep.join([str(root / "src"), str(root)]),
+        "NAURO_CLIENT_PYTHON": sys.executable,
+        "AWS_DEFAULT_REGION": "us-east-1",
+    }
+    result = subprocess.run(
+        [
+            interpreter,
+            "-m",
+            "pytest",
+            "-q",
+            "--noconftest",
+            "-c",
+            str(root / "pyproject.toml"),
+            "-p",
+            "tests.conftest",
+            f"{probe}::test_question_client_restart_over_tls[{scenario}]",
+            "--tb=short",
+        ],
+        cwd=root,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "1 passed" in result.stdout
+    assert "skipped" not in result.stdout


### PR DESCRIPTION
## Why

Question submissions need durable identities and verified receipt recovery when a response is lost or the client restarts. A no-change response must remain unresolved because an older request can still commit.

## What changed

Add dormant append/resolution payload and receipt verification, private durable submission records, an HTTPS adapter, and explicit submit/recover/retry coordination. Recovery only looks up the original operation. Explicit retry looks up first and resends the original identity and exact payload only after observed absence within the resend horizon.

Depends on the question transport merged in Nauro-AI/mcp-server#197. Add four real TLS/process restart scenarios and include the new modules in CI typing.

## Test plan

135 selected client tests passed on Python 3.12; all 53 question tests passed on Python 3.10. Both runs include all four paired TLS scenarios. All 116 selected server checks passed with the installed client and zero skips, including all ten retained paired checks. Full lint/formatting, all 32 typing targets and unchanged risk and contract gates passed.

## Risk / what to review

Review durable uncertainty before send, lookup-only recovery, response bindings and unresolved no-change handling. Resolution diagnostics rely on authenticated server verification. Receipts describe historical operations and do not establish current local replica state.

## Deferred

Concurrent writing remains incomplete. This transport has no production consumers. Production activation, automatic cloud retries, remaining mutation families and hosted timing proof are unchanged.
