### PR TITLE
Add opt-in decision reference delivery to the CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
           packages/nauro/src/nauro/sync/decision_reference.py
           packages/nauro/src/nauro/sync/decision_reference_contract.py
           packages/nauro/src/nauro/mcp/decision_reference.py
+          packages/nauro/src/nauro/cli/decision_reference.py
           scripts/controlled_decision_reference.py
           packages/nauro/src/nauro/auth.py
           packages/nauro/src/nauro/sync/merge.py

--- a/integration/test_decision_reference_cli_server.py
+++ b/integration/test_decision_reference_cli_server.py
@@ -1,0 +1,148 @@
+import json
+
+import httpx
+import pytest
+from mcp_server.generations import read_generation_pointer
+from nauro.cli import decision_reference as reference
+from nauro.cli.main import app
+from tests.conftest import TEST_PROJECT_ID
+from tests.test_decision_reference import ORIGIN, probe, signed_transport
+from tests.test_judgment_planning import USER_ID
+from typer.testing import CliRunner
+
+__all__ = ["probe", "signed_transport"]
+
+
+@pytest.fixture
+def cli(probe, tmp_path, monkeypatch):
+    credentials = tmp_path / "credentials.json"
+    credentials.write_text(
+        json.dumps({"user_id": USER_ID, "access_token": probe.headers["Authorization"][7:]})
+    )
+    credentials.chmod(0o600)
+    profile = tmp_path / "profile.json"
+    profile.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "endpoint": ORIGIN + "/mcp",
+                "project_id": TEST_PROJECT_ID,
+                "actor_id": USER_ID,
+                "credentials_file": str(credentials),
+            }
+        )
+    )
+    profile.chmod(0o600)
+    control = {"lose": None, "calls": []}
+
+    def wire(request):
+        body = json.loads(request.content)
+        response = probe.request(
+            request.method,
+            str(request.url),
+            content=request.content,
+            headers=dict(request.headers),
+        )
+        if body["method"] == "tools/call":
+            assert response.status_code == 200, response.text
+            assert "error" not in response.json(), response.text
+            mode = body["params"]["arguments"].get("request_mode", "prepare")
+            control["calls"].append(mode)
+            if mode == control["lose"]:
+                raise httpx.ReadError("lost", request=request)
+        return response
+
+    monkeypatch.setattr(
+        reference, "reference_client", lambda: httpx.Client(transport=httpx.MockTransport(wire))
+    )
+
+    def invoke(*arguments):
+        return CliRunner().invoke(
+            app, ["propose-decision", "--reference-profile", str(profile), *arguments]
+        )
+
+    return invoke, control
+
+
+def selected(invoke, saved, mode):
+    return invoke(
+        "--request-mode",
+        mode,
+        "--operation-id",
+        saved["request"]["operation_id"],
+        "--payload-digest",
+        saved["request"]["payload_digest"],
+    )
+
+
+@pytest.mark.parametrize("lost_mode", ["prepare", "submit"])
+def test_cli_discovers_and_recovers_lost_response_without_resend(cli, lost_mode):
+    invoke, control = cli
+    if lost_mode == "submit":
+        prepared = invoke(
+            "Preserve request identity across interrupted command execution.",
+            "--title",
+            "CLI decision",
+        )
+        assert prepared.exit_code == 0, (prepared.output, prepared.exception)
+        saved = json.loads(prepared.stdout)
+        control["lose"] = "submit"
+        failed = selected(invoke, saved, "submit")
+    else:
+        control["lose"] = "prepare"
+        failed = invoke(
+            "Preserve request identity across interrupted command execution.",
+            "--title",
+            "CLI decision",
+        )
+    assert failed.exit_code == 1
+    control["lose"] = None
+    discovery = invoke("--request-mode", "discover")
+    assert discovery.exit_code == 0, discovery.output
+    found = json.loads(discovery.stdout)["requests"]
+    assert len(found) == 1
+    recovered = selected(invoke, found[0], "recover")
+    assert recovered.exit_code == 0, recovered.output
+    assert json.loads(recovered.stdout) == found[0]
+    assert found[0]["status"] == ("committed" if lost_mode == "submit" else "prepared")
+    assert control["calls"] == (
+        ["prepare", "submit", "discover", "recover"]
+        if lost_mode == "submit"
+        else ["prepare", "discover", "recover"]
+    )
+    assert read_generation_pointer(TEST_PROJECT_ID).decision_counter == (
+        1 if lost_mode == "submit" else 0
+    )
+
+
+def test_cli_stale_requires_new_reference_and_repeated_submit_replays(cli):
+    invoke, _ = cli
+    drafts = []
+    for title in ["First CLI decision", "Second CLI decision"]:
+        result = invoke(
+            "Preserve request identity across interrupted command execution.",
+            "--title",
+            title,
+        )
+        assert result.exit_code == 0, result.output
+        drafts.append(json.loads(result.stdout))
+    winner = selected(invoke, drafts[0], "submit")
+    assert winner.exit_code == 0, winner.output
+    assert json.loads(winner.stdout)["status"] == "committed"
+    repeat = selected(invoke, drafts[0], "submit")
+    assert repeat.exit_code == 0
+    assert repeat.stdout == winner.stdout
+    stale = selected(invoke, drafts[1], "submit")
+    assert stale.exit_code == 0
+    assert json.loads(stale.stdout)["status"] == "stale"
+    fresh = invoke(
+        "Preserve request identity across interrupted command execution.",
+        "--title",
+        "Second CLI decision",
+    )
+    assert fresh.exit_code == 0
+    saved = json.loads(fresh.stdout)
+    assert saved["request"]["operation_id"] != drafts[1]["request"]["operation_id"]
+    assert saved["effective_draft"]["base_decision_counter"] == 1
+    assert selected(invoke, saved, "submit").exit_code == 0
+    assert read_generation_pointer(TEST_PROJECT_ID).decision_counter == 2

