### PR TITLE
Add opt-in decision reference startup over stdio

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,8 @@ jobs:
           packages/nauro/src/nauro/sync/decision_reference_contract.py
           packages/nauro/src/nauro/mcp/decision_reference.py
           packages/nauro/src/nauro/cli/decision_reference.py
+          packages/nauro/src/nauro/sync/decision_profile.py
+          packages/nauro/src/nauro/mcp/decision_reference_startup.py
           scripts/controlled_decision_reference.py
           packages/nauro/src/nauro/auth.py
           packages/nauro/src/nauro/sync/merge.py

--- a/integration/test_decision_reference_server.py
+++ b/integration/test_decision_reference_server.py
@@ -39,7 +39,8 @@ def installed(probe):
     tool = mcp._tool_manager.get_tool("propose_decision")
 
     def invoke(**arguments):
-        return asyncio.run(tool.run({"project_id": TEST_PROJECT_ID, **arguments}))
+        response = asyncio.run(tool.run({"project_id": TEST_PROJECT_ID, **arguments}))
+        return json.loads(response.content[0].text)
 
     yield invoke, transport
     mcp._tool_manager._tools["propose_decision"] = original

--- a/integration/test_decision_reference_startup_server.py
+++ b/integration/test_decision_reference_startup_server.py
@@ -67,7 +67,8 @@ def test_startup_connection_recovers_after_restart(probe, tmp_path, monkeypatch,
 
     def invoke(server, **arguments):
         tool = server._tool_manager.get_tool("propose_decision")
-        return asyncio.run(tool.run({"project_id": TEST_PROJECT_ID, **arguments}))
+        response = asyncio.run(tool.run({"project_id": TEST_PROJECT_ID, **arguments}))
+        return json.loads(response.content[0].text)
 
     def first(server, *, transport):
         assert transport == "stdio"

--- a/integration/test_decision_reference_startup_server.py
+++ b/integration/test_decision_reference_startup_server.py
@@ -1,0 +1,120 @@
+import asyncio
+import json
+from types import SimpleNamespace
+
+import httpx
+import pytest
+from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp.exceptions import ToolError
+from mcp_server import decision_delivery as delivery
+from mcp_server.generations import read_generation_pointer
+from nauro.mcp import decision_reference_startup as startup
+from tests.conftest import TEST_PROJECT_ID
+from tests.test_decision_reference import ORIGIN, probe, signed_transport
+from tests.test_judgment_planning import USER_ID
+
+__all__ = ["probe", "signed_transport"]
+
+
+@pytest.mark.parametrize("lost_mode", ["prepare", "submit"])
+def test_startup_connection_recovers_after_restart(probe, tmp_path, monkeypatch, lost_mode):
+    credentials = tmp_path / "credentials.json"
+    credentials.write_text(
+        json.dumps({"user_id": USER_ID, "access_token": probe.headers["Authorization"][7:]})
+    )
+    credentials.chmod(0o600)
+    profile = tmp_path / "profile.json"
+    profile.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "endpoint": ORIGIN + "/mcp",
+                "project_id": TEST_PROJECT_ID,
+                "actor_id": USER_ID,
+                "credentials_file": str(credentials),
+            }
+        )
+    )
+    profile.chmod(0o600)
+    control = {"lost": False, "observations": [], "modes": []}
+    clients = []
+
+    def wire(request):
+        body = json.loads(request.content)
+        response = probe.request(
+            request.method,
+            str(request.url),
+            content=request.content,
+            headers=dict(request.headers),
+        )
+        if body["method"] == "tools/call":
+            mode = body["params"]["arguments"].get("request_mode", "prepare")
+            control["modes"].append(mode)
+            if mode == lost_mode and not control["lost"]:
+                control["observations"].append(
+                    json.loads(response.json()["result"]["content"][0]["text"])
+                )
+                control["lost"] = True
+                raise httpx.ReadError("lost response", request=request)
+        return response
+
+    def client():
+        value = httpx.Client(transport=httpx.MockTransport(wire))
+        clients.append(value)
+        return value
+
+    monkeypatch.setattr(startup, "httpx", SimpleNamespace(Client=client))
+
+    def invoke(server, **arguments):
+        tool = server._tool_manager.get_tool("propose_decision")
+        return asyncio.run(tool.run({"project_id": TEST_PROJECT_ID, **arguments}))
+
+    def first(server, *, transport):
+        assert transport == "stdio"
+        content = {
+            "title": "Recover a started stdio decision",
+            "rationale": "Preserve saved request identity across interrupted stdio connections.",
+        }
+        with pytest.raises(ToolError, match="No verified result"):
+            if lost_mode == "prepare":
+                invoke(server, **content)
+            else:
+                saved = invoke(server, **content)
+                invoke(
+                    server,
+                    request_mode="submit",
+                    operation_id=saved["request"]["operation_id"],
+                    payload_digest=saved["request"]["payload_digest"],
+                )
+
+    monkeypatch.setattr(FastMCP, "run", first)
+    startup.run_reference_stdio(profile)
+    assert clients[0].is_closed is True
+    monkeypatch.setattr(
+        delivery, "run_pre_team_judgment", lambda *_: pytest.fail("Recovery executed")
+    )
+
+    def restarted(server, *, transport):
+        found = invoke(server, request_mode="discover")
+        assert found["requests"] == control["observations"]
+        saved = found["requests"][0]
+        recovered = invoke(
+            server,
+            request_mode="recover",
+            operation_id=saved["request"]["operation_id"],
+            payload_digest=saved["request"]["payload_digest"],
+        )
+        assert recovered == saved
+        assert saved["status"] == ("committed" if lost_mode == "submit" else "prepared")
+
+    monkeypatch.setattr(FastMCP, "run", restarted)
+    startup.run_reference_stdio(profile)
+    assert len(clients) == 2 and clients[1].is_closed is True
+    assert control["modes"] == (
+        ["prepare", "submit", "discover", "recover"]
+        if lost_mode == "submit"
+        else ["prepare", "discover", "recover"]
+    )
+    assert read_generation_pointer(TEST_PROJECT_ID).decision_counter == (
+        1 if lost_mode == "submit" else 0
+    )

