### PR TITLE
Add dormant client stack submission and receipt recovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,11 @@ jobs:
           packages/nauro/src/nauro/sync/generation_refresh.py
           packages/nauro/src/nauro/sync/generation_acquisition.py
           packages/nauro/src/nauro/store/submission_records.py
+          packages/nauro/src/nauro/store/stack_contract.py
+          packages/nauro/src/nauro/store/stack_records.py
+          packages/nauro/src/nauro/sync/stack_submission.py
+          packages/nauro/src/nauro/sync/stack_transport.py
+          packages/nauro/src/nauro/mcp/stack_responses.py
           packages/nauro/src/nauro/store/state_contract.py
           packages/nauro/src/nauro/store/state_records.py
           packages/nauro/src/nauro/sync/state_submission.py

--- a/packages/nauro/src/nauro/mcp/stack_responses.py
+++ b/packages/nauro/src/nauro/mcp/stack_responses.py
@@ -1,0 +1,77 @@
+"""Dormant MCP responses for explicit saved stack operations."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from filelock import Timeout
+from mcp.types import CallToolResult, TextContent
+
+from nauro.auth import ActiveUserReadError
+from nauro.store.stack_contract import StackCommitted, StackResult, StackScope
+from nauro.store.submission_records import SubmissionRecordError
+from nauro.sync import stack_submission
+from nauro.sync.stack_submission import StackTransport
+
+_RESULT_TEXT = {
+    "absent": (
+        "No receipt was found. This operation remains unresolved; an earlier request may "
+        "still commit. Recovery only checks for a receipt."
+    ),
+    "revision_conflict_observed": (
+        "This attempt found a revision conflict and made no write. This operation remains "
+        "unresolved; an earlier request may still commit. Recover the original operation. "
+        "Changed content or expected revision requires a new explicit submission."
+    ),
+    "expired": (
+        "The receipt replay window has expired. This does not prove that no write occurred. "
+        "Do not resend this operation."
+    ),
+    "digest_conflict": (
+        "This operation identity is bound to a different payload. "
+        "Do not resend this operation with changed content."
+    ),
+}
+
+
+def _response(result: StackResult) -> CallToolResult:
+    if isinstance(result, StackCommitted):
+        text = "Stack operation committed. This receipt does not establish current local state."
+    else:
+        text = _RESULT_TEXT[result.status]
+    return CallToolResult(
+        content=[TextContent(type="text", text=text)],
+        structuredContent=result.model_dump(mode="json"),
+        isError=result.status != "committed",
+    )
+
+
+def _run(operation: Callable[[], StackResult]) -> CallToolResult:
+    try:
+        return _response(operation())
+    except (SubmissionRecordError, ActiveUserReadError, OSError, Timeout):
+        return CallToolResult(
+            content=[
+                TextContent(
+                    type="text",
+                    text=(
+                        "Stack operation outcome is unconfirmed. Keep the saved submission "
+                        "and recover the original operation when access is available. "
+                        "Do not infer that no write occurred."
+                    ),
+                )
+            ],
+            isError=True,
+        )
+
+
+def submit_stack(scope: StackScope, transport: StackTransport) -> CallToolResult:
+    return _run(lambda: stack_submission.submit_stack(scope, transport))
+
+
+def recover_stack(scope: StackScope, transport: StackTransport) -> CallToolResult:
+    return _run(lambda: stack_submission.recover_stack(scope, transport))
+
+
+def retry_stack(scope: StackScope, transport: StackTransport) -> CallToolResult:
+    return _run(lambda: stack_submission.retry_stack(scope, transport))

--- a/packages/nauro/src/nauro/store/stack_contract.py
+++ b/packages/nauro/src/nauro/store/stack_contract.py
@@ -1,0 +1,223 @@
+"""Strict stack request identity and authenticated response evidence."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Annotated, Literal
+
+from nauro_core.identifiers import IdentifierKind, validate_identifier
+from nauro_core.operations.update_stack import compute_stack_revision, update_stack
+from nauro_core.provenance import validate_utc_timestamp
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    StrictInt,
+    StrictStr,
+    TypeAdapter,
+    field_validator,
+)
+
+from nauro.store.submission_records import Digest, SubmissionRecordError
+
+
+class StackTransportError(SubmissionRecordError):
+    """The stack response did not establish bound operation evidence."""
+
+
+class ClosedModel(BaseModel):
+    model_config = ConfigDict(
+        frozen=True,
+        extra="forbid",
+        strict=True,
+        revalidate_instances="always",
+        hide_input_in_errors=True,
+    )
+
+
+class StackScope(ClosedModel):
+    project_id: StrictStr
+    user_id: StrictStr
+    operation_kind: Literal["update_stack"] = "update_stack"
+    operation_id: StrictStr
+
+    @field_validator("project_id", "user_id")
+    @classmethod
+    def _ulid(cls, value: str) -> str:
+        return validate_identifier(IdentifierKind.ulid, value, field="stack_scope")
+
+    @field_validator("operation_id")
+    @classmethod
+    def _operation_id(cls, value: str) -> str:
+        return validate_identifier(IdentifierKind.operation_id, value, field="operation_id")
+
+
+class StackPayload(ClosedModel):
+    operation: Literal["update_stack"]
+    content: StrictStr
+    expected_revision: StrictStr | None
+
+
+def stack_payload(content: str, expected_revision: str | None = None) -> bytes:
+    request = StackPayload(
+        operation="update_stack", content=content, expected_revision=expected_revision
+    )
+    return update_stack(request.content, request.expected_revision).payload_bytes
+
+
+def read_stack_payload(raw: str) -> StackPayload:
+    payload = StackPayload.model_validate_json(raw, strict=True)
+    if stack_payload(payload.content, payload.expected_revision) != raw.encode("utf-8"):
+        raise ValueError("stack payload is not canonical")
+    return payload
+
+
+class _Response(ClosedModel):
+    version: StrictInt = Field(ge=1, le=1)
+    scope: StackScope
+    payload_digest: Digest
+
+    @field_validator("unresolved", mode="before", check_fields=False)
+    @classmethod
+    def _boolean(cls, value: object) -> object:
+        if type(value) is not bool:
+            raise ValueError("unresolved must be a boolean")
+        return value
+
+
+class StackCommitted(_Response):
+    status: Literal["committed"]
+    unresolved: Literal[False]
+    receipt_json: StrictStr
+
+
+class StackObserved(_Response):
+    status: Literal["absent"]
+    unresolved: Literal[True]
+
+
+class StackRevisionObserved(_Response):
+    status: Literal["revision_conflict_observed"]
+    unresolved: Literal[True]
+    expected_revision: StrictStr
+    current_revision: StrictStr
+
+    @field_validator("expected_revision", "current_revision")
+    @classmethod
+    def _revision(cls, value: str) -> str:
+        return validate_identifier(IdentifierKind.stack_revision, value, field="stack_revision")
+
+
+class StackUnavailable(_Response):
+    status: Literal["expired", "digest_conflict"]
+    unresolved: Literal[False]
+
+
+StackResult = StackCommitted | StackObserved | StackRevisionObserved | StackUnavailable
+_RESPONSE: TypeAdapter[StackResult] = TypeAdapter(
+    Annotated[StackResult, Field(discriminator="status")]
+)
+
+
+class _ReceiptDetails(ClosedModel):
+    base_generation_id: StrictStr
+    base_manifest_digest: Digest
+    base_snapshot_digest: Digest
+    previous_revision: StrictStr
+    stack_revision: Digest
+    snapshot_key: StrictStr
+    snapshot_digest: Digest
+
+    @field_validator("base_generation_id")
+    @classmethod
+    def _ulid(cls, value: str) -> str:
+        return validate_identifier(IdentifierKind.ulid, value, field="base_generation_id")
+
+    @field_validator("previous_revision")
+    @classmethod
+    def _revision(cls, value: str) -> str:
+        return validate_identifier(IdentifierKind.stack_revision, value, field="stack_revision")
+
+
+class _Receipt(ClosedModel):
+    receipt_id: StrictStr
+    operation_kind: Literal["update_stack"]
+    operation_id: StrictStr
+    result: Literal["committed"]
+    committed_at: StrictStr
+    artifact_digest: Digest
+    generation_id: StrictStr
+    target_kind: Literal["curated_stack"]
+    target_id: Literal["stack.md"]
+    details: _ReceiptDetails
+
+    @field_validator("receipt_id", "generation_id")
+    @classmethod
+    def _ulid(cls, value: str) -> str:
+        return validate_identifier(IdentifierKind.ulid, value, field="stack_receipt")
+
+    @field_validator("committed_at")
+    @classmethod
+    def _timestamp(cls, value: str) -> str:
+        return validate_utc_timestamp(value, field="committed_at")
+
+
+def _verify_receipt(raw: str, scope: StackScope, payload: StackPayload) -> None:
+    if len(raw.encode("utf-8")) > 1193:
+        raise ValueError("stack receipt exceeds byte limit")
+    receipt = _Receipt.model_validate_json(raw, strict=True)
+    canonical = json.dumps(
+        receipt.model_dump(mode="json"), sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    )
+    if canonical != raw or receipt.operation_id != scope.operation_id:
+        raise ValueError("receipt bytes or operation differ")
+    if receipt.details.stack_revision != compute_stack_revision(payload.content.encode("utf-8")):
+        raise ValueError("receipt content revision differs")
+    if receipt.generation_id == receipt.details.base_generation_id:
+        raise ValueError("receipt must advance the generation")
+    if (
+        receipt.details.snapshot_key
+        != f"generations/{scope.project_id}/{receipt.generation_id}/snapshot.json"
+    ):
+        raise ValueError("receipt snapshot differs")
+    if (
+        payload.expected_revision is not None
+        and receipt.details.previous_revision != payload.expected_revision
+    ):
+        raise ValueError("receipt precondition differs")
+
+
+def _unique_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result = dict(pairs)
+    if len(result) != len(pairs):
+        raise ValueError("duplicate JSON key")
+    return result
+
+
+def verify_stack_response(
+    raw: bytes, scope: StackScope, payload_json: str, *, lookup: bool = False
+) -> StackResult:
+    try:
+        scope = StackScope.model_validate(scope)
+        payload = read_stack_payload(payload_json)
+        if len(raw) > 64 * 1024:
+            raise ValueError("response exceeds byte limit")
+        result = _RESPONSE.validate_python(
+            json.loads(raw.decode("utf-8"), object_pairs_hook=_unique_object)
+        )
+        digest = hashlib.sha256(payload_json.encode("utf-8")).hexdigest()
+        if result.scope != scope or result.payload_digest != digest:
+            raise ValueError("stack response binding differs")
+        if lookup and result.status == "revision_conflict_observed":
+            raise ValueError("lookup cannot establish a no-write observation")
+        if isinstance(result, StackRevisionObserved) and (
+            result.expected_revision != payload.expected_revision
+            or result.current_revision == result.expected_revision
+        ):
+            raise ValueError("revision conflict does not bind the request")
+        if isinstance(result, StackCommitted):
+            _verify_receipt(result.receipt_json, scope, payload)
+        return result
+    except (ValueError, TypeError, RecursionError) as exc:
+        raise StackTransportError("The stack response did not verify.") from exc

