### PR TITLE
Accept negotiated generation reads in reference connections

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,8 @@ jobs:
           packages/nauro/src/nauro/sync/decision_reference_contract.py
           packages/nauro/src/nauro/mcp/decision_reference.py
           packages/nauro/src/nauro/cli/decision_reference.py
+          packages/nauro/src/nauro/sync/reference_reads.py
+          packages/nauro/src/nauro/mcp/reference_reads.py
           packages/nauro/src/nauro/sync/reference_auth.py
           packages/nauro/src/nauro/sync/reference_credentials.py
           packages/nauro/src/nauro/sync/reference_oauth.py

--- a/integration/test_reference_reads_server.py
+++ b/integration/test_reference_reads_server.py
@@ -1,0 +1,100 @@
+import asyncio
+import json
+
+import httpx
+import pytest
+from mcp_server import decision_delivery as delivery
+from mcp_server import generation_responses as generation
+from mcp_server.read_arguments import ContextArguments, DecisionArguments, parse_read_arguments
+from nauro.auth import ActiveCredentials
+from nauro.mcp.decision_reference import reference_server
+from nauro.sync.decision_reference import DecisionReferenceTransport
+from nauro.sync.reference_reads import READ_SPECS, read_schema
+from tests.conftest import TEST_PROJECT_ID
+from tests.test_decision_reference import ORIGIN, action, prepare, probe, signed_transport
+from tests.test_judgment_planning import USER_ID, _table
+
+__all__ = ["probe", "signed_transport"]
+
+
+def test_forward_existing_verified_generation_responses(probe, monkeypatch):
+    saved = prepare(probe)
+    committed = action(probe, saved, "submit")
+    assert committed["status"] == "committed"
+    expected = {
+        "get_context": generation.get_context(USER_ID, TEST_PROJECT_ID, "L2"),
+        "get_decision": generation.get_decision(USER_ID, TEST_PROJECT_ID, 1, "full"),
+    }
+    generation_id = json.loads(committed["execution"]["receipt_json"])["generation_id"]
+    assert all(
+        result.envelope["read_authority"]["generation_id"] == generation_id
+        for result in expected.values()
+    )
+    monkeypatch.setattr(delivery, "run_pre_team_judgment", lambda *_: pytest.fail("Read executed"))
+    reads = []
+
+    def wire(request):
+        body = json.loads(request.content)
+        assert request.headers["authorization"] == probe.headers["Authorization"]
+        if body["method"] == "tools/call" and body["params"]["name"] in READ_SPECS:
+            name = body["params"]["name"]
+            args = parse_read_arguments(name, body["params"]["arguments"])
+            assert args.project_id == TEST_PROJECT_ID
+            if isinstance(args, ContextArguments):
+                response = generation.get_context(USER_ID, TEST_PROJECT_ID, args.level)
+            else:
+                assert isinstance(args, DecisionArguments)
+                response = generation.get_decision(
+                    USER_ID, TEST_PROJECT_ID, args.number, args.mode
+                )
+            reads.append(name)
+            return httpx.Response(
+                200,
+                json={
+                    "jsonrpc": "2.0",
+                    "id": body["id"],
+                    "result": {
+                        "content": [{"type": "text", "text": response.text}],
+                        "isError": response.is_error,
+                    },
+                },
+            )
+        response = probe.request(
+            request.method,
+            str(request.url),
+            content=request.content,
+            headers=dict(request.headers),
+        )
+        if body["method"] == "tools/list":
+            value = response.json()
+            value["result"]["tools"].extend(
+                {"name": name, "inputSchema": read_schema(name)} for name in READ_SPECS
+            )
+            return httpx.Response(200, json=value)
+        return response
+
+    with httpx.Client(transport=httpx.MockTransport(wire)) as client:
+        transport = DecisionReferenceTransport(
+            ORIGIN + "/mcp",
+            TEST_PROJECT_ID,
+            USER_ID,
+            client,
+            lambda: ActiveCredentials(USER_ID, probe.headers["Authorization"][7:]),
+        )
+        transport.initialize()
+        server = reference_server(transport)
+        for name, arguments in [("get_context", {"level": "L2"}), ("get_decision", {"number": 1})]:
+            tool = server._tool_manager.get_tool(name)
+            result = asyncio.run(tool.run({"project_id": TEST_PROJECT_ID, **arguments}))
+            assert result.isError is False
+            assert result.content[0].text == expected[name].text
+            assert generation_id in result.content[0].text
+        _table().delete_item(Key={"pk": f"PROJECT#{TEST_PROJECT_ID}", "sk": f"MEMBER#{USER_ID}"})
+        refused = transport.read("get_context", project_id=TEST_PROJECT_ID)
+        assert refused["isError"] is True
+        assert (
+            refused["content"][0]["text"]
+            == "Error: The current authorized generation is unavailable."
+        )
+        assert generation_id not in refused["content"][0]["text"]
+    assert reads == ["get_context", "get_decision", "get_context"]