--- a/packages/nauro/src/nauro/cli/autogen.py
+++ b/packages/nauro/src/nauro/cli/autogen.py
@@ -519,4 +519,8 @@ def register_autogen_commands(app: typer.Typer) -> None:
             continue
         command_name = _command_name(spec["name"])
         callback = _make_command(spec)
+        if spec["name"] == "propose_decision":
+            from nauro.cli.decision_reference import with_reference_options
+
+            callback = with_reference_options(callback, spec)
         app.command(name=command_name, help=spec["description"].split("\n\n", 1)[0])(callback)

--- a/packages/nauro/src/nauro/cli/decision_reference.py
+++ b/packages/nauro/src/nauro/cli/decision_reference.py
@@ -1,0 +1,179 @@
+"""Explicit prepared-reference delivery for the existing decision command."""
+
+from __future__ import annotations
+
+import enum
+import inspect
+import json
+import os
+import stat
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, Literal
+
+import httpx
+import typer
+from nauro_core.mcp_tools import ToolSpec
+from pydantic import BaseModel, ConfigDict
+
+from nauro.auth import ActiveCredentials
+from nauro.cli._json_input import parse_json_list_of_dicts
+from nauro.sync.decision_reference import DecisionReferenceError, DecisionReferenceTransport
+from nauro.sync.decision_reference_contract import _json, validate_arguments
+
+
+class ReferenceProfile(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    version: Literal[1]
+    endpoint: str
+    project_id: str
+    actor_id: str
+    credentials_file: str
+
+
+class ReferenceCredentials(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    user_id: str
+    access_token: str
+
+
+class RequestMode(str, enum.Enum):
+    prepare = "prepare"
+    submit = "submit"
+    discover = "discover"
+    recover = "recover"
+    retry = "retry"
+
+
+def _private_json(path: Path) -> Any:
+    fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK)
+    with os.fdopen(fd, "rb") as stream:
+        info = os.fstat(stream.fileno())
+        if not stat.S_ISREG(info.st_mode) or info.st_uid != os.getuid() or info.st_mode & 0o077:
+            raise ValueError("Use an owner-only regular file")
+        raw = stream.read(65537)
+        if len(raw) > 65536:
+            raise ValueError("File exceeds size limit")
+        return _json(raw)
+
+
+def _credentials(path: Path) -> ActiveCredentials:
+    record = ReferenceCredentials.model_validate(_private_json(path))
+    if not record.user_id or not record.access_token:
+        raise ValueError("Missing credentials")
+    return ActiveCredentials(record.user_id, record.access_token)
+
+
+def reference_client() -> httpx.Client:
+    return httpx.Client()
+
+
+def _execute(profile: ReferenceProfile, request: dict[str, Any]) -> dict[str, Any]:
+    with reference_client() as client:
+        transport = DecisionReferenceTransport(
+            profile.endpoint,
+            profile.project_id,
+            profile.actor_id,
+            client,
+            lambda: _credentials(Path(profile.credentials_file)),
+        )
+        return transport.propose_decision(**request)
+
+
+def _reference_call(
+    path: Path, kwargs: dict[str, Any], spec: ToolSpec, context: typer.Context
+) -> None:
+    if kwargs["project"] is not None or kwargs["output_format"].value != "json":
+        raise typer.BadParameter("Reference delivery uses the profile project and JSON output")
+    try:
+        profile = ReferenceProfile.model_validate(_private_json(path))
+        if not Path(profile.credentials_file).is_absolute():
+            raise ValueError("Credentials path must be absolute")
+    except (ValueError, OSError):
+        raise typer.BadParameter("Invalid reference profile; use an owner-only file") from None
+    request: dict[str, Any] = {"project_id": profile.project_id}
+    names = set(spec["input_schema"]["properties"]) - {"project_id", "cwd"}
+    names.update({"request_mode", "operation_id", "payload_digest", "after"})
+    for name in names:
+        value = kwargs.get(name)
+        source = context.get_parameter_source(name)
+        if source is None or source.name == "DEFAULT" or value is None:
+            continue
+        if isinstance(value, enum.Enum):
+            value = value.value
+        if name == "rejected":
+            value = parse_json_list_of_dicts(value, "--rejected")
+        request[name] = value
+    try:
+        validate_arguments(request, profile.project_id)
+    except ValueError:
+        raise typer.BadParameter(
+            "Invalid reference arguments for the selected request mode"
+        ) from None
+    try:
+        result = _execute(profile, request)
+    except (DecisionReferenceError, ValueError, OSError):
+        typer.echo(
+            "No verified result. Use discover or recover with this profile. No retry was sent.",
+            err=True,
+        )
+        raise typer.Exit(1) from None
+    typer.echo(json.dumps(result, indent=2))
+
+
+def with_reference_options(command: Callable[..., None], spec: ToolSpec) -> Callable[..., None]:
+    signature = inspect.signature(command)
+    params = [
+        param.replace(default=typer.Argument(None, help="Decision rationale."))
+        if param.name == "rationale"
+        else param
+        for param in signature.parameters.values()
+    ]
+    params.append(
+        inspect.Parameter(
+            "context",
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            annotation=typer.Context,
+            default=None,
+        )
+    )
+    options = [
+        ("reference_profile", Path, "Explicit operator profile for prepared-reference delivery."),
+        (
+            "request_mode",
+            RequestMode,
+            "Reference mode; defaults to prepare. Approve its effective draft before submit.",
+        ),
+        ("operation_id", str, "Saved request reference, not a newly generated identity."),
+        ("payload_digest", str, "Digest returned with the saved request."),
+        ("after", str, "Discovery cursor returned by the server."),
+    ]
+    params.extend(
+        inspect.Parameter(
+            name,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            annotation=annotation,
+            default=typer.Option(None, "--" + name.replace("_", "-"), help=help_text),
+        )
+        for name, annotation, help_text in options
+    )
+
+    def dispatch(**kwargs: Any) -> None:
+        context = kwargs.pop("context")
+        profile = kwargs.pop("reference_profile")
+        if profile is not None:
+            _reference_call(profile, kwargs, spec, context)
+            return
+        reference_values = [kwargs.pop(name) for name, _, _ in options[1:]]
+        if any(value is not None for value in reference_values):
+            raise typer.BadParameter("Reference modes require --reference-profile")
+        if kwargs.get("rationale") is None:
+            raise typer.BadParameter("Missing argument RATIONALE")
+        command(**kwargs)
+
+    dispatch.__signature__ = inspect.Signature(parameters=params)  # type: ignore[attr-defined]
+    dispatch.__name__ = command.__name__
+    dispatch.__doc__ = command.__doc__
+    return dispatch

--- a/packages/nauro/src/nauro/cli/decision_reference.py
+++ b/packages/nauro/src/nauro/cli/decision_reference.py
@@ -48,6 +48,8 @@ class RequestMode(str, enum.Enum):
 
 
 def _private_json(path: Path) -> Any:
+    if not all(hasattr(os, name) for name in ("O_NOFOLLOW", "O_NONBLOCK", "getuid")):
+        raise ValueError("Private reference files are unsupported on this platform")
     fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK)
     with os.fdopen(fd, "rb") as stream:
         info = os.fstat(stream.fileno())