--- a/packages/nauro/src/nauro/store/stack_records.py
+++ b/packages/nauro/src/nauro/store/stack_records.py
@@ -1,0 +1,225 @@
+"""Private durable stack identities with recoverable no-write observations."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import stat
+import tempfile
+import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Annotated, Literal
+
+from filelock import BaseFileLock, FileLock, UnixFileLock, WindowsFileLock
+from nauro_core.identifiers import IdentifierKind, validate_identifier
+from nauro_core.provenance import validate_utc_timestamp
+from pydantic import Field, StrictInt, StrictStr, ValidationError, field_validator, model_validator
+
+from nauro.store.home import nauro_home
+from nauro.store.stack_contract import (
+    ClosedModel,
+    StackResult,
+    StackScope,
+    read_stack_payload,
+    verify_stack_response,
+)
+from nauro.store.submission_records import (
+    SUBMISSION_RECORDS_DIR,
+    Digest,
+    SubmissionRecordCorruptError,
+    SubmissionRecordError,
+    _directory_sync,
+    _ensure_directory,
+    require_submission_actor,
+)
+
+_MAX_BYTES = 2 * 1024 * 1024
+
+
+class StackSubmission(ClosedModel):
+    schema_version: StrictInt = Field(default=1, ge=1, le=1)
+    scope: StackScope
+    created_at: StrictStr
+    payload_json: StrictStr
+    payload_digest: Digest
+    phase: Literal["prepared", "uncertain", "resolved"]
+    result: Annotated[StackResult, Field(discriminator="status")] | None = None
+
+    @field_validator("created_at")
+    @classmethod
+    def _timestamp(cls, value: str) -> str:
+        return validate_utc_timestamp(value, field="created_at")
+
+    @model_validator(mode="after")
+    def _bindings(self) -> StackSubmission:
+        read_stack_payload(self.payload_json)
+        if hashlib.sha256(self.payload_json.encode("utf-8")).hexdigest() != self.payload_digest:
+            raise ValueError("stack payload digest differs")
+        if self.result is not None:
+            verify_stack_response(
+                self.result.model_dump_json().encode(), self.scope, self.payload_json
+            )
+        terminal = self.result is not None and not self.result.unresolved
+        if (self.phase == "resolved") != terminal:
+            raise ValueError("stack phase and result disagree")
+        if self.phase == "prepared" and self.result is not None:
+            raise ValueError("prepared stack cannot contain a response")
+        return self
+
+
+class _Stored(ClosedModel):
+    record: StackSubmission
+    digest: Digest
+
+    @model_validator(mode="after")
+    def _integrity(self) -> _Stored:
+        if hashlib.sha256(self.record.model_dump_json().encode()).hexdigest() != self.digest:
+            raise ValueError("stack record checksum differs")
+        return self
+
+
+def _directory(project_id: str, user_id: str) -> Path:
+    validate_identifier(IdentifierKind.ulid, project_id, field="project_id")
+    validate_identifier(IdentifierKind.ulid, user_id, field="user_id")
+    return nauro_home() / SUBMISSION_RECORDS_DIR / "stack" / project_id / user_id
+
+
+def _record_path(scope: StackScope) -> Path:
+    scope = StackScope.model_validate(scope)
+    key = hashlib.sha256(scope.model_dump_json().encode()).hexdigest()
+    return _directory(scope.project_id, scope.user_id) / f"{key}.json"
+
+
+def _read(path: Path) -> StackSubmission | None:
+    try:
+        fd = os.open(
+            path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+        )
+    except FileNotFoundError:
+        return None
+    try:
+        with os.fdopen(fd, "rb") as handle:
+            if not stat.S_ISREG(os.fstat(handle.fileno()).st_mode):
+                raise SubmissionRecordCorruptError("The stack record is not a regular file.")
+            raw = handle.read(_MAX_BYTES + 1)
+        if len(raw) > _MAX_BYTES:
+            raise SubmissionRecordCorruptError("The stack record exceeds its size limit.")
+        stored = _Stored.model_validate_json(raw, strict=True)
+        if stored.model_dump_json().encode() != raw:
+            raise SubmissionRecordCorruptError("The stack record encoding differs.")
+        return stored.record
+    except (ValidationError, UnicodeError, SubmissionRecordError) as exc:
+        raise SubmissionRecordCorruptError("The stack record did not verify.") from exc
+
+
+def read_stack_submission(scope: StackScope) -> StackSubmission | None:
+    require_submission_actor(scope.user_id)
+    record = _read(_record_path(scope))
+    if record is not None and record.scope != scope:
+        raise SubmissionRecordCorruptError("The stack record belongs to another scope.")
+    require_submission_actor(scope.user_id)
+    return record
+
+
+def list_stack_submissions(project_id: str, user_id: str) -> tuple[StackSubmission, ...]:
+    require_submission_actor(user_id)
+    try:
+        entries = os.scandir(_directory(project_id, user_id))
+    except FileNotFoundError:
+        return ()
+    records = []
+    with entries:
+        for entry in entries:
+            if entry.name.endswith(".json"):
+                record = _read(Path(entry.path))
+                if (
+                    record is None
+                    or record.scope.project_id != project_id
+                    or record.scope.user_id != user_id
+                    or _record_path(record.scope) != Path(entry.path)
+                ):
+                    raise SubmissionRecordCorruptError(
+                        "The stack record path differs from its scope."
+                    )
+                records.append(record)
+    require_submission_actor(user_id)
+    return tuple(sorted(records, key=lambda record: (record.created_at, record.scope.operation_id)))
+
+
+@contextmanager
+def stack_submission_lock(scope: StackScope) -> Iterator[None]:
+    require_submission_actor(scope.user_id)
+    path = _record_path(scope)
+    _ensure_directory(path.parent)
+    lock: BaseFileLock = FileLock(str(path.with_suffix(".lock")), timeout=0, mode=0o600)
+    if type(lock) not in (UnixFileLock, WindowsFileLock):
+        raise SubmissionRecordError("Native stack submission locking is unavailable.")
+    with lock:
+        if type(lock) not in (UnixFileLock, WindowsFileLock):
+            raise SubmissionRecordError("Native stack submission locking is unavailable.")
+        _directory_sync(path.parent)
+        require_submission_actor(scope.user_id)
+        yield
+
+
+def _write(record: StackSubmission) -> None:
+    path = _record_path(record.scope)
+    stored = _Stored(
+        record=record, digest=hashlib.sha256(record.model_dump_json().encode()).hexdigest()
+    )
+    encoded = stored.model_dump_json().encode()
+    if len(encoded) > _MAX_BYTES:
+        raise SubmissionRecordError("The stack record exceeds its size limit.")
+    fd, name = tempfile.mkstemp(prefix=".stack-submission-", dir=path.parent)
+    temporary = Path(name)
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(encoded)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+        _directory_sync(path.parent)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def prepare_stack_submission(project_id: str, user_id: str, payload: bytes) -> StackSubmission:
+    require_submission_actor(user_id)
+    record = StackSubmission(
+        scope=StackScope(project_id=project_id, user_id=user_id, operation_id=uuid.uuid4().hex),
+        created_at=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+        payload_json=payload.decode("utf-8"),
+        payload_digest=hashlib.sha256(payload).hexdigest(),
+        phase="prepared",
+    )
+    with stack_submission_lock(record.scope):
+        if read_stack_submission(record.scope) is not None:
+            raise SubmissionRecordError("The generated stack identity already exists.")
+        _write(record)
+        require_submission_actor(user_id)
+    return record
+
+
+def mark_stack_uncertain(record: StackSubmission) -> StackSubmission:
+    if record.phase == "resolved" or read_stack_submission(record.scope) != record:
+        raise SubmissionRecordError("The saved stack submission cannot make this transition.")
+    updated = StackSubmission.model_validate({**record.model_dump(), "phase": "uncertain"})
+    _write(updated)
+    return updated
+
+
+def record_stack_result(record: StackSubmission, result: StackResult) -> StackSubmission:
+    if record.phase == "resolved" or read_stack_submission(record.scope) != record:
+        raise SubmissionRecordError("The saved stack submission cannot make this transition.")
+    updated = StackSubmission.model_validate(
+        {
+            **record.model_dump(),
+            "phase": "uncertain" if result.unresolved else "resolved",
+            "result": result,
+        }
+    )
+    _write(updated)
+    return updated

--- a/packages/nauro/src/nauro/sync/stack_submission.py
+++ b/packages/nauro/src/nauro/sync/stack_submission.py
@@ -1,0 +1,104 @@
+"""Explicit stack submission and lookup-only recovery."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Protocol
+
+from nauro.store.stack_contract import (
+    StackResult,
+    StackScope,
+    StackTransportError,
+    verify_stack_response,
+)
+from nauro.store.stack_records import (
+    StackSubmission,
+    mark_stack_uncertain,
+    read_stack_submission,
+    record_stack_result,
+    stack_submission_lock,
+)
+from nauro.store.submission_records import SubmissionRecordError, require_submission_actor
+
+
+class StackRecoveryRequiredError(SubmissionRecordError):
+    """The original stack operation requires lookup before another send."""
+
+
+class StackRetryExpiredError(SubmissionRecordError):
+    """The original stack operation is outside its resend horizon."""
+
+
+class StackTransport(Protocol):
+    def submit(self, record: StackSubmission) -> StackResult: ...
+
+    def lookup(self, record: StackSubmission) -> StackResult: ...
+
+
+def _load(scope: StackScope) -> StackSubmission:
+    record = read_stack_submission(scope)
+    if record is None:
+        raise SubmissionRecordError("The saved stack submission is missing.")
+    return record
+
+
+def _require_window(record: StackSubmission) -> None:
+    created = datetime.fromisoformat(record.created_at.replace("Z", "+00:00"))
+    elapsed = datetime.now(timezone.utc) - created
+    if not timedelta(0) <= elapsed <= timedelta(hours=24):
+        raise StackRetryExpiredError("The stack submission is outside the resend horizon.")
+
+
+def _accept(record: StackSubmission, result: StackResult, *, lookup: bool) -> StackResult:
+    result = verify_stack_response(
+        result.model_dump_json().encode(), record.scope, record.payload_json, lookup=lookup
+    )
+    require_submission_actor(record.scope.user_id)
+    record_stack_result(record, result)
+    require_submission_actor(record.scope.user_id)
+    return result
+
+
+def _send(record: StackSubmission, transport: StackTransport) -> StackResult:
+    _require_window(record)
+    uncertain = mark_stack_uncertain(record)
+    require_submission_actor(record.scope.user_id)
+    _require_window(uncertain)
+    result = transport.submit(uncertain)
+    if result.status == "absent":
+        raise StackTransportError("A stack send cannot return an absent lookup result.")
+    return _accept(uncertain, result, lookup=False)
+
+
+def submit_stack(scope: StackScope, transport: StackTransport) -> StackResult:
+    require_submission_actor(scope.user_id)
+    with stack_submission_lock(scope):
+        record = _load(scope)
+        if record.result is not None and not record.result.unresolved:
+            return record.result
+        if record.phase != "prepared":
+            raise StackRecoveryRequiredError(
+                "Look up the original stack operation before retrying."
+            )
+        return _send(record, transport)
+
+
+def recover_stack(scope: StackScope, transport: StackTransport) -> StackResult:
+    require_submission_actor(scope.user_id)
+    with stack_submission_lock(scope):
+        record = _load(scope)
+        if record.result is not None and not record.result.unresolved:
+            return record.result
+        return _accept(record, transport.lookup(record), lookup=True)
+
+
+def retry_stack(scope: StackScope, transport: StackTransport) -> StackResult:
+    require_submission_actor(scope.user_id)
+    with stack_submission_lock(scope):
+        record = _load(scope)
+        if record.result is not None and not record.result.unresolved:
+            return record.result
+        result = _accept(record, transport.lookup(record), lookup=True)
+        if result.status != "absent":
+            return result
+        return _send(_load(scope), transport)