--- a/packages/nauro/src/nauro/mcp/decision_reference.py
+++ b/packages/nauro/src/nauro/mcp/decision_reference.py
@@ -9,6 +9,7 @@ from mcp.server.fastmcp import FastMCP
 from mcp.types import CallToolResult, TextContent, ToolAnnotations
 from pydantic import create_model, model_validator
 
+from nauro.mcp.reference_reads import register_reference_reads
 from nauro.sync.decision_reference import DecisionReferenceTransport
 from nauro.sync.decision_reference_contract import reference_schema, validate_arguments
 
@@ -41,6 +42,7 @@ def reference_server(transport: DecisionReferenceTransport) -> FastMCP:
     )
     server._mcp_server.version = __version__
     _register_decision_reference(server, transport)
+    register_reference_reads(server, transport)
     return server
 
 

--- a/packages/nauro/src/nauro/mcp/reference_reads.py
+++ b/packages/nauro/src/nauro/mcp/reference_reads.py
@@ -1,0 +1,61 @@
+"""Register only the negotiated read pair in an isolated reference server."""
+
+from __future__ import annotations
+
+from typing import Any, Literal, cast
+
+from mcp.server.fastmcp import FastMCP
+from mcp.types import CallToolResult, TextContent, ToolAnnotations
+from pydantic import create_model, model_validator
+
+from nauro.sync.decision_reference import DecisionReferenceTransport
+from nauro.sync.reference_reads import READ_SPECS, read_schema, validate_read
+
+
+def _register(server: FastMCP, transport: DecisionReferenceTransport, name: str) -> None:
+    def result(arguments: dict[str, Any]) -> CallToolResult:
+        response = transport.read(name, **arguments)
+        return CallToolResult(
+            content=[TextContent(type="text", text=response["content"][0]["text"])],
+            isError=response["isError"],
+        )
+
+    def get_context(project_id: str, level: Literal["L0", "L1", "L2"] = "L0") -> CallToolResult:
+        return result({"project_id": project_id, "level": level})
+
+    def get_decision(
+        project_id: str,
+        number: int,
+        mode: Literal["header", "full"] = "full",
+    ) -> CallToolResult:
+        return result({"project_id": project_id, "number": number, "mode": mode})
+
+    spec = READ_SPECS[name]
+    server.add_tool(
+        get_context if name == "get_context" else get_decision,
+        name=name,
+        title=spec["title"],
+        description=spec["description"],
+        annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False, idempotentHint=True),
+        structured_output=False,
+    )
+    tool = server._tool_manager.get_tool(name)
+    assert tool is not None
+
+    @model_validator(mode="before")
+    def validate_call(cls: Any, value: Any) -> Any:
+        validate_read(name, value, transport.project)
+        return value
+
+    tool.fn_metadata.arg_model = create_model(
+        "ReferenceReadArguments",
+        __base__=tool.fn_metadata.arg_model,
+        __validators__={"validate_call": cast(Any, validate_call)},
+    )
+    tool.parameters = read_schema(name)
+
+
+def register_reference_reads(server: FastMCP, transport: DecisionReferenceTransport) -> None:
+    if transport.reads_available:
+        for name in READ_SPECS:
+            _register(server, transport, name)