--- a/packages/nauro/tests/snapshots/public_contract_v1.json
+++ b/packages/nauro/tests/snapshots/public_contract_v1.json
@@ -1020,6 +1020,15 @@
             "type": "text"
           },
           {
+            "flags": [
+              "--after"
+            ],
+            "kind": "option",
+            "name": "after",
+            "required": false,
+            "type": "text"
+          },
+          {
             "choices": [
               "high",
               "low",
@@ -1088,6 +1097,15 @@
             "type": "choice"
           },
           {
+            "flags": [
+              "--operation-id"
+            ],
+            "kind": "option",
+            "name": "operation_id",
+            "required": false,
+            "type": "text"
+          },
+          {
             "choices": [
               "json",
               "text"
@@ -1103,6 +1121,15 @@
           },
           {
             "flags": [
+              "--payload-digest"
+            ],
+            "kind": "option",
+            "name": "payload_digest",
+            "required": false,
+            "type": "text"
+          },
+          {
+            "flags": [
               "--project"
             ],
             "kind": "option",
@@ -1113,8 +1140,17 @@
           {
             "kind": "argument",
             "name": "rationale",
-            "required": true,
+            "required": false,
             "type": "text"
+          },
+          {
+            "flags": [
+              "--reference-profile"
+            ],
+            "kind": "option",
+            "name": "reference_profile",
+            "required": false,
+            "type": "path"
           },
           {
             "flags": [
@@ -1124,6 +1160,22 @@
             "name": "rejected",
             "required": false,
             "type": "text"
+          },
+          {
+            "choices": [
+              "discover",
+              "prepare",
+              "recover",
+              "retry",
+              "submit"
+            ],
+            "flags": [
+              "--request-mode"
+            ],
+            "kind": "option",
+            "name": "request_mode",
+            "required": false,
+            "type": "choice"
           },
           {
             "flags": [

--- a/packages/nauro/tests/test_decision_reference_cli.py
+++ b/packages/nauro/tests/test_decision_reference_cli.py
@@ -1,0 +1,174 @@
+import json
+
+import pytest
+from typer.testing import CliRunner
+
+from nauro.cli import autogen
+from nauro.cli import decision_reference as reference
+from nauro.cli.main import app
+from nauro.sync.decision_reference import DecisionReferenceError
+
+PROJECT = "01KQ6AZGNA0B3QBF67NBXP3S45"
+ACTOR = "01K" + "0" * 21 + "08"
+REFERENCE = "decision-request:" + "01K" + "0" * 21 + "09"
+
+
+@pytest.fixture
+def configured(tmp_path, monkeypatch):
+    monkeypatch.setenv("NAURO_HOME", str(tmp_path / "home"))
+    credentials = tmp_path / "credentials.json"
+    credentials.write_text(json.dumps({"user_id": ACTOR, "access_token": "synthetic"}))
+    credentials.chmod(0o600)
+    path = tmp_path / "profile.json"
+    path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "endpoint": "https://probe.example/mcp",
+                "project_id": PROJECT,
+                "actor_id": ACTOR,
+                "credentials_file": str(credentials),
+            }
+        )
+    )
+    path.chmod(0o600)
+    monkeypatch.setattr(
+        autogen, "resolve_target_project", lambda *_: pytest.fail("Local resolution")
+    )
+    return path, credentials
+
+
+def invoke(path, *arguments):
+    return CliRunner().invoke(
+        app, ["propose-decision", "--reference-profile", str(path), *arguments]
+    )
+
+
+def test_prepare_preserves_explicit_content_and_omits_cli_defaults(configured, monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        reference, "_execute", lambda profile, request: calls.append(request) or {"saved": True}
+    )
+    result = invoke(
+        configured[0], "Approved rationale", "--title", "Draft", "--confidence", "medium"
+    )
+    assert result.exit_code == 0, result.output
+    assert calls == [
+        {
+            "project_id": PROJECT,
+            "rationale": "Approved rationale",
+            "title": "Draft",
+            "confidence": "medium",
+        }
+    ]
+    assert json.loads(result.stdout) == {"saved": True}
+
+
+@pytest.mark.parametrize("mode", ["submit", "recover", "retry"])
+def test_reference_only_modes_do_not_receive_default_content(configured, monkeypatch, mode):
+    calls = []
+    monkeypatch.setattr(reference, "_execute", lambda profile, request: calls.append(request) or {})
+    result = invoke(
+        configured[0],
+        "--request-mode",
+        mode,
+        "--operation-id",
+        REFERENCE,
+        "--payload-digest",
+        "0" * 64,
+    )
+    assert result.exit_code == 0, result.output
+    assert calls == [
+        {
+            "project_id": PROJECT,
+            "request_mode": mode,
+            "operation_id": REFERENCE,
+            "payload_digest": "0" * 64,
+        }
+    ]
+
+
+def test_discovery_cursor_is_forwarded(configured, monkeypatch):
+    calls = []
+    monkeypatch.setattr(reference, "_execute", lambda profile, request: calls.append(request) or {})
+    result = invoke(configured[0], "--request-mode", "discover", "--after", "opaque")
+    assert result.exit_code == 0, result.output
+    assert calls == [{"project_id": PROJECT, "request_mode": "discover", "after": "opaque"}]
+
+
+@pytest.mark.parametrize(
+    "extra",
+    [
+        ["changed"],
+        ["--title", ""],
+        ["--operation", "add"],
+        ["--project", "other"],
+        ["--format", "text"],
+    ],
+)
+def test_reference_rejects_content_and_local_selectors_before_execution(
+    configured, monkeypatch, extra
+):
+    monkeypatch.setattr(reference, "_execute", lambda *_: pytest.fail("Execution"))
+    result = invoke(
+        configured[0],
+        "--request-mode",
+        "recover",
+        "--operation-id",
+        REFERENCE,
+        "--payload-digest",
+        "0" * 64,
+        *extra,
+    )
+    assert result.exit_code == 2
+
+
+def test_transport_failure_never_falls_back_or_retries(configured, monkeypatch):
+    calls = []
+
+    def fail(*args):
+        calls.append(args)
+        raise DecisionReferenceError("sensitive internal value")
+
+    monkeypatch.setattr(reference, "_execute", fail)
+    result = invoke(configured[0], "--request-mode", "discover")
+    assert result.exit_code == 1
+    assert len(calls) == 1
+    assert "sensitive internal value" not in result.output
+    assert "No retry was sent" in result.output
+
+
+@pytest.mark.parametrize(
+    "change", ["permissions", "symlink", "unknown", "duplicate", "relative_credentials"]
+)
+def test_invalid_profile_fails_before_execution(configured, monkeypatch, change):
+    path, _ = configured
+    monkeypatch.setattr(reference, "_execute", lambda *_: pytest.fail("Execution"))
+    if change == "permissions":
+        path.chmod(0o644)
+    elif change == "symlink":
+        target = path.with_name("target.json")
+        path.rename(target)
+        path.symlink_to(target)
+    elif change == "duplicate":
+        path.write_text('{"version":1,"version":1}')
+    else:
+        value = json.loads(path.read_text())
+        value["extra" if change == "unknown" else "credentials_file"] = "relative"
+        path.write_text(json.dumps(value))
+    assert invoke(path, "--request-mode", "discover").exit_code == 2
+
+
+def test_reference_mode_without_profile_refuses_local_dispatch(configured):
+    result = CliRunner().invoke(app, ["propose-decision", "--request-mode", "discover"])
+    assert result.exit_code == 2
+
+
+def test_credentials_are_reloaded_and_private(configured):
+    _, path = configured
+    assert reference._credentials(path).access_token == "synthetic"
+    path.write_text(json.dumps({"user_id": ACTOR, "access_token": "replacement"}))
+    assert reference._credentials(path).access_token == "replacement"
+    path.chmod(0o644)
+    with pytest.raises(ValueError, match="owner-only"):
+        reference._credentials(path)

--- a/packages/nauro/tests/test_decision_reference_cli.py
+++ b/packages/nauro/tests/test_decision_reference_cli.py
@@ -172,3 +172,10 @@ def test_credentials_are_reloaded_and_private(configured):
     path.chmod(0o644)
     with pytest.raises(ValueError, match="owner-only"):
         reference._credentials(path)
+
+
+def test_unsupported_platform_refuses_before_open(configured, monkeypatch):
+    monkeypatch.delattr(reference.os, "O_NOFOLLOW")
+    with pytest.raises(ValueError, match="unsupported on this platform"):
+        reference._private_json(configured[0])
+    assert invoke(configured[0], "--request-mode", "discover").exit_code == 2


### PR DESCRIPTION
## Why

The existing decision command cannot use the prepared-reference transport without a separate driver. Add an explicit opt-in path while preserving its default local behavior.

## What changed

- Add an operator-selected profile and preparation, submission, discovery, recovery and explicit retry modes to `nauro propose-decision`.
- Reuse strict request and receipt verification. Reference-only calls reject content changes; failures never fall back to local writes or resend automatically.
- Read dedicated credentials from private files and refuse platforms without the required file-safety primitives. Update the CLI contract snapshot and typing checks.

## Test plan

102 client and consumer-contract tests passed using locked client dependencies. An explicit paired-server run passed 20 integration tests, including lost responses, exact replay and stale re-preparation. No tests skipped. Targeted typing, lint, formatting and source-risk checks passed.

## Risk / what to review

The rationale argument is parser-optional for reference-only modes but remains required for the default local path. Explicit default-valued content must still be rejected on reference-only calls.

Concurrent writing remains incomplete. This opt-in path requires a dedicated profile and access-token file, negotiates only the isolated reference-tool registry, and does not add automatic token refresh. Normal authentication configuration, stdio startup and production activation are unchanged.