--- a/packages/nauro/src/nauro/sync/stack_transport.py
+++ b/packages/nauro/src/nauro/sync/stack_transport.py
@@ -1,0 +1,71 @@
+"""Dormant HTTPS adapter for original stack payloads and verified receipts."""
+
+from __future__ import annotations
+
+import httpx
+
+from nauro.auth import read_active_credentials
+from nauro.store.stack_contract import StackResult, StackTransportError, verify_stack_response
+from nauro.store.stack_records import StackSubmission
+from nauro.store.submission_records import SubmissionActorMismatchError, require_submission_actor
+
+
+class HttpStackTransport:
+    def __init__(self, base_url: str, client: httpx.Client) -> None:
+        url = httpx.URL(base_url)
+        if (
+            url.scheme != "https"
+            or not url.host
+            or url.userinfo
+            or url.query
+            or url.fragment
+            or url.path not in {"", "/"}
+        ):
+            raise StackTransportError("Stack transport requires a trusted HTTPS origin.")
+        self._base_url = str(url).rstrip("/")
+        self._client = client
+
+    def _request(self, record: StackSubmission, *, lookup: bool) -> StackResult:
+        record = StackSubmission.model_validate(record)
+        credentials = read_active_credentials()
+        if credentials.user_id != record.scope.user_id:
+            raise SubmissionActorMismatchError(
+                "The active account does not own this stack submission."
+            )
+        body = {
+            "version": 1,
+            "project_id": record.scope.project_id,
+            "expected_user_id": record.scope.user_id,
+            "operation_id": record.scope.operation_id,
+            "payload_digest": record.payload_digest,
+            "payload_json": record.payload_json,
+        }
+        route = "/stack/lookup" if lookup else "/stack/submit"
+        try:
+            with self._client.stream(
+                "POST",
+                self._base_url + route,
+                json=body,
+                headers={"Authorization": f"Bearer {credentials.access_token}"},
+                timeout=25,
+                follow_redirects=False,
+            ) as response:
+                if response.status_code != 200:
+                    raise StackTransportError("The server did not return a stack result.")
+                raw = bytearray()
+                for chunk in response.iter_bytes():
+                    raw.extend(chunk)
+                    if len(raw) > 64 * 1024:
+                        raise StackTransportError("The stack response exceeds its byte limit.")
+        except httpx.HTTPError as exc:
+            raise StackTransportError(
+                "The stack outcome is unresolved. Look up its original identity."
+            ) from exc
+        require_submission_actor(record.scope.user_id)
+        return verify_stack_response(bytes(raw), record.scope, record.payload_json, lookup=lookup)
+
+    def submit(self, record: StackSubmission) -> StackResult:
+        return self._request(record, lookup=False)
+
+    def lookup(self, record: StackSubmission) -> StackResult:
+        return self._request(record, lookup=True)