--- a/packages/nauro/src/nauro/sync/decision_reference.py
+++ b/packages/nauro/src/nauro/sync/decision_reference.py
@@ -12,7 +12,6 @@ from nauro.auth import ActiveCredentials, read_active_credentials
 from nauro.sync.decision_reference_contract import (
     MAX_RESPONSE,
     _json,
-    reference_schema,
     validate_arguments,
     verify_observation,
 )
@@ -20,6 +19,7 @@ from nauro.sync.decision_reference_contract import (
     DecisionReferenceError as DecisionReferenceError,
 )
 from nauro.sync.judgment_transport import JudgmentTransportError
+from nauro.sync.reference_reads import negotiate_registry, validate_read, verify_read_result
 
 
 class DecisionReferenceTransport:
@@ -47,6 +47,7 @@ class DecisionReferenceTransport:
         self.client, self.credentials = client, credentials
         self._sequence = 0
         self._initialized = False
+        self.reads_available = False
 
     def _credentials(self) -> ActiveCredentials:
         credentials = self.credentials()
@@ -88,14 +89,15 @@ class DecisionReferenceTransport:
             self._credentials()
             result = _json(bytes(raw))
             if (
-                result.get("jsonrpc") != "2.0"
+                not isinstance(result, dict)
+                or result.get("jsonrpc") != "2.0"
                 or type(result.get("id")) is not int
                 or result.get("id") != request_id
                 or "error" in result
             ):
                 raise ValueError("Invalid RPC response")
             return result["result"]
-        except (httpx.HTTPError, ValueError, KeyError, TypeError) as exc:
+        except (httpx.HTTPError, ValueError, KeyError, TypeError, RecursionError) as exc:
             raise DecisionReferenceError(
                 "No verified result. Discover or recover the original request"
             ) from exc
@@ -111,14 +113,10 @@ class DecisionReferenceTransport:
                 "clientInfo": {"name": "nauro-decision-reference", "version": "1"},
             },
         )
-        if result.get("protocolVersion") != "2025-06-18":
+        if not isinstance(result, dict) or result.get("protocolVersion") != "2025-06-18":
             raise DecisionReferenceError("Unsupported MCP protocol")
         self._rpc("notifications/initialized", {}, notification=True)
-        tools = self._rpc("tools/list", {})["tools"]
-        if [tool["name"] for tool in tools] != ["propose_decision"] or tools[0].get(
-            "inputSchema"
-        ) != reference_schema():
-            raise DecisionReferenceError("Unexpected isolated tool registry")
+        self.reads_available = negotiate_registry(self._rpc("tools/list", {}))
         self._initialized = True
 
     def propose_decision(self, **arguments: Any) -> dict[str, Any]:
@@ -154,3 +152,14 @@ class DecisionReferenceTransport:
             return value
         except (ValueError, KeyError, TypeError, AttributeError, JudgmentTransportError) as exc:
             raise DecisionReferenceError("Invalid saved request or receipt evidence") from exc
+
+    def read(self, name: str, **arguments: Any) -> dict[str, Any]:
+        validate_read(name, arguments, self.project)
+        self.initialize()
+        if not self.reads_available:
+            raise DecisionReferenceError("The selected endpoint does not expose generation reads")
+        try:
+            result = self._rpc("tools/call", {"name": name, "arguments": arguments})
+            return verify_read_result(result)
+        except ValueError:
+            raise DecisionReferenceError("No verified read result. No retry was sent") from None

