### PR TITLE
Clarify read-only project frames in generation stores

### DIFF
--- a/packages/nauro/src/nauro/store/generation_store.py
+++ b/packages/nauro/src/nauro/store/generation_store.py
@@ -4,7 +4,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass, field
 from types import MappingProxyType
 
-from nauro_core.constants import DECISIONS_DIR
+from nauro_core.constants import DECISIONS_DIR, PROJECT_MD
 from nauro_core.protected_generation_membership import (
     InvalidGenerationPath,
     validate_protected_generation_path,
@@ -18,6 +18,12 @@ from nauro.store.generation_projection import (
 )
 from nauro.store.generation_read import read_installed_generation
 from nauro.store.resolution import ResolvedProjectBinding
+
+_PROJECT_FRAME_READ_ONLY = (
+    "project.md is read-only for generation projects. Preserve local edits in a separate "
+    "quarantine directory outside the replica and sync roots. Do not copy them into the "
+    "active generation or upload them through raw sync."
+)
 
 
 class GenerationStoreReadOnlyError(GenerationAuthorityError):
@@ -56,9 +62,13 @@ class GenerationSnapshotStore:
         return self._contents.get(canonical)
 
     def write_file(self, path: str, content: str) -> None:
+        if path == PROJECT_MD:
+            raise GenerationStoreReadOnlyError(_PROJECT_FRAME_READ_ONLY)
         raise GenerationStoreReadOnlyError("Generation snapshots do not permit file writes.")
 
     def delete_file(self, path: str) -> None:
+        if path == PROJECT_MD:
+            raise GenerationStoreReadOnlyError(_PROJECT_FRAME_READ_ONLY)
         raise GenerationStoreReadOnlyError("Generation snapshots do not permit file deletion.")
 
     def list_decisions(self) -> list[str]:

--- a/packages/nauro/tests/test_generation_reads.py
+++ b/packages/nauro/tests/test_generation_reads.py
@@ -26,6 +26,7 @@ CASES = [
     ("get_decision", (1,), {}),
     ("get_decision", (1, "header"), {}),
     ("get_raw_file", ("state.md",), {}),
+    ("get_raw_file", ("project.md",), {}),
     ("list_decisions", (), {"limit": 1, "include_superseded": True}),
     ("search_decisions", ("durability",), {"limit": 1, "include_superseded": True}),
     ("check_decision", ("Use durability barriers", "interrupted refresh"), {}),
@@ -298,3 +299,17 @@ def test_corrupt_installed_bytes_refuse_before_rendering(admitted, monkeypatch):
     with pytest.raises(GenerationProjectionVerificationError) as raised:
         reads.get_raw_file(binding, "state.md", actor=USER_ID)
     assert raised.value.code == "generation_verification_failed"
+
+
+@POSIX
+def test_project_frame_read_preserves_unpublished_flat_edits(admitted):
+    binding, current, _ = admitted
+    edited = b"# Project\n\nUnpublished local scope changes.\n"
+    flat = binding.store_path / "project.md"
+    flat.write_bytes(edited)
+    expected = operations.get_raw_file(GenerationSnapshotStore(current[0]), "project.md")
+    response = reads.get_raw_file(binding, "project.md", actor=USER_ID)
+    assert response.result == expected
+    assert response.projection == current[0].target.identity
+    assert flat.read_bytes() == edited
+    assert "Unpublished" not in repr(response)

--- a/packages/nauro/tests/test_generation_store.py
+++ b/packages/nauro/tests/test_generation_store.py
@@ -143,3 +143,20 @@ def test_store_has_only_dormant_generation_consumers():
                     if alias.name == "nauro.store.generation_store"
                 )
     assert sorted(consumers) == ["mcp/generation_reads.py", "sync/generation_refresh.py"]
+
+
+def test_project_frame_refusal_preserves_bytes_and_gives_quarantine_guidance():
+    content = b"# Project\n\nOriginal scope.\n"
+    store = GenerationSnapshotStore(_projection({"project.md": content}))
+    message = (
+        "project.md is read-only for generation projects. Preserve local edits in a separate "
+        "quarantine directory outside the replica and sync roots. Do not copy them into the "
+        "active generation or upload them through raw sync."
+    )
+    with pytest.raises(GenerationStoreReadOnlyError) as write:
+        store.write_file("project.md", "Changed scope")
+    with pytest.raises(GenerationStoreReadOnlyError) as delete:
+        store.delete_file("project.md")
+    assert str(write.value) == str(delete.value) == message
+    assert write.value.code == delete.value.code == "generation_store_read_only"
+    assert store.read_file("project.md").encode() == content

--- a/packages/nauro/tests/test_read_dispatch.py
+++ b/packages/nauro/tests/test_read_dispatch.py
@@ -23,6 +23,7 @@ CASES = [("get_context", {"level": level}) for level in ("L0", "L1", "L2")] + [
     ("get_decision", {"number": 1, "mode": "full"}),
     ("get_decision", {"number": 1, "mode": "header"}),
     ("get_raw_file", {"path": "state.md"}),
+    ("get_raw_file", {"path": "project.md"}),
     ("list_decisions", {"limit": 1, "include_superseded": True}),
     ("search_decisions", {"query": "durability", "limit": 1}),
     ("check_decision", {"proposed_approach": "durability", "context": "refresh"}),


### PR DESCRIPTION
## Why

Generation snapshots already refuse writes, but project.md needs explicit guidance for preserving local edits under the read-only project frame policy.

## What changed

Add a project-specific write/delete refusal that directs callers to preserve edits outside replica and sync roots. Keep the existing error code. Extend raw-read coverage to project.md and verify that flat edits stay unchanged while reads use the selected generation.

## Test plan

222 selected tests passed on Python 3.12 and 3.10. All 19 cross-repository checks passed explicitly with zero skips. All 43 typing targets, full lint/formatting and unchanged quality gates passed.

## Deferred

This dormant prerequisite does not activate migration or production routing, move files into quarantine, or add a project-frame write route. Concurrent writing remains incomplete; production activation is unchanged.