--- a/packages/nauro/tests/fixtures/stack_transport_server.py
+++ b/packages/nauro/tests/fixtures/stack_transport_server.py
@@ -1,0 +1,154 @@
+"""Run with the paired server interpreter and its synthetic storage fixtures."""
+
+import json
+import os
+import socket
+import subprocess
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+from tests.test_authenticated_client_recovery import _tls_context
+from tests.test_judgment_staging import _object_inventory, _scan_table
+from tests.test_stack_transport import BASE_STACK, USER_ID, _body, _post, transport
+
+from tests.conftest import TEST_PROJECT_ID
+
+__all__ = ["transport"]
+
+_CLIENT = """
+import json, os, ssl, sys
+import httpx
+from nauro.store.stack_contract import StackTransportError, stack_payload
+from nauro_core.operations.update_stack import compute_stack_revision
+from nauro.store.stack_records import prepare_stack_submission, list_stack_submissions
+from nauro.sync.stack_transport import HttpStackTransport
+from nauro.sync.stack_submission import submit_stack, recover_stack, retry_stack
+endpoint, certificate, project, user, mode = sys.argv[1:]
+with httpx.Client(verify=ssl.create_default_context(cafile=certificate), trust_env=False) as client:
+    transport = HttpStackTransport(endpoint,client)
+    if mode == 'send':
+        revision=compute_stack_revision(b'# Stack\\n\\n- Python\\n')
+        record=prepare_stack_submission(project,user,stack_payload('Frozen stack',revision))
+        try:
+            result=submit_stack(record.scope,transport)
+        except StackTransportError:
+            os._exit(17)
+    else:
+        record,=list_stack_submissions(project,user)
+        result=(retry_stack if mode == 'retry' else recover_stack)(record.scope,transport)
+    print(result.model_dump_json())
+"""
+
+
+@pytest.mark.parametrize("scenario", ["commit_drop", "conflict_drop", "conflict_saved"])
+def test_stack_client_restart_over_tls(transport, s3_bucket, tmp_path, scenario):
+    context, certificate = _tls_context(transport.key, tmp_path)
+    calls, receipts, failures = [], [], []
+    if scenario.startswith("conflict"):
+        changed = _post(
+            transport, "submit", _body(content="Intervening stack", operation_id="intervening")
+        )
+        assert changed.status_code == 200
+        assert changed.json()["status"] == "committed"
+
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, *_args):
+            pass
+
+        def do_POST(self):
+            try:
+                body = self.rfile.read(int(self.headers["Content-Length"]))
+                calls.append((self.path, json.loads(body)))
+                response = transport.client.post(
+                    self.path,
+                    content=body,
+                    headers={"Authorization": self.headers["Authorization"]},
+                )
+                assert response.status_code == 200, response.text
+                value = response.json()
+                if value["status"] == "committed":
+                    receipts.append(value["receipt_json"])
+                if len(calls) == 1 and scenario.endswith("drop"):
+                    self.connection.shutdown(socket.SHUT_RDWR)
+                    self.connection.close()
+                    return
+                self.send_response(200)
+                self.send_header("Content-Length", str(len(response.content)))
+                self.end_headers()
+                self.wfile.write(response.content)
+            except Exception as exc:
+                failures.append(f"{type(exc).__name__}: {exc}")
+                self.send_error(500)
+
+    home = tmp_path / "stack-client-home"
+    home.mkdir()
+    (home / "config.json").write_text(
+        json.dumps({"auth": {"user_id": USER_ID, "access_token": transport.token}})
+    )
+    env = {key: value for key, value in os.environ.items() if key != "PYTHONPATH"}
+    env["NAURO_HOME"] = str(home)
+    with HTTPServer(("127.0.0.1", 0), Handler) as server:
+        server.socket = context.wrap_socket(server.socket, server_side=True)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        command = [
+            os.environ["NAURO_CLIENT_PYTHON"],
+            "-c",
+            _CLIENT,
+            f"https://localhost:{server.server_port}",
+            str(certificate),
+            TEST_PROJECT_ID,
+            USER_ID,
+        ]
+
+        def invoke(mode):
+            result = subprocess.run(command + [mode], env=env, capture_output=True, timeout=30)
+            assert failures == []
+            return result
+
+        try:
+            sent = invoke("send")
+            assert sent.returncode == (17 if scenario.endswith("drop") else 0), sent.stderr.decode()
+            if scenario == "conflict_saved":
+                assert json.loads(sent.stdout)["status"] == "revision_conflict_observed"
+                assert json.loads(sent.stdout)["unresolved"] is True
+            before_rows = _scan_table()
+            before_objects = _object_inventory(s3_bucket, f"generations/{TEST_PROJECT_ID}/")
+            recovered = invoke("recover")
+            assert recovered.returncode == 0, recovered.stderr.decode()
+            assert _scan_table() == before_rows
+            assert _object_inventory(s3_bucket, f"generations/{TEST_PROJECT_ID}/") == before_objects
+            if scenario.startswith("conflict"):
+                assert json.loads(recovered.stdout)["status"] == "absent"
+                assert json.loads(recovered.stdout)["unresolved"] is True
+                assert [path for path, _ in calls] == ["/stack/submit", "/stack/lookup"]
+                restored = _post(
+                    transport, "submit", _body(content=BASE_STACK.decode(), operation_id="restore")
+                )
+                assert restored.status_code == 200
+                assert restored.json()["status"] == "committed"
+                recovered = invoke("retry")
+                assert recovered.returncode == 0, recovered.stderr.decode()
+                assert [path for path, _ in calls] == [
+                    "/stack/submit",
+                    "/stack/lookup",
+                    "/stack/lookup",
+                    "/stack/submit",
+                ]
+            else:
+                assert [path for path, _ in calls] == ["/stack/submit", "/stack/lookup"]
+            assert len({json.dumps(body, sort_keys=True) for _, body in calls}) == 1
+            assert json.loads(recovered.stdout)["receipt_json"] == receipts[0]
+            rows = _scan_table()
+            objects = _object_inventory(s3_bucket, f"generations/{TEST_PROJECT_ID}/")
+            count = len(calls)
+            cached = invoke("recover")
+            assert cached.returncode == 0, cached.stderr.decode()
+            assert json.loads(cached.stdout) == json.loads(recovered.stdout)
+            assert len(calls) == count
+            assert _scan_table() == rows
+            assert _object_inventory(s3_bucket, f"generations/{TEST_PROJECT_ID}/") == objects
+        finally:
+            server.shutdown()
+            thread.join(timeout=5)

