### PR TITLE
Accept bounded decision discovery pages

### DIFF
--- a/packages/nauro/src/nauro/sync/decision_reference.py
+++ b/packages/nauro/src/nauro/sync/decision_reference.py
@@ -135,7 +135,7 @@ class DecisionReferenceTransport:
                     or type(value["version"]) is not int
                     or value["version"] != 1
                     or not isinstance(value["requests"], list)
-                    or len(value["requests"]) > 1
+                    or len(value["requests"]) > 10
                 ):
                     raise ValueError("Invalid discovery page")
                 if value["next_after"] is not None and not isinstance(value["next_after"], str):

--- a/packages/nauro/tests/test_decision_discovery_pages.py
+++ b/packages/nauro/tests/test_decision_discovery_pages.py
@@ -1,0 +1,68 @@
+import hashlib
+import json
+
+import pytest
+
+from nauro.sync.decision_reference import DecisionReferenceError
+from tests.test_judgment_submission import _payload
+from tests.test_reference_reads import ACTOR, PROJECT, wire
+
+__all__ = ["wire"]
+
+
+def observation(index):
+    raw = _payload()
+    return {
+        "version": 1,
+        "request": {
+            "project_id": PROJECT,
+            "actor_id": ACTOR,
+            "operation_id": f"decision-request:01K{index:023d}",
+            "created_at": "2026-01-01T00:00:00.000000Z",
+            "payload_digest": hashlib.sha256(raw).hexdigest(),
+            "payload_json": raw.decode(),
+        },
+        "effective_draft": json.loads(raw),
+        "admission": "never_admitted",
+        "admitted_at": None,
+        "deadline": None,
+        "status": "prepared",
+        "unresolved": False,
+        "execution": None,
+    }
+
+
+def set_page(wire, rows):
+    page = {"version": 1, "requests": rows, "next_after": "opaque-cursor"}
+    wire.control["result"] = {
+        "content": [{"type": "text", "text": json.dumps(page)}],
+        "isError": False,
+    }
+    return page
+
+
+@pytest.mark.parametrize("count", [0, 1, 10])
+def test_discovery_accepts_old_and_bounded_pages(wire, count):
+    page = set_page(wire, [observation(index) for index in range(count)])
+    assert wire.transport.propose_decision(project_id=PROJECT, request_mode="discover") == page
+    wire.transport.propose_decision(
+        project_id=PROJECT, request_mode="discover", after=page["next_after"]
+    )
+    assert wire.calls[-1][0]["params"]["arguments"]["after"] == "opaque-cursor"
+
+
+def test_discovery_refuses_more_than_ten_records(wire):
+    set_page(wire, [observation(index) for index in range(11)])
+    with pytest.raises(DecisionReferenceError) as caught:
+        wire.transport.propose_decision(project_id=PROJECT, request_mode="discover")
+    assert str(caught.value.__cause__) == "Invalid discovery page"
+
+
+@pytest.mark.parametrize("index", [0, 5, 9])
+def test_each_record_requires_exact_saved_bytes(wire, index):
+    rows = [observation(index) for index in range(10)]
+    rows[index]["request"]["payload_digest"] = "0" * 64
+    set_page(wire, rows)
+    with pytest.raises(DecisionReferenceError) as caught:
+        wire.transport.propose_decision(project_id=PROJECT, request_mode="discover")
+    assert str(caught.value.__cause__) == "Saved bytes differ from digest"


### PR DESCRIPTION
## Why

The reference client rejects discovery responses containing more than one saved request. It must accept bounded pages before the server can reduce the number of calls needed to find a request after restart or a lost response.

## What changed

Accept up to ten requests per discovery page. Continue to verify every saved request and receipt, preserve existing one-record responses, and reject oversized pages or invalid evidence. Tool names, arguments and approval behavior are unchanged.

## Test plan

Client reference and public-contract tests, explicit client/server protocol checks, changed-file lint and formatting, targeted typing, and the source-risk gate. All passed without skipped conformance checks.

## Risk / what to review

This is a client prerequisite. Before server batching is enabled, install a compatible build in every client used against that endpoint and restart and verify running stdio and driver processes. Merging this PR does not upgrade those processes.

Discovery is not a snapshot, so an empty search result does not prove that no matching request exists. Fewer pages do not establish hosted latency. Concurrent writing remains incomplete, and production activation is unchanged.