--- a/packages/nauro/src/nauro/sync/reference_reads.py
+++ b/packages/nauro/src/nauro/sync/reference_reads.py
@@ -1,0 +1,94 @@
+"""Closed registry and read-result contracts for the reference connection."""
+
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+from nauro_core.mcp_tools import GET_CONTEXT, GET_DECISION
+
+from nauro.sync.decision_reference_contract import (
+    MAX_RESPONSE,
+    DecisionReferenceError,
+    reference_schema,
+)
+
+READ_SPECS = {spec["name"]: spec for spec in (GET_CONTEXT, GET_DECISION)}
+
+
+def read_schema(name: str) -> dict[str, Any]:
+    schema = copy.deepcopy(READ_SPECS[name]["input_schema"])
+    schema["required"] = [*schema.get("required", []), "project_id"]
+    schema["additionalProperties"] = False
+    return schema
+
+
+def negotiate_registry(result: Any) -> bool:
+    if (
+        not isinstance(result, dict)
+        or set(result) != {"tools"}
+        or not isinstance(result["tools"], list)
+    ):
+        raise DecisionReferenceError("Unexpected isolated tool registry")
+    schemas = {"propose_decision": reference_schema()}
+    names: set[str] = set()
+    tools = result["tools"]
+    if len(tools) == 3:
+        schemas.update({name: read_schema(name) for name in READ_SPECS})
+    if len(tools) != len(schemas):
+        raise DecisionReferenceError("Unexpected isolated tool registry")
+    for tool in tools:
+        if not isinstance(tool, dict) or not isinstance(tool.get("name"), str):
+            raise DecisionReferenceError("Unexpected isolated tool registry")
+        name = tool["name"]
+        if name in names or name not in schemas or tool.get("inputSchema") != schemas[name]:
+            raise DecisionReferenceError("Unexpected isolated tool registry")
+        names.add(name)
+    return len(tools) == 3
+
+
+def validate_read(name: str, arguments: Any, project: str) -> None:
+    if name not in READ_SPECS or not isinstance(arguments, dict):
+        raise DecisionReferenceError("Invalid reference read")
+    schema = read_schema(name)
+    if (
+        set(arguments) - set(schema["properties"])
+        or set(schema["required"]) - set(arguments)
+        or arguments.get("project_id") != project
+    ):
+        raise DecisionReferenceError(
+            "Read must select the configured project with supported fields"
+        )
+    if name == "get_context":
+        level = arguments.get("level", "L0")
+        if not isinstance(level, str) or level not in {"L0", "L1", "L2"}:
+            raise DecisionReferenceError("Invalid context level")
+    else:
+        mode = arguments.get("mode", "full")
+        if (
+            type(arguments["number"]) is not int
+            or not isinstance(mode, str)
+            or mode not in {"header", "full"}
+        ):
+            raise DecisionReferenceError("Invalid decision number or mode")
+
+
+def verify_read_result(result: Any) -> dict[str, Any]:
+    if (
+        not isinstance(result, dict)
+        or set(result) != {"content", "isError"}
+        or type(result["isError"]) is not bool
+    ):
+        raise DecisionReferenceError("Invalid reference read result")
+    content = result["content"]
+    if not isinstance(content, list) or len(content) != 1 or not isinstance(content[0], dict):
+        raise DecisionReferenceError("Invalid reference read content")
+    text = content[0]
+    if (
+        set(text) != {"type", "text"}
+        or text["type"] != "text"
+        or not isinstance(text["text"], str)
+        or len(text["text"].encode("utf-8")) > MAX_RESPONSE
+    ):
+        raise DecisionReferenceError("Invalid reference read text")
+    return result

--- a/packages/nauro/tests/test_decision_reference_startup.py
+++ b/packages/nauro/tests/test_decision_reference_startup.py
@@ -221,7 +221,9 @@ def test_protocol_outcome_flags_preserve_verified_evidence(status, expected_erro
         if status is None
         else {"status": status, "execution": {"receipt_json": receipt}, "title": "Décision"}
     )