--- a/packages/nauro/tests/test_stack_responses.py
+++ b/packages/nauro/tests/test_stack_responses.py
@@ -1,0 +1,190 @@
+"""Truthful MCP stack responses through the durable coordinator."""
+
+import json
+from unittest.mock import Mock, call
+
+import pytest
+from filelock import Timeout
+
+from nauro.auth import ActiveUserReadError
+from nauro.mcp import stack_responses as responses
+from nauro.store import stack_records as records
+from nauro.store.stack_contract import StackTransportError, verify_stack_response
+from nauro.store.submission_records import SubmissionRecordError
+from nauro.sync import stack_submission
+from tests.test_stack_submission import OTHER, _body, _prepared, _result, home
+
+__all__ = ["home"]
+
+
+@pytest.mark.parametrize(
+    ("status", "text"),
+    [
+        (
+            "absent",
+            "No receipt was found. This operation remains unresolved; an earlier request may "
+            "still commit. Recovery only checks for a receipt.",
+        ),
+        (
+            "revision_conflict_observed",
+            "This attempt found a revision conflict and made no write. This operation remains "
+            "unresolved; an earlier request may still commit. Recover the original operation. "
+            "Changed content or expected revision requires a new explicit submission.",
+        ),
+        (
+            "expired",
+            "The receipt replay window has expired. This does not prove that no write occurred. "
+            "Do not resend this operation.",
+        ),
+        (
+            "digest_conflict",
+            "This operation identity is bound to a different payload. "
+            "Do not resend this operation with changed content.",
+        ),
+    ],
+)
+def test_noncommit_keeps_exact_evidence_and_truthful_text(home, status, text):
+    record = _prepared("a" * 64)
+    result = _result(record, status)
+    transport = Mock(submit=Mock(return_value=result), lookup=Mock(return_value=result))
+    action = responses.recover_stack if status == "absent" else responses.submit_stack
+    response = action(record.scope, transport)
+    assert response.isError is True
+    assert response.structuredContent == result.model_dump(mode="json")
+    assert response.content[0].text == text
+    assert records.read_stack_submission(record.scope).result == result
+
+
+@pytest.mark.parametrize("status", ["revision_conflict_observed"])
+def test_observation_then_commit_and_cached_receipt(home, status):
+    record = _prepared("a" * 64)
+    body = _body(record)
+    committed = verify_stack_response(json.dumps(body).encode(), record.scope, record.payload_json)
+    transport = Mock(
+        submit=Mock(return_value=_result(record, status)), lookup=Mock(return_value=committed)
+    )
+    assert responses.submit_stack(record.scope, transport).structuredContent["unresolved"] is True
+    response = responses.recover_stack(record.scope, transport)
+    assert response.isError is False
+    assert response.structuredContent == body
+    assert response.content[0].text == (
+        "Stack operation committed. This receipt does not establish current local state."
+    )
+    assert responses.recover_stack(record.scope, transport) == response
+    assert responses.retry_stack(record.scope, transport) == response
+    assert responses.submit_stack(record.scope, transport) == response
+    assert transport.method_calls == [
+        call.submit(
+            records.StackSubmission.model_validate({**record.model_dump(), "phase": "uncertain"})
+        ),
+        call.lookup(
+            records.StackSubmission.model_validate(
+                {**record.model_dump(), "phase": "uncertain", "result": _result(record, status)}
+            )
+        ),
+    ]
+
+
+def test_retry_looks_up_before_sending_exact_saved_identity(home):
+    record = _prepared()
+    sent = []
+
+    def send(saved):
+        sent.append(saved)
+        return _result(record)
+
+    transport = Mock(
+        lookup=Mock(return_value=_result(record, "absent")), submit=Mock(side_effect=send)
+    )
+    response = responses.retry_stack(record.scope, transport)
+    assert response.isError is False
+    assert [event[0] for event in transport.method_calls] == ["lookup", "submit"]
+    assert sent[0].scope == record.scope
+    assert sent[0].payload_json == record.payload_json
+    assert sent[0].payload_digest == record.payload_digest
+    assert sent[0].phase == "uncertain"
+
+
+def test_recovery_never_submits_and_repeat_submit_does_not_resend(home):
+    record = _prepared()
+    transport = Mock(submit=Mock(return_value=_result(record, "revision_conflict_observed")))
+    responses.submit_stack(record.scope, transport)
+    blocked = responses.submit_stack(record.scope, transport)
+    assert blocked.isError is True
+    assert blocked.structuredContent is None
+    transport.lookup.return_value = _result(record, "absent")
+    assert responses.recover_stack(record.scope, transport).structuredContent["unresolved"] is True
+    assert transport.submit.call_count == 1
+    assert transport.lookup.call_count == 1
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [
+        SubmissionRecordError("private record path"),
+        StackTransportError("secret response"),
+        ActiveUserReadError("account detail"),
+        OSError("private path"),
+        Timeout("private lock"),
+    ],
+)
+def test_known_failure_does_not_disclose_or_claim_outcome(home, failure):
+    record = _prepared()
+    transport = Mock(submit=Mock(side_effect=failure))
+    response = responses.submit_stack(record.scope, transport)
+    assert response.isError is True
+    assert response.structuredContent is None
+    assert response.content[0].text == (
+        "Stack operation outcome is unconfirmed. Keep the saved submission "
+        "and recover the original operation when access is available. "
+        "Do not infer that no write occurred."
+    )
+    assert records.read_stack_submission(record.scope).phase == "uncertain"
+    transport.lookup.assert_not_called()
+
+
+def test_failed_receipt_persistence_does_not_render_success(home, monkeypatch):
+    record = _prepared()
+    transport = Mock(submit=Mock(return_value=_result(record)))
+    monkeypatch.setattr(
+        stack_submission, "record_stack_result", Mock(side_effect=OSError("final barrier"))
+    )
+    response = responses.submit_stack(record.scope, transport)
+    assert response.isError is True
+    assert response.structuredContent is None
+    assert records.read_stack_submission(record.scope).phase == "uncertain"
+
+
+def test_invalid_receipt_is_not_rendered(home):
+    record = _prepared()
+    invalid = _result(record).model_copy(update={"receipt_json": "secret invalid evidence"})
+    response = responses.submit_stack(record.scope, Mock(submit=Mock(return_value=invalid)))
+    assert response.isError is True
+    assert response.structuredContent is None
+    assert records.read_stack_submission(record.scope).phase == "uncertain"
+
+
+def test_unknown_programming_failure_propagates(home):
+    record = _prepared()
+    with pytest.raises(TypeError, match="implementation defect"):
+        responses.submit_stack(
+            record.scope, Mock(submit=Mock(side_effect=TypeError("implementation defect")))
+        )
+
+
+def test_actor_change_after_transport_does_not_disclose_receipt(home):
+    record = _prepared()
+    result = _result(record)
+
+    def change_account(saved):
+        (home / "config.json").write_text(
+            json.dumps({"auth": {"user_id": OTHER, "access_token": "synthetic-test-token"}})
+        )
+        return result
+
+    transport = Mock(submit=Mock(side_effect=change_account))
+    response = responses.submit_stack(record.scope, transport)
+    assert response.isError is True
+    assert response.structuredContent is None
+    assert result.receipt_json not in response.content[0].text
+    transport.lookup.assert_not_called()