--- a/packages/nauro/src/nauro/cli/commands/serve.py
+++ b/packages/nauro/src/nauro/cli/commands/serve.py
@@ -5,8 +5,10 @@ stdin/stdout. stdio is the sole supported local transport; the former local
 FastAPI HTTP transport has been retired.
 
 The server resolves project context from the cwd's ``.nauro/config.json``;
-there is no ``--project`` flag — one source of truth.
+there is no ``--project`` flag. Explicit reference mode instead uses its operator profile.
 """
+
+from pathlib import Path
 
 import typer
 
@@ -18,10 +20,25 @@ def serve(
         help="Run over stdio (the only supported transport).",
         hidden=True,
     ),
+    reference_profile: Path | None = typer.Option(
+        None,
+        "--reference-profile",
+        help="Start a decision-only reference connection using an explicit operator profile.",
+    ),
 ) -> None:
     """Start the Nauro MCP server over stdio.
     '--stdio' is a no-op, accepted for client configs that still spawn 'nauro serve --stdio'.
     """
+    if reference_profile is not None:
+        from nauro.mcp.decision_reference_startup import ReferenceStartupError, run_reference_stdio
+
+        try:
+            run_reference_stdio(reference_profile)
+        except ReferenceStartupError as exc:
+            typer.echo(str(exc), err=True)
+            raise typer.Exit(1) from None
+        return
+
     from nauro.mcp.stdio_server import run_stdio
 
     run_stdio()

--- a/packages/nauro/src/nauro/cli/decision_reference.py
+++ b/packages/nauro/src/nauro/cli/decision_reference.py
@@ -5,38 +5,18 @@ from __future__ import annotations
 import enum
 import inspect
 import json
-import os
-import stat
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any
 
 import httpx
 import typer
 from nauro_core.mcp_tools import ToolSpec
-from pydantic import BaseModel, ConfigDict
 
-from nauro.auth import ActiveCredentials
 from nauro.cli._json_input import parse_json_list_of_dicts
-from nauro.sync.decision_reference import DecisionReferenceError, DecisionReferenceTransport
-from nauro.sync.decision_reference_contract import _json, validate_arguments
-
-
-class ReferenceProfile(BaseModel):
-    model_config = ConfigDict(extra="forbid", strict=True)
-
-    version: Literal[1]
-    endpoint: str
-    project_id: str
-    actor_id: str
-    credentials_file: str
-
-
-class ReferenceCredentials(BaseModel):
-    model_config = ConfigDict(extra="forbid", strict=True)
-
-    user_id: str
-    access_token: str
+from nauro.sync.decision_profile import ReferenceProfile, load_reference_profile, profile_transport
+from nauro.sync.decision_reference import DecisionReferenceError
+from nauro.sync.decision_reference_contract import validate_arguments
 
 
 class RequestMode(str, enum.Enum):
@@ -47,40 +27,13 @@ class RequestMode(str, enum.Enum):
     retry = "retry"
 
 
-def _private_json(path: Path) -> Any:
-    if not all(hasattr(os, name) for name in ("O_NOFOLLOW", "O_NONBLOCK", "getuid")):
-        raise ValueError("Private reference files are unsupported on this platform")
-    fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK)
-    with os.fdopen(fd, "rb") as stream:
-        info = os.fstat(stream.fileno())
-        if not stat.S_ISREG(info.st_mode) or info.st_uid != os.getuid() or info.st_mode & 0o077:
-            raise ValueError("Use an owner-only regular file")
-        raw = stream.read(65537)
-        if len(raw) > 65536:
-            raise ValueError("File exceeds size limit")
-        return _json(raw)
-
-
-def _credentials(path: Path) -> ActiveCredentials:
-    record = ReferenceCredentials.model_validate(_private_json(path))
-    if not record.user_id or not record.access_token:
-        raise ValueError("Missing credentials")
-    return ActiveCredentials(record.user_id, record.access_token)
-
-
 def reference_client() -> httpx.Client:
     return httpx.Client()
 
 
 def _execute(profile: ReferenceProfile, request: dict[str, Any]) -> dict[str, Any]:
     with reference_client() as client:
-        transport = DecisionReferenceTransport(
-            profile.endpoint,
-            profile.project_id,
-            profile.actor_id,
-            client,
-            lambda: _credentials(Path(profile.credentials_file)),
-        )
+        transport = profile_transport(profile, client)
         return transport.propose_decision(**request)
 
 
@@ -90,9 +43,7 @@ def _reference_call(
     if kwargs["project"] is not None or kwargs["output_format"].value != "json":
         raise typer.BadParameter("Reference delivery uses the profile project and JSON output")
     try:
-        profile = ReferenceProfile.model_validate(_private_json(path))
-        if not Path(profile.credentials_file).is_absolute():
-            raise ValueError("Credentials path must be absolute")
+        profile = load_reference_profile(path)
     except (ValueError, OSError):
         raise typer.BadParameter("Invalid reference profile; use an owner-only file") from None
     request: dict[str, Any] = {"project_id": profile.project_id}

--- a/packages/nauro/src/nauro/mcp/decision_reference.py
+++ b/packages/nauro/src/nauro/mcp/decision_reference.py
@@ -24,6 +24,26 @@ INSTRUCTIONS = (
 
 def bind_decision_reference(server: FastMCP, transport: DecisionReferenceTransport) -> None:
     """Replace only propose_decision on an explicitly supplied server instance."""
+    if server._tool_manager.get_tool("propose_decision") is None:
+        raise ValueError("The existing decision tool must be registered first")
+    server.remove_tool("propose_decision")
+    _register_decision_reference(server, transport)
+
+
+def reference_server(transport: DecisionReferenceTransport) -> FastMCP:
+    from nauro import __version__
+
+    server = FastMCP(
+        "nauro",
+        instructions=f"{INSTRUCTIONS} Project ID: {transport.project}.",
+        log_level="WARNING",
+    )
+    server._mcp_server.version = __version__
+    _register_decision_reference(server, transport)
+    return server
+
+
+def _register_decision_reference(server: FastMCP, transport: DecisionReferenceTransport) -> None:
 
     def propose_decision(
         project_id: str,
@@ -49,9 +69,6 @@ def bind_decision_reference(server: FastMCP, transport: DecisionReferenceTranspo
         }
         return transport.propose_decision(**arguments)
 
-    if server._tool_manager.get_tool("propose_decision") is None:
-        raise ValueError("The existing decision tool must be registered first")
-    server.remove_tool("propose_decision")
     server.add_tool(
         propose_decision,
         name="propose_decision",

--- a/packages/nauro/src/nauro/mcp/decision_reference.py
+++ b/packages/nauro/src/nauro/mcp/decision_reference.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+import json
 from typing import Any, Literal, cast
 
 from mcp.server.fastmcp import FastMCP
-from mcp.types import ToolAnnotations
+from mcp.types import CallToolResult, TextContent, ToolAnnotations
 from pydantic import create_model, model_validator
 
 from nauro.sync.decision_reference import DecisionReferenceTransport
@@ -61,13 +62,18 @@ def _register_decision_reference(server: FastMCP, transport: DecisionReferenceTr
         reversibility: str | None = None,
         files_affected: list[str] | None = None,
         resolves_questions: list[str] | None = None,
-    ) -> dict[str, Any]:
+    ) -> CallToolResult:
         arguments = {
             key: value
             for key, value in locals().items()
             if value is not None and key != "transport"
         }
-        return transport.propose_decision(**arguments)
+        result = transport.propose_decision(**arguments)
+        return CallToolResult(
+            content=[TextContent(type="text", text=json.dumps(result, ensure_ascii=False))],
+            isError=result.get("status")
+            in {"stale", "unresolved", "pending", "expired", "conflict", "disposed"},
+        )
 
     server.add_tool(
         propose_decision,

--- a/packages/nauro/src/nauro/mcp/decision_reference_startup.py
+++ b/packages/nauro/src/nauro/mcp/decision_reference_startup.py
@@ -1,0 +1,27 @@
+"""Start an explicit decision-only stdio connection without local store startup."""
+
+from pathlib import Path
+
+import httpx
+
+from nauro.mcp.decision_reference import reference_server
+from nauro.sync.decision_profile import load_reference_profile, profile_transport
+from nauro.sync.decision_reference import DecisionReferenceError
+
+
+class ReferenceStartupError(Exception):
+    pass
+
+
+def run_reference_stdio(path: Path) -> None:
+    with httpx.Client() as client:
+        try:
+            profile = load_reference_profile(path)
+            transport = profile_transport(profile, client)
+            transport.initialize()
+        except (ValueError, OSError, DecisionReferenceError):
+            raise ReferenceStartupError(
+                "Could not start the reference connection. "
+                "Check the profile, credentials and server."
+            ) from None
+        reference_server(transport).run(transport="stdio")

--- a/packages/nauro/src/nauro/sync/decision_profile.py
+++ b/packages/nauro/src/nauro/sync/decision_profile.py
@@ -1,0 +1,75 @@
+"""Operator-selected profile and private credentials for reference delivery."""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+from typing import Any, Literal
+
+import httpx
+from pydantic import BaseModel, ConfigDict
+
+from nauro.auth import ActiveCredentials
+from nauro.sync.decision_reference import DecisionReferenceTransport
+from nauro.sync.decision_reference_contract import _json
+
+
+class ReferenceProfile(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    version: Literal[1]
+    endpoint: str
+    project_id: str
+    actor_id: str
+    credentials_file: str
+
+
+class ReferenceCredentials(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    user_id: str
+    access_token: str
+
+
+def _private_json(path: Path) -> Any:
+    if not all(hasattr(os, name) for name in ("O_NOFOLLOW", "O_NONBLOCK", "getuid")):
+        raise ValueError("Private reference files are unsupported on this platform")
+    fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK)
+    with os.fdopen(fd, "rb") as stream:
+        info = os.fstat(stream.fileno())
+        if not stat.S_ISREG(info.st_mode) or info.st_uid != os.getuid() or info.st_mode & 0o077:
+            raise ValueError("Use an owner-only regular file")
+        raw = stream.read(65537)
+        if len(raw) > 65536:
+            raise ValueError("File exceeds size limit")
+        return _json(raw)
+
+
+def read_reference_credentials(path: Path) -> ActiveCredentials:
+    try:
+        record = ReferenceCredentials.model_validate(_private_json(path))
+        if not record.user_id or not record.access_token:
+            raise ValueError("Missing credentials")
+        return ActiveCredentials(record.user_id, record.access_token)
+    except (ValueError, OSError):
+        raise ValueError("Reference credentials unavailable") from None
+
+
+def load_reference_profile(path: Path) -> ReferenceProfile:
+    profile = ReferenceProfile.model_validate(_private_json(path))
+    if not Path(profile.credentials_file).is_absolute():
+        raise ValueError("Credentials path must be absolute")
+    return profile
+
+
+def profile_transport(
+    profile: ReferenceProfile, client: httpx.Client
+) -> DecisionReferenceTransport:
+    return DecisionReferenceTransport(
+        profile.endpoint,
+        profile.project_id,
+        profile.actor_id,
+        client,
+        lambda: read_reference_credentials(Path(profile.credentials_file)),
+    )

--- a/packages/nauro/tests/snapshots/public_contract_v1.json
+++ b/packages/nauro/tests/snapshots/public_contract_v1.json
@@ -1364,6 +1364,15 @@
         "name": "serve",
         "params": [
           {
+            "flags": [
+              "--reference-profile"
+            ],
+            "kind": "option",
+            "name": "reference_profile",
+            "required": false,
+            "type": "path"
+          },
+          {
             "default": true,
             "flags": [
               "--stdio"

--- a/packages/nauro/tests/test_decision_reference_cli.py
+++ b/packages/nauro/tests/test_decision_reference_cli.py
@@ -6,6 +6,7 @@ from typer.testing import CliRunner
 from nauro.cli import autogen
 from nauro.cli import decision_reference as reference
 from nauro.cli.main import app
+from nauro.sync import decision_profile
 from nauro.sync.decision_reference import DecisionReferenceError
 
 PROJECT = "01KQ6AZGNA0B3QBF67NBXP3S45"
@@ -166,16 +167,16 @@ def test_reference_mode_without_profile_refuses_local_dispatch(configured):
 
 def test_credentials_are_reloaded_and_private(configured):
     _, path = configured
-    assert reference._credentials(path).access_token == "synthetic"
+    assert decision_profile.read_reference_credentials(path).access_token == "synthetic"
     path.write_text(json.dumps({"user_id": ACTOR, "access_token": "replacement"}))
-    assert reference._credentials(path).access_token == "replacement"
+    assert decision_profile.read_reference_credentials(path).access_token == "replacement"
     path.chmod(0o644)
-    with pytest.raises(ValueError, match="owner-only"):
-        reference._credentials(path)
+    with pytest.raises(ValueError, match="Reference credentials unavailable"):
+        decision_profile.read_reference_credentials(path)
 
 
 def test_unsupported_platform_refuses_before_open(configured, monkeypatch):
-    monkeypatch.delattr(reference.os, "O_NOFOLLOW")
+    monkeypatch.delattr(decision_profile.os, "O_NOFOLLOW")
     with pytest.raises(ValueError, match="unsupported on this platform"):
-        reference._private_json(configured[0])
+        decision_profile._private_json(configured[0])
     assert invoke(configured[0], "--request-mode", "discover").exit_code == 2

--- a/packages/nauro/tests/test_decision_reference_startup.py
+++ b/packages/nauro/tests/test_decision_reference_startup.py
@@ -196,3 +196,95 @@ app()
                 }
 
     asyncio.run(asyncio.wait_for(session(), timeout=15))
+
+
+@pytest.mark.parametrize(
+    ("status", "expected_error"),
+    [
+        ("stale", True),
+        ("unresolved", True),
+        ("pending", True),
+        ("expired", True),
+        ("conflict", True),
+        ("disposed", True),
+        ("committed", False),
+        ("prepared", False),
+        (None, False),
+    ],
+)
+def test_protocol_outcome_flags_preserve_verified_evidence(status, expected_error):
+    from mcp.types import CallToolRequest, CallToolRequestParams
+
+    receipt = '{"receipt_id":"synthetic","result":"committed"}'
+    value = (
+        {"version": 1, "requests": [], "next_after": None}
+        if status is None
+        else {"status": status, "execution": {"receipt_json": receipt}, "title": "Décision"}
+    )
+    transport = SimpleNamespace(project=PROJECT, propose_decision=lambda **_: value)
+    server = reference_server(transport)
+    request = CallToolRequest(
+        method="tools/call",
+        params=CallToolRequestParams(
+            name="propose_decision", arguments={"project_id": PROJECT, "request_mode": "discover"}
+        ),
+    )
+    response = asyncio.run(server._mcp_server.request_handlers[CallToolRequest](request)).root
+    assert response.isError is expected_error
+    assert len(response.content) == 1
+    assert response.content[0].type == "text"
+    assert response.content[0].text == json.dumps(value, ensure_ascii=False)
+    assert json.loads(response.content[0].text) == value
+
+
+@pytest.mark.parametrize(("status", "expected_error"), [("committed", False), ("stale", True)])
+def test_controlled_driver_retains_domain_evidence(profile, monkeypatch, status, expected_error):
+    import runpy
+    import sys
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[3]
+    main = runpy.run_path(str(root / "scripts" / "controlled_decision_reference.py"))["main"]
+    project_dir = profile[0].parent
+    manifest, request, evidence = (
+        project_dir / name for name in ("manifest.json", "request.json", "evidence.jsonl")
+    )
+    manifest.write_text(
+        json.dumps(
+            {
+                "endpoint": "https://decision-probe.nauro.ai/mcp",
+                "project_id": PROJECT,
+                "actor_id": ACTOR,
+                "isolated": True,
+            }
+        )
+    )
+    request.write_text(json.dumps({"project_id": PROJECT, "rationale": "Synthetic draft"}))
+    value = {"status": status, "execution": {"receipt_json": "exact saved receipt"}}
+    transport = SimpleNamespace(
+        project=PROJECT, initialize=lambda: None, propose_decision=lambda **_: value
+    )
+    monkeypatch.setitem(main.__globals__, "DecisionReferenceTransport", lambda *_: transport)
+    monkeypatch.setitem(main.__globals__, "mcp", reference_server(transport))
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "driver",
+            "--manifest",
+            str(manifest),
+            "--request",
+            str(request),
+            "--evidence",
+            str(evidence),
+            "--credentials",
+            str(profile[1]),
+            "--execute",
+        ],
+    )
+    assert main() == 0
+    rows = [json.loads(row) for row in evidence.read_text().splitlines()]
+    assert len(rows) == 2
+    assert rows[1]["status"] == "verified"
+    assert rows[1]["result"] == value
+    assert rows[1]["mcp_is_error"] is expected_error

--- a/packages/nauro/tests/test_decision_reference_startup.py
+++ b/packages/nauro/tests/test_decision_reference_startup.py
@@ -1,0 +1,198 @@
+import asyncio
+import json
+from types import SimpleNamespace
+
+import httpx
+import pytest
+from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp.exceptions import ToolError
+from typer.testing import CliRunner
+
+from nauro.cli.main import app
+from nauro.mcp import decision_reference_startup as startup
+from nauro.mcp import stdio_server
+from nauro.mcp.decision_reference import INSTRUCTIONS, reference_server
+from nauro.sync.decision_profile import load_reference_profile, profile_transport
+from nauro.sync.decision_reference_contract import reference_schema
+
+PROJECT = "01KQ6AZGNA0B3QBF67NBXP3S45"
+ACTOR = "01K" + "0" * 21 + "08"
+
+
+@pytest.fixture
+def profile(tmp_path, monkeypatch):
+    monkeypatch.setenv("NAURO_HOME", str(tmp_path / "home"))
+    credentials = tmp_path / "credentials.json"
+    credentials.write_text(json.dumps({"user_id": ACTOR, "access_token": "synthetic"}))
+    credentials.chmod(0o600)
+    path = tmp_path / "profile.json"
+    path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "endpoint": "https://probe.example/mcp",
+                "project_id": PROJECT,
+                "actor_id": ACTOR,
+                "credentials_file": str(credentials),
+            }
+        )
+    )
+    path.chmod(0o600)
+    return path, credentials
+
+
+def test_default_serve_uses_existing_startup(monkeypatch):
+    calls = []
+    monkeypatch.setattr(stdio_server, "run_stdio", lambda: calls.append("legacy"))
+    monkeypatch.setattr(startup, "run_reference_stdio", lambda *_: pytest.fail("Reference startup"))
+    result = CliRunner().invoke(app, ["serve"])
+    assert result.exit_code == 0
+    assert calls == ["legacy"]
+
+
+@pytest.mark.parametrize("legacy_schema", [False, True])
+def test_reference_startup_negotiates_before_serving_and_never_pulls(
+    profile, monkeypatch, legacy_schema
+):
+    path, _ = profile
+    methods, clients, served = [], [], []
+    original_tools = dict(stdio_server.mcp._tool_manager._tools)
+    monkeypatch.setattr(stdio_server, "_pull_on_startup", lambda: pytest.fail("Startup pull"))
+    monkeypatch.setattr(stdio_server, "run_stdio", lambda: pytest.fail("Legacy fallback"))
+
+    def wire(request):
+        body = json.loads(request.content)
+        methods.append(body["method"])
+        if body["method"] == "notifications/initialized":
+            return httpx.Response(202)
+        payload = (
+            {"protocolVersion": "2025-06-18"}
+            if body["method"] == "initialize"
+            else {
+                "tools": [
+                    {
+                        "name": "propose_decision",
+                        "inputSchema": {} if legacy_schema else reference_schema(),
+                    }
+                ]
+            }
+        )
+        return httpx.Response(200, json={"jsonrpc": "2.0", "id": body["id"], "result": payload})
+
+    def client():
+        value = httpx.Client(transport=httpx.MockTransport(wire))
+        clients.append(value)
+        return value
+
+    monkeypatch.setattr(startup, "httpx", SimpleNamespace(Client=client))
+
+    def run(server, *, transport):
+        assert transport == "stdio"
+        assert methods == ["initialize", "notifications/initialized", "tools/list"]
+        assert list(server._tool_manager._tools) == ["propose_decision"]
+        assert server.instructions == f"{INSTRUCTIONS} Project ID: {PROJECT}."
+        assert server._tool_manager.get_tool("propose_decision").parameters == reference_schema()
+        served.append(server)
+
+    monkeypatch.setattr(FastMCP, "run", run)
+    result = CliRunner().invoke(app, ["serve", "--reference-profile", str(path)])
+    assert result.exit_code == (1 if legacy_schema else 0), result.output
+    assert len(served) == (0 if legacy_schema else 1)
+    assert result.stdout == ""
+    assert clients[0].is_closed is True
+    assert stdio_server.mcp._tool_manager._tools == original_tools
+
+
+def test_invalid_startup_profile_never_transmits(profile, monkeypatch):
+    path, _ = profile
+    path.write_text('{"access_token":"do-not-print"}')
+    monkeypatch.setattr(startup, "profile_transport", lambda *_: pytest.fail("Transport"))
+    result = CliRunner().invoke(app, ["serve", "--reference-profile", str(path)])
+    assert result.exit_code == 1
+    assert result.stdout == ""
+    assert "do-not-print" not in result.output
+    assert "Could not start" in result.stderr
+
+
+def test_bad_credentials_after_startup_do_not_leak_or_transmit(profile):
+    path, credentials = profile
+    with httpx.Client(transport=httpx.MockTransport(lambda _: pytest.fail("Network"))) as client:
+        transport = profile_transport(load_reference_profile(path), client)
+        transport._initialized = True
+        server = reference_server(transport)
+        credentials.write_text(
+            json.dumps({"user_id": ACTOR, "access_token": {"secret": "do-not-print"}})
+        )
+        tool = server._tool_manager.get_tool("propose_decision")
+        with pytest.raises(ToolError, match="Reference credentials unavailable") as caught:
+            asyncio.run(tool.run({"project_id": PROJECT, "request_mode": "discover"}))
+        assert "do-not-print" not in str(caught.value)
+
+
+def test_reference_server_instances_do_not_share_tools(profile):
+    path, _ = profile
+    with httpx.Client() as client:
+        transport = profile_transport(load_reference_profile(path), client)
+        first, second = reference_server(transport), reference_server(transport)
+        first.remove_tool("propose_decision")
+        assert list(second._tool_manager._tools) == ["propose_decision"]
+        assert stdio_server.mcp._tool_manager.get_tool("get_context") is not None
+
+
+def test_reference_cli_serves_real_stdio_protocol(profile):
+    import sys
+
+    from mcp import ClientSession, StdioServerParameters
+    from mcp.client.stdio import stdio_client
+
+    bootstrap = """
+import json
+from types import SimpleNamespace
+import httpx
+from nauro.cli.main import app
+from nauro.mcp import decision_reference_startup as startup
+from nauro.sync.decision_reference_contract import reference_schema
+
+def wire(request):
+    assert str(request.url) == 'https://probe.example/mcp'
+    body = json.loads(request.content)
+    if body['method'] == 'notifications/initialized':
+        return httpx.Response(202)
+    if body['method'] == 'initialize':
+        result = {'protocolVersion': '2025-06-18'}
+    elif body['method'] == 'tools/list':
+        result = {'tools': [{'name': 'propose_decision', 'inputSchema': reference_schema()}]}
+    else:
+        assert body['method'] == 'tools/call'
+        assert body['params']['arguments']['request_mode'] == 'discover'
+        result = {'content': [{'type': 'text', 'text': json.dumps(
+            {'version': 1, 'requests': [], 'next_after': None})}]}
+    return httpx.Response(200, json={'jsonrpc': '2.0', 'id': body['id'], 'result': result})
+
+startup.httpx = SimpleNamespace(Client=lambda: httpx.Client(transport=httpx.MockTransport(wire)))
+app()
+"""
+
+    async def session():
+        params = StdioServerParameters(
+            command=sys.executable,
+            args=["-c", bootstrap, "serve", "--reference-profile", str(profile[0])],
+        )
+        async with stdio_client(params) as (reader, writer):
+            async with ClientSession(reader, writer) as client:
+                initialized = await client.initialize()
+                assert initialized.instructions == f"{INSTRUCTIONS} Project ID: {PROJECT}."
+                tools = await client.list_tools()
+                assert [tool.name for tool in tools.tools] == ["propose_decision"]
+                assert tools.tools[0].inputSchema == reference_schema()
+                result = await client.call_tool(
+                    "propose_decision", {"project_id": PROJECT, "request_mode": "discover"}
+                )
+                assert result.isError is False
+                assert json.loads(result.content[0].text) == {
+                    "version": 1,
+                    "requests": [],
+                    "next_after": None,
+                }
+
+    asyncio.run(asyncio.wait_for(session(), timeout=15))

--- a/scripts/controlled_decision_reference.py
+++ b/scripts/controlled_decision_reference.py
@@ -13,6 +13,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import httpx
+from mcp.types import CallToolResult, TextContent
 from nauro.auth import ActiveCredentials
 from nauro.mcp.decision_reference import bind_decision_reference
 from nauro.mcp.stdio_server import mcp
@@ -114,10 +115,18 @@ def main() -> int:
                 bind_decision_reference(mcp, transport)
                 tool = mcp._tool_manager.get_tool("propose_decision")
                 assert tool is not None
-                result = asyncio.run(tool.run(request))
+                response = asyncio.run(tool.run(request))
+                if (
+                    not isinstance(response, CallToolResult)
+                    or len(response.content) != 1
+                    or not isinstance(response.content[0], TextContent)
+                ):
+                    raise ValueError("Unexpected decision tool response")
+                result = _json(response.content[0].text)
             outcome = {
                 "status": "verified",
                 "result": result,
+                "mcp_is_error": response.isError,
                 "elapsed_seconds": time.monotonic() - started,
                 "initialization_seconds": initialized - started,
                 "tool_seconds": time.monotonic() - initialized,


### PR DESCRIPTION
## Why

Installed MCP clients need a stdio entry point for the prepared decision-reference transport. The explicit connection must preserve hosted error signals and avoid mixing hosted writes with the local store.

## What changed

- Add `nauro serve --reference-profile` to start a decision-only connection using the existing `propose_decision` name. Negotiate the hosted schema before serving and skip local startup and pulls in this mode.
- Share private profile and credential handling with the CLI. Report credential failures without file contents and close the HTTP client when startup fails or stdio exits.
- Return explicit MCP results so stale and unresolved outcomes retain the hosted error flags and exact verified JSON evidence. Adapt the controlled driver to retain the domain result and record the error flag.

## Test plan

132 client and contract tests passed, including an actual subprocess stdio handshake and protocol-level outcome mapping. An explicit paired-server run passed 22 integration tests, including restart recovery after lost preparation and commit responses. No tests skipped. Targeted typing, lint, formatting, source-risk, helper and docstring checks passed.

## Risk / what to review

Concurrent writing remains incomplete. This mode requires an explicit operator profile, a dedicated access-token file and the isolated reference-tool registry. It does not add token refresh or general hosted read routing. Default stdio startup, normal authentication configuration and production activation remain unchanged.