-    transport = SimpleNamespace(project=PROJECT, propose_decision=lambda **_: value)
+    transport = SimpleNamespace(
+        project=PROJECT, reads_available=False, propose_decision=lambda **_: value
+    )
     server = reference_server(transport)
     request = CallToolRequest(
         method="tools/call",
@@ -262,7 +264,10 @@ def test_controlled_driver_retains_domain_evidence(profile, monkeypatch, status,
     request.write_text(json.dumps({"project_id": PROJECT, "rationale": "Synthetic draft"}))
     value = {"status": status, "execution": {"receipt_json": "exact saved receipt"}}
     transport = SimpleNamespace(
-        project=PROJECT, initialize=lambda: None, propose_decision=lambda **_: value
+        project=PROJECT,
+        reads_available=False,
+        initialize=lambda: None,
+        propose_decision=lambda **_: value,
     )
     monkeypatch.setitem(main.__globals__, "DecisionReferenceTransport", lambda *_: transport)
     monkeypatch.setitem(main.__globals__, "mcp", reference_server(transport))

--- a/packages/nauro/tests/test_reference_reads.py
+++ b/packages/nauro/tests/test_reference_reads.py
@@ -1,0 +1,352 @@
+import asyncio
+import json
+from types import SimpleNamespace
+
+import httpx
+import pytest
+from mcp.server.fastmcp.exceptions import ToolError
+
+from nauro.auth import ActiveCredentials
+from nauro.mcp.decision_reference import reference_server
+from nauro.sync.decision_reference import DecisionReferenceError, DecisionReferenceTransport
+from nauro.sync.decision_reference_contract import MAX_RESPONSE, reference_schema
+from nauro.sync.reference_reads import (
+    READ_SPECS,
+    negotiate_registry,
+    read_schema,
+    verify_read_result,
+)
+
+PROJECT = "01KQ6AZGNA0B3QBF67NBXP3S45"
+ACTOR = "01K" + "0" * 21 + "08"
+TEXT = (
+    "# Synthetic decision\n\nGeneration: synthetic-generation. Committed: synthetic-time.\n"
+    "Authorization checked for this read."
+)
+
+
+def registry(expanded=True):
+    tools = [{"name": "propose_decision", "inputSchema": reference_schema()}]
+    if expanded:
+        tools.extend({"name": name, "inputSchema": read_schema(name)} for name in READ_SPECS)
+    return {"tools": tools}
+
+
+@pytest.fixture
+def wire():
+    calls = []
+    control = {
+        "registry": registry(),
+        "result": {"content": [{"type": "text", "text": TEXT}], "isError": False},
+        "token": "first",
+        "status": 200,
+        "rpc_id_delta": 0,
+    }
+
+    def send(request):
+        body = json.loads(request.content)
+        calls.append((body, request.headers["authorization"]))
+        if body["method"] == "notifications/initialized":
+            return httpx.Response(202)
+        if body["method"] == "initialize":
+            result = {"protocolVersion": "2025-06-18"}
+        elif body["method"] == "tools/list":
+            result = control["registry"]
+        else:
+            if control["status"] == "lost":
+                raise httpx.ReadError("lost", request=request)
+            result = control["result"]
+            if control["status"] != 200:
+                return httpx.Response(control["status"])
+        return httpx.Response(
+            200,
+            json={"jsonrpc": "2.0", "id": body["id"] + control["rpc_id_delta"], "result": result},
+        )
+
+    with httpx.Client(transport=httpx.MockTransport(send)) as client:
+        transport = DecisionReferenceTransport(
+            "https://probe.example/mcp",
+            PROJECT,
+            ACTOR,
+            client,
+            lambda: ActiveCredentials(ACTOR, control["token"]),
+        )
+        yield SimpleNamespace(control=control, calls=calls, transport=transport)
+
+
+@pytest.mark.parametrize("expanded", [False, True])
+def test_exact_registry_controls_local_tools(wire, expanded):
+    wire.control["registry"] = registry(expanded)
+    wire.transport.initialize()
+    server = reference_server(wire.transport)
+    assert wire.transport.reads_available is expanded
+    assert set(server._tool_manager._tools) == {t["name"] for t in registry(expanded)["tools"]}
+    for spec in registry(expanded)["tools"]:
+        assert server._tool_manager.get_tool(spec["name"]).parameters == spec["inputSchema"]
+    assert server._tool_manager.get_tool("propose_decision").parameters == reference_schema()
+
+
+def test_registry_order_does_not_change_admission():
+    value = registry()
+    value["tools"].reverse()
+    assert negotiate_registry(value) is True
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        None,
+        [],
+        {},
+        {"tools": []},
+        {"tools": "bad"},
+        {"tools": [None]},
+        {"tools": [{"name": []}]},
+        {"tools": registry()["tools"][:2]},
+        {"tools": registry()["tools"] + [registry()["tools"][0]]},
+        {"tools": [registry()["tools"][0]] * 3},
+        {**registry(), "nextCursor": "more"},
+        {**registry(), "nextCursor": None},
+    ],
+)
+def test_incomplete_or_malformed_registry_is_refused(wire, bad):
+    wire.control["registry"] = bad
+    with pytest.raises(DecisionReferenceError, match="registry"):
+        wire.transport.initialize()
+    assert wire.transport.reads_available is False
+    assert wire.transport._initialized is False
+    assert [c[0]["method"] for c in wire.calls] == [
+        "initialize",
+        "notifications/initialized",
+        "tools/list",
+    ]
+
+
+@pytest.mark.parametrize("mutation", ["name", "schema", "proposal"])
+def test_unknown_or_changed_schema_is_refused(mutation):
+    value = registry()
+    if mutation == "name":
+        value["tools"][2]["name"] = "delete_file"
+    else:
+        index = 0 if mutation == "proposal" else 1
+        value["tools"][index]["inputSchema"]["required"] = []
+    with pytest.raises(DecisionReferenceError):
+        negotiate_registry(value)
+
+
+def test_singleton_read_is_refused_without_tool_call(wire):
+    wire.control["registry"] = registry(False)
+    with pytest.raises(DecisionReferenceError, match="does not expose"):
+        wire.transport.read("get_context", project_id=PROJECT)
+    assert len(wire.calls) == 3
+
+
+@pytest.mark.parametrize(
+    "name,arguments",
+    [
+        ("get_context", {}),
+        ("get_context", {"project_id": "other"}),
+        ("get_context", {"project_id": PROJECT, "extra": True}),
+        ("get_context", {"project_id": PROJECT, "level": 1}),
+        ("get_context", {"project_id": PROJECT, "level": "l0"}),
+        ("get_context", {"project_id": PROJECT, "level": None}),
+        ("get_decision", {"project_id": PROJECT}),
+        ("get_decision", {"project_id": PROJECT, "number": True}),
+        ("get_decision", {"project_id": PROJECT, "number": "1"}),
+        ("get_decision", {"project_id": PROJECT, "number": 1.0}),
+        ("get_decision", {"project_id": PROJECT, "number": 1, "mode": "other"}),
+    ],
+)
+def test_invalid_reads_refuse_before_network_and_before_mcp_coercion(wire, name, arguments):
+    with pytest.raises(DecisionReferenceError):
+        wire.transport.read(name, **arguments)
+    assert wire.calls == []
+    wire.transport.reads_available = True
+    tool = reference_server(wire.transport)._tool_manager.get_tool(name)
+    with pytest.raises(ToolError):
+        asyncio.run(tool.run(arguments))
+    assert wire.calls == []
+
+
+@pytest.mark.parametrize("is_error", [False, True])
+@pytest.mark.parametrize(
+    "name,arguments",
+    [("get_context", {"level": "L2"}), ("get_decision", {"number": 4, "mode": "header"})],
+)
+def test_read_preserves_exact_text_and_error_flag_and_reloads_credentials(
+    wire, is_error, name, arguments
+):
+    wire.control["result"]["isError"] = is_error
+    wire.transport.initialize()
+    tool = reference_server(wire.transport)._tool_manager.get_tool(name)
+    wire.control["token"] = "renewed"
+    result = asyncio.run(tool.run({"project_id": PROJECT, **arguments}))
+    assert result.isError is is_error
+    assert len(result.content) == 1
+    assert result.content[0].text == TEXT
+    assert wire.calls[-1] == (
+        {
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "tools/call",
+            "params": {"name": name, "arguments": {"project_id": PROJECT, **arguments}},
+        },
+        "Bearer renewed",
+    )
+    assert len(wire.calls) == 4
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        None,
+        [],
+        {},
+        {"content": [], "isError": False},
+        {"content": [{"type": "text", "text": "bad"}]},
+        {"content": [{"type": "text", "text": "bad"}], "isError": "false"},
+        {"content": [{"type": "image", "data": "bad"}], "isError": False},
+        {"content": [{"type": "text", "text": 5}], "isError": False},
+        {"content": [{"type": "text", "text": "bad", "extra": 1}], "isError": False},
+        {"content": [{"type": "text", "text": "bad"}], "isError": False, "structuredContent": {}},
+    ],
+)
+def test_malformed_read_results_are_not_forwarded(wire, bad):
+    wire.control["result"] = bad
+    with pytest.raises(DecisionReferenceError, match="No verified read result"):
+        wire.transport.read("get_context", project_id=PROJECT)
+    assert len(wire.calls) == 4
+
+
+def test_text_and_wire_size_limits_are_enforced(wire):
+    value = {"content": [{"type": "text", "text": "x" * (MAX_RESPONSE + 1)}], "isError": False}
+    with pytest.raises(DecisionReferenceError):
+        verify_read_result(value)
+    wire.control["result"] = value
+    with pytest.raises(DecisionReferenceError, match="No verified read result"):
+        wire.transport.read("get_context", project_id=PROJECT)
+    assert len(wire.calls) == 4
+
+
+@pytest.mark.parametrize("failure", [401, 403, 503, "lost", "id"])
+def test_failed_read_has_no_reissue(wire, failure):
+    wire.transport.initialize()
+    if failure == "id":
+        wire.control["rpc_id_delta"] = 1
+    else:
+        wire.control["status"] = failure
+    with pytest.raises(DecisionReferenceError, match="No verified read result"):
+        wire.transport.read("get_decision", project_id=PROJECT, number=4)
+    assert len(wire.calls) == 4
+
+
+@pytest.mark.parametrize("version", [1, 2])
+def test_negotiated_reads_over_real_stdio(version, tmp_path):
+    import sys
+    import time
+
+    from mcp import ClientSession, StdioServerParameters
+    from mcp.client.stdio import stdio_client
+
+    from nauro.sync.decision_profile import RenewalProfile
+    from nauro.sync.reference_auth import ReferenceAuth
+
+    tmp_path.chmod(0o700)
+    credentials = tmp_path / "credentials.json"
+    config = {
+        "version": version,
+        "endpoint": "https://probe.example/mcp",
+        "project_id": PROJECT,
+        "actor_id": ACTOR,
+        "credentials_file": str(credentials),
+    }
+    if version == 1:
+        credentials.write_text(json.dumps({"user_id": ACTOR, "access_token": "synthetic"}))
+        credentials.chmod(0o600)
+    else:
+        config.update(
+            issuer="https://issuer.example/",
+            client_id="synthetic-client",
+            audience="https://probe.example/mcp",
+            expected_subject="synthetic-owner",
+            redirect_uri="http://127.0.0.1:18765/callback",
+        )
+        with httpx.Client() as client:
+            auth = ReferenceAuth(RenewalProfile.model_validate(config), client)
+            with auth.store.locked():
+                auth.store.write(
+                    auth._record(("synthetic", "synthetic-refresh", int(time.time()) + 600))
+                )
+    path = tmp_path / "profile.json"
+    path.write_text(json.dumps(config))
+    path.chmod(0o600)
+    bootstrap = """
+import json
+from types import SimpleNamespace
+import httpx
+from nauro.cli.main import app
+from nauro.mcp import decision_reference_startup as startup
+from nauro.sync.decision_reference_contract import reference_schema
+from nauro.sync.reference_reads import READ_SPECS, read_schema
+
+def wire(request):
+    assert request.headers['authorization'] == 'Bearer synthetic'
+    body = json.loads(request.content)
+    if body['method'] == 'notifications/initialized':
+        return httpx.Response(202)
+    if body['method'] == 'initialize':
+        result = {'protocolVersion': '2025-06-18'}
+    elif body['method'] == 'tools/list':
+        result = {'tools': [{'name': 'propose_decision', 'inputSchema': reference_schema()}] + [
+            {'name': name, 'inputSchema': read_schema(name)} for name in READ_SPECS]}
+    else:
+        assert body['method'] == 'tools/call'
+        name = body['params']['name']
+        assert name in READ_SPECS
+        result = {'content': [{'type': 'text', 'text': 'Exact génération text.\\n'}],
+                  'isError': name == 'get_context'}
+    return httpx.Response(200, json={'jsonrpc': '2.0', 'id': body['id'], 'result': result})
+startup.httpx = SimpleNamespace(Client=lambda: httpx.Client(transport=httpx.MockTransport(wire)))
+app()
+"""
+
+    async def session():
+        params = StdioServerParameters(
+            command=sys.executable,
+            args=["-c", bootstrap, "serve", "--reference-profile", str(path)],
+        )
+        async with stdio_client(params) as (reader, writer):
+            async with ClientSession(reader, writer) as client:
+                await client.initialize()
+                listed = await client.list_tools()
+                assert {tool.name: tool.inputSchema for tool in listed.tools} == {
+                    tool["name"]: tool["inputSchema"] for tool in registry()["tools"]
+                }
+                context = await client.call_tool("get_context", {"project_id": PROJECT})
+                decision = await client.call_tool(
+                    "get_decision", {"project_id": PROJECT, "number": 1}
+                )
+                assert context.isError is True
+                assert decision.isError is False
+                assert context.content == decision.content
+                assert decision.content[0].text == "Exact génération text.\n"
+
+    asyncio.run(asyncio.wait_for(session(), timeout=15))
+
+
+@pytest.mark.parametrize(
+    "raw", [b"[]", b'{"jsonrpc":"2.0","id":4,"id":4,"result":{}}', b"[" * 2000 + b"]" * 2000]
+)
+def test_malformed_rpc_envelopes_refuse_without_resend(wire, raw):
+    wire.transport.initialize()
+    sent = []
+
+    def respond(request):
+        sent.append(request)
+        return httpx.Response(200, content=raw)
+
+    with httpx.Client(transport=httpx.MockTransport(respond)) as client:
+        wire.transport.client = client
+        with pytest.raises(DecisionReferenceError, match="No verified read result"):
+            wire.transport.read("get_context", project_id=PROJECT)
+    assert len(sent) == 1