--- a/packages/nauro/tests/test_stack_submission.py
+++ b/packages/nauro/tests/test_stack_submission.py
@@ -1,0 +1,607 @@
+"""Stack identity durability and nonterminal observation recovery."""
+
+import errno
+import hashlib
+import json
+import stat
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from unittest.mock import Mock
+
+import httpx
+import pytest
+from filelock import SoftFileLock, Timeout
+
+from nauro.store import stack_records as records
+from nauro.store.stack_contract import StackTransportError, stack_payload, verify_stack_response
+from nauro.store.submission_records import (
+    SubmissionActorMismatchError,
+    SubmissionRecordCorruptError,
+    SubmissionRecordError,
+    list_submissions,
+)
+from nauro.sync import stack_submission as submission
+from nauro.sync.stack_transport import HttpStackTransport
+from tests.test_judgment_submission import OTHER, PROJECT, USER, home
+
+__all__ = ["home"]
+GENERATION = "01K00000000000000000000004"
+BASE = "01K00000000000000000000005"
+
+
+def _prepared(expected_revision="a" * 64):
+    return records.prepare_stack_submission(
+        PROJECT, USER, stack_payload("Frozen stack", expected_revision)
+    )
+
+
+def _body(record, status="committed"):
+    result = {
+        "version": 1,
+        "scope": record.scope.model_dump(),
+        "payload_digest": record.payload_digest,
+        "status": status,
+        "unresolved": status in {"absent", "revision_conflict_observed"},
+    }
+    if status == "revision_conflict_observed":
+        result.update(
+            expected_revision=json.loads(record.payload_json)["expected_revision"],
+            current_revision="b" * 64,
+        )
+    if status == "committed":
+        receipt = {
+            "receipt_id": GENERATION,
+            "operation_kind": "update_stack",
+            "operation_id": record.scope.operation_id,
+            "result": "committed",
+            "committed_at": "2026-09-06T00:00:00.000000Z",
+            "artifact_digest": "a" * 64,
+            "generation_id": GENERATION,
+            "target_kind": "curated_stack",
+            "target_id": "stack.md",
+            "details": {
+                "base_generation_id": BASE,
+                "base_manifest_digest": "a" * 64,
+                "base_snapshot_digest": "a" * 64,
+                "previous_revision": json.loads(record.payload_json)["expected_revision"]
+                or "a" * 64,
+                "stack_revision": hashlib.sha256(
+                    json.loads(record.payload_json)["content"].encode()
+                ).hexdigest(),
+                "snapshot_key": f"generations/{PROJECT}/{GENERATION}/snapshot.json",
+                "snapshot_digest": "c" * 64,
+            },
+        }
+        result.update(receipt_json=json.dumps(receipt, sort_keys=True, separators=(",", ":")))
+    return result
+
+
+def _result(record, status="committed"):
+    return verify_stack_response(
+        json.dumps(_body(record, status)).encode(), record.scope, record.payload_json
+    )
+
+
+def test_private_records_and_distinct_new_identities(home):
+    first, second = _prepared(), _prepared()
+    changed = records.prepare_stack_submission(PROJECT, USER, stack_payload("Changed", "a" * 64))
+    assert (
+        len({first.scope.operation_id, second.scope.operation_id, changed.scope.operation_id}) == 3
+    )
+    assert first.payload_json == second.payload_json
+    path = records._record_path(first.scope)
+    assert path.is_relative_to(home / "submission-records" / "stack")
+    assert path.stat().st_mode & 0o777 == 0o600
+    assert records.list_stack_submissions(PROJECT, USER) == (first, second, changed)
+    assert list_submissions(PROJECT, USER) == ()
+
+
+@pytest.mark.parametrize("status", ["revision_conflict_observed"])
+def test_observation_recovers_later_commit_without_resubmit(home, status):
+    record = _prepared("a" * 64)
+    transport = Mock()
+    transport.submit.return_value = _result(record, status)
+    observed = submission.submit_stack(record.scope, transport)
+    assert observed.unresolved is True
+    assert records.read_stack_submission(record.scope).phase == "uncertain"
+    with pytest.raises(submission.StackRecoveryRequiredError):
+        submission.submit_stack(record.scope, transport)
+    transport.lookup.return_value = _result(record)
+    recovered = submission.recover_stack(record.scope, transport)
+    assert recovered == _result(record)
+    assert recovered.unresolved is False
+    assert records.read_stack_submission(record.scope).phase == "resolved"
+    assert submission.recover_stack(record.scope, transport) == recovered
+    transport.submit.assert_called_once()
+    transport.lookup.assert_called_once()
+
+
+def test_explicit_retry_looks_up_first_and_preserves_original_bytes(home):
+    record = _prepared()
+    calls = []
+
+    def lookup(saved):
+        calls.append("lookup")
+        assert saved.payload_json == record.payload_json
+        return _result(record, "absent")
+
+    def send(saved):
+        calls.append("send")
+        assert saved.scope == record.scope
+        assert saved.payload_json == record.payload_json
+        assert saved.payload_digest == record.payload_digest
+        assert records.read_stack_submission(record.scope) == saved
+        assert saved.phase == "uncertain"
+        return _result(record, "revision_conflict_observed")
+
+    result = submission.retry_stack(record.scope, Mock(lookup=lookup, submit=send))
+    assert calls == ["lookup", "send"]
+    assert result.unresolved is True
+
+
+@pytest.mark.parametrize("status", ["committed", "expired", "digest_conflict"])
+def test_retry_never_sends_for_non_absent_lookup(home, status):
+    record = _prepared()
+    transport = Mock(lookup=Mock(return_value=_result(record, status)))
+    assert submission.retry_stack(record.scope, transport) == _result(record, status)
+    transport.submit.assert_not_called()
+
+
+def test_recovery_of_absence_never_sends(home):
+    record = _prepared()
+    transport = Mock(lookup=Mock(return_value=_result(record, "absent")))
+    result = submission.recover_stack(record.scope, transport)
+    assert result.unresolved is True
+    assert result.status == "absent"
+    transport.submit.assert_not_called()
+
+
+@pytest.mark.parametrize("status", ["revision_conflict_observed"])
+def test_lookup_cannot_return_submit_observations(home, status):
+    record = _prepared("a" * 64)
+    transport = Mock(lookup=Mock(return_value=_result(record, status)))
+    with pytest.raises(StackTransportError):
+        submission.retry_stack(record.scope, transport)
+    transport.submit.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "elapsed,allowed",
+    [
+        (timedelta(hours=24), True),
+        (timedelta(hours=24, microseconds=1), False),
+        (timedelta(microseconds=-1), False),
+    ],
+)
+def test_exact_resend_horizon(home, monkeypatch, elapsed, allowed):
+    record = _prepared()
+    now = datetime.now(timezone.utc)
+    created = (now - elapsed).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+    record = records.StackSubmission.model_validate({**record.model_dump(), "created_at": created})
+    records._write(record)
+
+    class Clock:
+        fromisoformat = staticmethod(datetime.fromisoformat)
+
+        @staticmethod
+        def now(tz):
+            return now
+
+    monkeypatch.setattr(submission, "datetime", Clock)
+    transport = Mock(
+        lookup=Mock(return_value=_result(record, "absent")),
+        submit=Mock(return_value=_result(record)),
+    )
+    if allowed:
+        assert submission.retry_stack(record.scope, transport).status == "committed"
+    else:
+        with pytest.raises(submission.StackRetryExpiredError):
+            submission.retry_stack(record.scope, transport)
+        transport.submit.assert_not_called()
+    transport.lookup.assert_called_once()
+
+
+def test_file_barrier_failure_prevents_send(home, monkeypatch):
+    record = _prepared()
+    original = records.os.fsync
+
+    def fail(fd):
+        if stat.S_ISREG(records.os.fstat(fd).st_mode):
+            raise OSError(errno.ENOSPC, "synthetic full disk")
+        original(fd)
+
+    monkeypatch.setattr(records.os, "fsync", fail)
+    transport = Mock()
+    with pytest.raises(OSError) as error:
+        submission.submit_stack(record.scope, transport)
+    assert error.value.errno == errno.ENOSPC
+    transport.submit.assert_not_called()
+    assert records.read_stack_submission(record.scope) == record
+
+
+def test_failed_namespace_barrier_is_repeated_before_network(home, monkeypatch):
+    record = _prepared()
+    original_replace = records.os.replace
+    original_sync = records._directory_sync
+
+    def replace(source, target):
+        original_replace(source, target)
+        monkeypatch.setattr(
+            records, "_directory_sync", Mock(side_effect=OSError(errno.EIO, "sync"))
+        )
+
+    monkeypatch.setattr(records.os, "replace", replace)
+    transport = Mock()
+    with pytest.raises(OSError):
+        submission.submit_stack(record.scope, transport)
+    with pytest.raises(OSError):
+        submission.recover_stack(record.scope, transport)
+    transport.submit.assert_not_called()
+    transport.lookup.assert_not_called()
+    monkeypatch.setattr(records, "_directory_sync", original_sync)
+    monkeypatch.setattr(records.os, "replace", original_replace)
+    transport.lookup.return_value = _result(record, "absent")
+    assert submission.recover_stack(record.scope, transport).status == "absent"
+    transport.submit.assert_not_called()
+
+
+def test_failed_receipt_persistence_leaves_recovery_available(home, monkeypatch):
+    record = _prepared()
+    original = records._write
+
+    def fail(saved):
+        if saved.phase == "resolved":
+            raise OSError(errno.EIO, "receipt persistence")
+        original(saved)
+
+    monkeypatch.setattr(records, "_write", fail)
+    transport = Mock(
+        submit=Mock(return_value=_result(record)), lookup=Mock(return_value=_result(record))
+    )
+    with pytest.raises(OSError):
+        submission.submit_stack(record.scope, transport)
+    assert records.read_stack_submission(record.scope).phase == "uncertain"
+    monkeypatch.setattr(records, "_write", original)
+    assert submission.recover_stack(record.scope, transport).status == "committed"
+    transport.submit.assert_called_once()
+
+
+def test_native_lock_and_corruption_refuse_before_network(home, monkeypatch):
+    record = _prepared()
+    with records.stack_submission_lock(record.scope):
+        with pytest.raises(Timeout):
+            with records.stack_submission_lock(record.scope):
+                pass
+    monkeypatch.setattr(records, "FileLock", SoftFileLock)
+    with pytest.raises(SubmissionRecordError):
+        with records.stack_submission_lock(record.scope):
+            pass
+    path = records._record_path(record.scope)
+    raw = json.loads(path.read_bytes())
+    raw["record"]["payload_json"] = "{}"
+    path.write_text(json.dumps(raw))
+    with pytest.raises(SubmissionRecordCorruptError):
+        records.read_stack_submission(record.scope)
+
+
+def test_restart_recovers_observation_without_send(home):
+    record = _prepared()
+    submission.submit_stack(
+        record.scope, Mock(submit=Mock(return_value=_result(record, "revision_conflict_observed")))
+    )
+    script = """
+import json,sys
+from nauro.store.stack_records import list_stack_submissions
+from nauro.store.stack_contract import verify_stack_response
+from nauro.sync.stack_submission import recover_stack
+record,=list_stack_submissions(sys.argv[1],sys.argv[2])
+class Transport:
+    def submit(self,record): raise AssertionError("recovery submitted")
+    def lookup(self,saved):
+        assert saved == record
+        return verify_stack_response(
+            sys.stdin.buffer.read(),record.scope,record.payload_json,lookup=True)
+result=recover_stack(record.scope,Transport())
+print(result.model_dump_json())
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script, PROJECT, USER],
+        input=json.dumps(_body(record)).encode(),
+        capture_output=True,
+        check=True,
+    )
+    assert json.loads(result.stdout) == _body(record)
+    assert records.read_stack_submission(record.scope).phase == "resolved"
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [("version", True), ("unresolved", 0), ("payload_digest", "0" * 64), ("extra", 1)],
+)
+def test_response_binding_is_strict(home, field, value):
+    record = _prepared()
+    body = _body(record)
+    body[field] = value
+    with pytest.raises(StackTransportError):
+        verify_stack_response(json.dumps(body).encode(), record.scope, record.payload_json)
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("operation_id", "other"),
+        ("target_id", "project.md"),
+        ("target_kind", "decision"),
+        ("generation_id", BASE),
+        ("artifact_digest", "invalid"),
+        ("committed_at", "yesterday"),
+        ("receipt_id", "invalid"),
+    ],
+)
+def test_receipt_fields_are_verified(home, field, value):
+    record = _prepared()
+    body = _body(record)
+    receipt = json.loads(body["receipt_json"])
+    receipt[field] = value
+    body["receipt_json"] = json.dumps(receipt, sort_keys=True, separators=(",", ":"))
+    with pytest.raises(StackTransportError):
+        verify_stack_response(json.dumps(body).encode(), record.scope, record.payload_json)
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("snapshot_key", "other/snapshot.json"),
+        ("previous_revision", "b" * 64),
+        ("stack_revision", "absent"),
+        ("stack_revision", "b" * 64),
+        ("source_revision", "invalid"),
+        ("extra", "x"),
+    ],
+)
+def test_receipt_details_are_closed_and_bound(home, field, value):
+    record = _prepared("a" * 64)
+    body = _body(record)
+    receipt = json.loads(body["receipt_json"])
+    receipt["details"][field] = value
+    body["receipt_json"] = json.dumps(receipt, sort_keys=True, separators=(",", ":"))
+    with pytest.raises(StackTransportError):
+        verify_stack_response(json.dumps(body).encode(), record.scope, record.payload_json)
+
+
+def test_noncanonical_receipt_and_duplicate_response_keys_refuse(home):
+    record = _prepared()
+    body = _body(record)
+    body["receipt_json"] += " "
+    with pytest.raises(StackTransportError):
+        verify_stack_response(json.dumps(body).encode(), record.scope, record.payload_json)
+    duplicate = json.dumps(_body(record))[:-1] + ',"version":1}'
+    with pytest.raises(StackTransportError):
+        verify_stack_response(duplicate.encode(), record.scope, record.payload_json)
+
+
+def test_https_adapter_retains_identity_and_rechecks_account(home):
+    record = _prepared()
+    calls = []
+
+    def handler(request):
+        calls.append(request)
+        assert json.loads(request.content) == {
+            "version": 1,
+            "project_id": PROJECT,
+            "expected_user_id": USER,
+            "operation_id": record.scope.operation_id,
+            "payload_digest": record.payload_digest,
+            "payload_json": record.payload_json,
+        }
+        return httpx.Response(200, json=_body(record, "absent"))
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        transport = HttpStackTransport("https://example.test", client)
+        assert transport.lookup(record).status == "absent"
+        assert str(calls[0].url) == "https://example.test/stack/lookup"
+        (home / "config.json").write_text(
+            json.dumps({"auth": {"user_id": OTHER, "access_token": "other"}})
+        )
+        with pytest.raises(SubmissionActorMismatchError):
+            transport.lookup(record)
+        assert len(calls) == 1
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://example.test",
+        "https://user@example.test",
+        "https://example.test/path",
+        "https://example.test/?q=x",
+    ],
+)
+def test_untrusted_origin_refuses(url):
+    with httpx.Client() as client:
+        with pytest.raises(StackTransportError):
+            HttpStackTransport(url, client)
+
+
+@pytest.mark.parametrize("code", [302, 401, 503])
+def test_http_errors_never_retry_or_redirect(home, code):
+    record = _prepared()
+    calls = []
+
+    def handler(request):
+        calls.append(request)
+        return httpx.Response(code, headers={"Location": "https://other.test"})
+
+    with httpx.Client(transport=httpx.MockTransport(handler), follow_redirects=True) as client:
+        with pytest.raises(StackTransportError):
+            submission.submit_stack(
+                record.scope, HttpStackTransport("https://example.test", client)
+            )
+    assert len(calls) == 1
+    assert records.read_stack_submission(record.scope).phase == "uncertain"
+
+
+def test_durable_send_and_receipt_barriers(home, monkeypatch):
+    record = _prepared()
+    events = []
+    original = records.os.fsync
+
+    def sync(fd):
+        original(fd)
+        events.append("file" if stat.S_ISREG(records.os.fstat(fd).st_mode) else "directory")
+
+    def send(saved):
+        assert events[-2:] == ["file", "directory"]
+        assert records.read_stack_submission(record.scope) == saved
+        events.append("send")
+        return _result(record)
+
+    monkeypatch.setattr(records.os, "fsync", sync)
+    assert submission.submit_stack(record.scope, Mock(submit=send)).status == "committed"
+    assert events[-2:] == ["file", "directory"]
+    assert events.count("send") == 1
+
+
+def test_unreadable_record_is_not_absence(home, monkeypatch):
+    record = _prepared()
+    path = records._record_path(record.scope)
+    original = records.os.open
+
+    def denied(target, flags, *args, **kwargs):
+        if target == path:
+            raise PermissionError(errno.EACCES, "synthetic access refusal")
+        return original(target, flags, *args, **kwargs)
+
+    monkeypatch.setattr(records.os, "open", denied)
+    transport = Mock()
+    with pytest.raises(PermissionError) as error:
+        submission.recover_stack(record.scope, transport)
+    assert error.value.errno == errno.EACCES
+    transport.lookup.assert_not_called()
+    transport.submit.assert_not_called()
+
+
+def test_changed_account_during_response_retains_uncertain_record(home):
+    record = _prepared()
+
+    def handler(request):
+        (home / "config.json").write_text(
+            json.dumps({"auth": {"user_id": OTHER, "access_token": "other"}})
+        )
+        return httpx.Response(200, json=_body(record))
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        with pytest.raises(SubmissionActorMismatchError):
+            submission.submit_stack(
+                record.scope, HttpStackTransport("https://example.test", client)
+            )
+    (home / "config.json").write_text(
+        json.dumps({"auth": {"user_id": USER, "access_token": "synthetic-test-token"}})
+    )
+    assert records.read_stack_submission(record.scope).phase == "uncertain"
+
+
+def test_response_size_limit_retains_uncertainty(home):
+    record = _prepared()
+    with httpx.Client(
+        transport=httpx.MockTransport(
+            lambda request: httpx.Response(200, content=b" " * (64 * 1024 + 1))
+        )
+    ) as client:
+        with pytest.raises(StackTransportError):
+            submission.submit_stack(
+                record.scope, HttpStackTransport("https://example.test", client)
+            )
+    assert records.read_stack_submission(record.scope).phase == "uncertain"
+
+
+def test_invalid_payload_cannot_create_saved_identity(home):
+    with pytest.raises(ValueError):
+        records.prepare_stack_submission(
+            PROJECT, USER, b' {"delta":"x","expected_revision":null,"operation":"update_stack"}'
+        )
+    assert records.list_stack_submissions(PROJECT, USER) == ()
+
+
+def test_resolved_record_cannot_be_reopened(home):
+    record = _prepared()
+    submission.submit_stack(record.scope, Mock(submit=Mock(return_value=_result(record))))
+    saved = records.read_stack_submission(record.scope)
+    with pytest.raises(SubmissionRecordError):
+        records.mark_stack_uncertain(saved)
+    with pytest.raises(SubmissionRecordError):
+        records.record_stack_result(saved, _result(record, "absent"))
+
+
+def test_stack_modules_have_no_production_consumers():
+    import ast
+    from pathlib import Path
+
+    root = Path(__file__).parents[1] / "src" / "nauro"
+    modules = {
+        "nauro.mcp.stack_responses",
+        "nauro.store.stack_contract",
+        "nauro.store.stack_records",
+        "nauro.sync.stack_submission",
+        "nauro.sync.stack_transport",
+    }
+    found = []
+    for path in root.rglob("*.py"):
+        own = "nauro." + ".".join(path.relative_to(root).with_suffix("").parts)
+        if own in modules:
+            continue
+        for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
+            if isinstance(node, ast.Import):
+                imports = {alias.name for alias in node.names}
+            elif isinstance(node, ast.ImportFrom):
+                imports = {node.module} | {f"{node.module}.{alias.name}" for alias in node.names}
+            else:
+                continue
+            if imports & modules:
+                found.append(str(path.relative_to(root)))
+    assert found == []
+
+
+@pytest.mark.parametrize("content", ["\x01" * 40000, "😀" * 40000], ids=["escaped", "unicode"])
+def test_maximum_payload_round_trips_private_record(home, content):
+    record = records.prepare_stack_submission(PROJECT, USER, stack_payload(content, "a" * 64))
+    assert records.read_stack_submission(record.scope) == record
+    assert json.loads(record.payload_json)["content"] == content
+
+
+def test_revision_change_requires_distinct_preparation(home):
+    first = _prepared(None)
+    second = _prepared("a" * 64)
+    assert first.scope.operation_id != second.scope.operation_id
+    assert first.payload_json != second.payload_json
+    assert json.loads(first.payload_json)["expected_revision"] is None
+
+
+def test_discovery_is_separate_from_other_families(home):
+    from nauro.store.question_records import list_question_submissions
+    from nauro.store.state_records import list_state_submissions
+
+    record = _prepared()
+    assert list_question_submissions(PROJECT, USER) == ()
+    assert list_state_submissions(PROJECT, USER) == ()
+    assert records.list_stack_submissions(PROJECT, USER) == (record,)
+
+
+@pytest.mark.parametrize(
+    "field,value", [("project_id", OTHER), ("user_id", OTHER), ("operation_id", "other")]
+)
+def test_response_scope_is_bound(home, field, value):
+    record = _prepared()
+    body = _body(record)
+    body["scope"][field] = value
+    with pytest.raises(StackTransportError):
+        verify_stack_response(json.dumps(body).encode(), record.scope, record.payload_json)
+
+
+def test_stack_has_no_noop_observation(home):
+    record = _prepared()
+    body = _body(record, "absent")
+    body["status"] = "noop_observed"
+    with pytest.raises(StackTransportError):
+        verify_stack_response(json.dumps(body).encode(), record.scope, record.payload_json)

--- a/packages/nauro/tests/test_stack_transport_pair.py
+++ b/packages/nauro/tests/test_stack_transport_pair.py
@@ -1,0 +1,47 @@
+"""Installed client TLS conformance against the paired server source."""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.parametrize("scenario", ["commit_drop", "conflict_drop", "conflict_saved"])
+def test_paired_stack_transport(scenario):
+    interpreter = os.environ.get("NAURO_SERVER_PYTHON")
+    source = os.environ.get("NAURO_SERVER_ROOT")
+    if not interpreter or not source:
+        pytest.skip("Set NAURO_SERVER_PYTHON and NAURO_SERVER_ROOT for paired stack transport.")
+    root = Path(source).resolve()
+    probe = Path(__file__).parent / "fixtures" / "stack_transport_server.py"
+    env = {
+        **os.environ,
+        "PYTHONPATH": os.pathsep.join([str(root / "src"), str(root)]),
+        "NAURO_CLIENT_PYTHON": sys.executable,
+        "AWS_DEFAULT_REGION": "us-east-1",
+    }
+    result = subprocess.run(
+        [
+            interpreter,
+            "-m",
+            "pytest",
+            "-q",
+            "--noconftest",
+            "-c",
+            str(root / "pyproject.toml"),
+            "-p",
+            "tests.conftest",
+            f"{probe}::test_stack_client_restart_over_tls[{scenario}]",
+            "--tb=short",
+        ],
+        cwd=root,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "1 passed" in result.stdout
+    assert "skipped" not in result.stdout


### PR DESCRIPTION
## Why

Stack operations need durable identities and verified recovery after a lost response or client restart. Revision conflicts must remain unresolved because an older request can still commit.

## What changed

Add dormant canonical payload and receipt verification, private durable records, HTTPS transport, explicit submit/recover/retry coordination and MCP response adapters. Bind receipt revisions to exact submitted content and any supplied precondition. Recovery only looks up the original operation. Explicit retry requires a fresh absent lookup within the resend horizon and preserves the original identity and bytes.

Depends on the server transport merged in Nauro-AI/mcp-server#199. Add real TLS/process restart tests and include all five modules in CI typing and the production-consumer guard.

## Test plan

211 selected client tests passed on Python 3.12. All 76 stack tests passed on Python 3.10. Both include three explicit paired TLS scenarios with zero skips. All 236 selected server tests passed with all 13 cross-repository checks enabled. Full lint/formatting, all 38 typing targets and unchanged risk and consumer gates passed.

## Risk / what to review

Review receipt/content binding, durable uncertainty before send, lookup-only recovery and errors after failed persistence or account changes. A null revision remains an unconditional pre-team request. Historical receipts do not establish current local replica state.

## Deferred

Concurrent writing remains incomplete. Production registration, public MCP identity, automatic cloud retries, remaining mutation families and activation are unchanged.