### PR DESCRIPTION
## Why

The opt-in reference connection accepts only `propose_decision`. It must recognize the existing read tools before the isolated server can expose committed-generation reads to installed clients.

## What changed

Accept either the existing single-tool registry or exactly that tool plus `get_context` and `get_decision`. Verify all schemas and reject duplicate, partial, unknown or paginated registries. Register the read pair only after successful negotiation.

Require the configured project and strict inputs on the isolated read path. Forward bounded text and the exact error flag without automatic reissue, authentication refresh or local fallback. Default tools, CLI commands and decision approval/recovery semantics are unchanged.

## Test plan

286 client and contract tests plus 25 explicit paired-server tests passed, with zero skips. Coverage includes real stdio sessions with both profile versions, registry and input refusals, response limits, exact text/error forwarding, and single-request behavior on failure. Typing, lint/format, source-risk, helper and docstring checks pass.

The paired read test uses a test-only adapter around existing verified server renderers. It confirms forwarding and membership refusal; it does not establish the pending public routes or real-host compatibility.

## Risk / what to review

Review schema negotiation, validation before argument coercion, conditional registration and response limits. The isolated read schemas explicitly require `project_id` and reject extra fields. Rendered text relies on the authenticated server's verified reader; this client does not independently verify artifact hashes from text.

Server exposure must follow this client prerequisite. Older strict clients will reject the expanded registry, so upgrade installed clients before a separately approved server deployment. This PR does not expose server tools or refresh local replicas.

Concurrent writing remains incomplete. Production stays on the single-writer interim; deployment, sync, hooks and generation activation are unchanged.
