### PR TITLE
Integrate ordinary client decisions and generation reads

### DIFF
--- a/packages/nauro/src/nauro/auth.py
+++ b/packages/nauro/src/nauro/auth.py
@@ -35,6 +35,7 @@ from nauro.store.home import config_file
 # Public OAuth identifiers — safe to ship; not secrets. Do not strip.
 DEFAULT_AUTH0_DOMAIN = "dev-q1kuoa1a154u26iw.us.auth0.com"
 DEFAULT_AUTH0_CLIENT_ID = "FoVl59QaztJou17Xqr3e2QYOupAr1Ke3"
+DEFAULT_AUTH_REDIRECT_URI = "http://localhost:18457/callback"
 DEFAULT_API_URL = "https://mcp.nauro.ai"
 DEFAULT_AUTH0_AUDIENCE = "https://mcp.nauro.ai/mcp"
 

--- a/packages/nauro/src/nauro/cli/autogen.py
+++ b/packages/nauro/src/nauro/cli/autogen.py
@@ -27,6 +27,7 @@ import typer
 from nauro_core.mcp_tools import ALL_TOOLS, ToolSpec
 
 from nauro.cli._json_input import parse_json_list_of_dicts
+from nauro.cli.generation_reads import read_command, require_legacy_read
 from nauro.cli.utils import cli_origin, resolve_target_project
 from nauro.mcp import tools as mcp_tools
 from nauro.mcp.rendering import resolve_renderer_kwargs, try_render_envelope
@@ -464,6 +465,10 @@ def _make_command(spec: ToolSpec) -> Callable[..., None]:
                 kwargs[name] = value.value
 
         adapter_kwargs = {name: kwargs[name] for name in schema_arg_names if name in kwargs}
+        if read_command(
+            tool_name, store_path.name, adapter_kwargs, text=output_format is OutputFormat.text
+        ):
+            return
         if accepts_origin:
             adapter_kwargs["origin"] = cli_origin()
         if accepts_base_commit:
@@ -480,11 +485,13 @@ def _make_command(spec: ToolSpec) -> Callable[..., None]:
             if rendered is not None:
                 # Rendered stdout is the sole carrier of error/guidance prose;
                 # no stderr duplicate. Exit codes stay format-independent.
+                require_legacy_read(tool_name, store_path)
                 typer.echo(rendered)
                 code = _exit_code_for_envelope(envelope)
                 if code:
                     raise typer.Exit(code=code)
                 return
+        require_legacy_read(tool_name, store_path)
         _emit_json_mode(envelope)
 
     command.__signature__ = inspect.Signature(parameters=params)  # type: ignore[attr-defined]

--- a/packages/nauro/src/nauro/cli/commands/auth.py
+++ b/packages/nauro/src/nauro/cli/commands/auth.py
@@ -30,6 +30,7 @@ import typer
 from nauro_core import sanitize_sub
 
 from nauro.auth import (
+    DEFAULT_AUTH_REDIRECT_URI,
     RATE_LIMITED_MESSAGE,
     PartialAuthConfigError,
     decode_jwt_payload,
@@ -44,7 +45,7 @@ auth_app = typer.Typer(help="Manage authentication for remote sync.")
 
 AUTH0_SCOPES = "openid profile email offline_access read:context write:context"
 REDIRECT_PORT = 18457
-REDIRECT_URI = f"http://localhost:{REDIRECT_PORT}/callback"
+REDIRECT_URI = DEFAULT_AUTH_REDIRECT_URI
 
 
 def _generate_pkce() -> tuple[str, str]:

--- a/packages/nauro/src/nauro/cli/commands/auth.py
+++ b/packages/nauro/src/nauro/cli/commands/auth.py
@@ -157,6 +157,8 @@ def login(
     if isinstance(reference_profile, Path):
         _reference_auth("login", reference_profile)
         return
+    if _generation_auth("login"):
+        return
     try:
         domain, client_id, api_url, audience = resolve_auth_config(os.environ, load_config())
     except PartialAuthConfigError as exc:
@@ -263,6 +265,8 @@ def status(
     if isinstance(reference_profile, Path):
         _reference_auth("status", reference_profile)
         return
+    if _generation_auth("status"):
+        return
     config = load_config()
     auth = config.get("auth")
     if not isinstance(auth, dict):
@@ -293,6 +297,8 @@ def logout(
     if isinstance(reference_profile, Path):
         _reference_auth("logout", reference_profile)
         return
+    if _generation_auth("logout"):
+        return
     config = load_config()
     if "auth" not in config:
         typer.echo("Not authenticated - nothing to clear.")
@@ -315,9 +321,26 @@ def _reference_auth(action: str, path: Path) -> None:
 
 @auth_app.command()
 def refresh(
-    reference_profile: Path = typer.Option(
-        ..., "--reference-profile", help="Select reference credentials to renew."
+    reference_profile: Path | None = typer.Option(
+        None, "--reference-profile", help="Select reference credentials to renew."
     ),
 ) -> None:
     """Renew selected reference credentials without replaying a request."""
-    _reference_auth("refresh", reference_profile)
+    if isinstance(reference_profile, Path):
+        _reference_auth("refresh", reference_profile)
+    elif not _generation_auth("refresh"):
+        raise typer.BadParameter("Select a migrated project or --reference-profile")
+
+
+def _generation_auth(action: str) -> bool:
+    from nauro.cli.generation_auth import run_generation_auth
+
+    try:
+        result = run_generation_auth(action, REDIRECT_URI, typer.echo)
+    except ValueError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(code=1) from None
+    if result is None:
+        return False
+    typer.echo(result)
+    return True

--- a/packages/nauro/src/nauro/cli/commands/sync.py
+++ b/packages/nauro/src/nauro/cli/commands/sync.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 import typer
 
 from nauro.auth import load_access_token
+from nauro.cli.generation_reads import refresh_command
 from nauro.cli.integrations.outcomes import BridgeOutcome
 from nauro.cli.integrations.render import render
 from nauro.cli.utils import resolve_target_project
@@ -46,6 +47,8 @@ def sync(
     project_name, store_path = resolve_target_project(project)
     # store_path.name is the project_id (the store directory is id-keyed).
     project_key = store_path.name
+    if refresh_command(project_key, push_only=push_only):
+        return
     trigger = message or "manual sync"
 
     with operation_session() as session:

--- a/packages/nauro/src/nauro/cli/decision_reference.py
+++ b/packages/nauro/src/nauro/cli/decision_reference.py
@@ -46,7 +46,22 @@ def _reference_call(
         profile = load_reference_profile(path)
     except (ValueError, OSError):
         raise typer.BadParameter("Invalid reference profile; use an owner-only file") from None
-    request: dict[str, Any] = {"project_id": profile.project_id}
+    request = _request(profile.project_id, kwargs, spec, context)
+    try:
+        result = _execute(profile, request)
+    except (DecisionReferenceError, ValueError, OSError):
+        typer.echo(
+            "No verified result. Use discover or recover with this profile. No retry was sent.",
+            err=True,
+        )
+        raise typer.Exit(1) from None
+    typer.echo(json.dumps(result, indent=2))
+
+
+def _request(
+    project_id: str, kwargs: dict[str, Any], spec: ToolSpec, context: typer.Context
+) -> dict[str, Any]:
+    request: dict[str, Any] = {"project_id": project_id}
     names = set(spec["input_schema"]["properties"]) - {"project_id", "cwd"}
     names.update({"request_mode", "operation_id", "payload_digest", "after"})
     for name in names:
@@ -60,20 +75,40 @@ def _reference_call(
             value = parse_json_list_of_dicts(value, "--rejected")
         request[name] = value
     try:
-        validate_arguments(request, profile.project_id)
+        validate_arguments(request, project_id)
     except ValueError:
         raise typer.BadParameter(
             "Invalid reference arguments for the selected request mode"
         ) from None
+    return request
+
+
+def _generation_call(kwargs: dict[str, Any], spec: ToolSpec, context: typer.Context) -> bool:
+    from nauro.sync.generation_decision import (
+        REFUSED_STATUSES,
+        execute_decision,
+        select_decision_connection,
+    )
+
     try:
-        result = _execute(profile, request)
-    except (DecisionReferenceError, ValueError, OSError):
+        selected = select_decision_connection(
+            kwargs.get("project"), use_cwd=kwargs.get("project") is None
+        )
+        if selected is None:
+            return False
+        request = _request(selected[1], kwargs, spec, context)
+        result = execute_decision(selected, request, use_cwd=kwargs.get("project") is None)
+    except (ValueError, OSError):
         typer.echo(
-            "No verified result. Use discover or recover with this profile. No retry was sent.",
+            "No verified result. Check auth status or log in, then discover or recover "
+            "in this project. No retry was sent.",
             err=True,
         )
         raise typer.Exit(1) from None
     typer.echo(json.dumps(result, indent=2))
+    if result.get("status") in REFUSED_STATUSES or result.get("unresolved") is True:
+        raise typer.Exit(1)
+    return True
 
 
 def with_reference_options(command: Callable[..., None], spec: ToolSpec) -> Callable[..., None]:
@@ -118,6 +153,8 @@ def with_reference_options(command: Callable[..., None], spec: ToolSpec) -> Call
         profile = kwargs.pop("reference_profile")
         if profile is not None:
             _reference_call(profile, kwargs, spec, context)
+            return
+        if _generation_call(kwargs, spec, context):
             return
         reference_values = [kwargs.pop(name) for name, _, _ in options[1:]]
         if any(value is not None for value in reference_values):

--- a/packages/nauro/src/nauro/cli/generation_auth.py
+++ b/packages/nauro/src/nauro/cli/generation_auth.py
@@ -2,53 +2,14 @@
 
 from __future__ import annotations
 
-import os
 from collections.abc import Callable
-from pathlib import Path
-from urllib.parse import urlsplit
 
 import httpx
 
-from nauro.auth import PartialAuthConfigError, resolve_auth_config
-from nauro.store.config import load_config
-from nauro.store.read_authority import observe_generation_marker
-from nauro.store.resolution import NoProjectError, resolve_project_binding
-from nauro.sync.generation_credentials import GenerationAuth, GenerationConnection
+from nauro.auth import PartialAuthConfigError
+from nauro.sync.generation_connection import selected_connection
+from nauro.sync.generation_credentials import GenerationAuth
 from nauro.sync.reference_auth import AUTH_ERRORS
-
-
-def _origin(value: str) -> str:
-    url = urlsplit(value)
-    if (
-        url.scheme != "https"
-        or not url.hostname
-        or url.username
-        or url.password
-        or url.query
-        or url.fragment
-        or url.path not in {"", "/"}
-    ):
-        raise ValueError("Trusted HTTPS API origin required")
-    return value.rstrip("/")
-
-
-def selected_connection(redirect_uri: str) -> tuple[GenerationConnection, str] | None:
-    try:
-        binding = resolve_project_binding(project_id=None, cwd=str(Path.cwd()))
-    except NoProjectError:
-        return None
-    if observe_generation_marker(binding) is None:
-        return None
-    domain, client, api, audience = resolve_auth_config(os.environ, load_config())
-    if binding.server_url is None or _origin(binding.server_url) != _origin(api):
-        raise ValueError("Project and trusted authentication endpoints differ")
-    return GenerationConnection(
-        endpoint=_origin(api) + "/mcp",
-        issuer=f"https://{domain}/",
-        client_id=client,
-        audience=audience,
-        redirect_uri=redirect_uri,
-    ), binding.project_id
 
 
 def run_generation_auth(

--- a/packages/nauro/src/nauro/cli/generation_auth.py
+++ b/packages/nauro/src/nauro/cli/generation_auth.py
@@ -1,0 +1,79 @@
+"""Select normal authentication from the current project's authority."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+from pathlib import Path
+from urllib.parse import urlsplit
+
+import httpx
+
+from nauro.auth import PartialAuthConfigError, resolve_auth_config
+from nauro.store.config import load_config
+from nauro.store.read_authority import observe_generation_marker
+from nauro.store.resolution import NoProjectError, resolve_project_binding
+from nauro.sync.generation_credentials import GenerationAuth, GenerationConnection
+from nauro.sync.reference_auth import AUTH_ERRORS
+
+
+def _origin(value: str) -> str:
+    url = urlsplit(value)
+    if (
+        url.scheme != "https"
+        or not url.hostname
+        or url.username
+        or url.password
+        or url.query
+        or url.fragment
+        or url.path not in {"", "/"}
+    ):
+        raise ValueError("Trusted HTTPS API origin required")
+    return value.rstrip("/")
+
+
+def selected_connection(redirect_uri: str) -> tuple[GenerationConnection, str] | None:
+    try:
+        binding = resolve_project_binding(project_id=None, cwd=str(Path.cwd()))
+    except NoProjectError:
+        return None
+    if observe_generation_marker(binding) is None:
+        return None
+    domain, client, api, audience = resolve_auth_config(os.environ, load_config())
+    if binding.server_url is None or _origin(binding.server_url) != _origin(api):
+        raise ValueError("Project and trusted authentication endpoints differ")
+    return GenerationConnection(
+        endpoint=_origin(api) + "/mcp",
+        issuer=f"https://{domain}/",
+        client_id=client,
+        audience=audience,
+        redirect_uri=redirect_uri,
+    ), binding.project_id
+
+
+def run_generation_auth(
+    action: str, redirect_uri: str, present_url: Callable[[str], None]
+) -> str | None:
+    try:
+        selected = selected_connection(redirect_uri)
+        if selected is None:
+            return None
+        connection, project = selected
+        with httpx.Client(trust_env=False) as client:
+            auth = GenerationAuth(connection, project, client)
+            if action == "login":
+                auth.login(present_url)
+            elif action == "refresh":
+                auth.refresh()
+            elif action == "logout":
+                auth.logout()
+            elif action == "status":
+                return auth.status()
+            else:
+                raise ValueError("Unsupported authentication action")
+        return "Generation credentials updated. No decision was submitted."
+    except (*AUTH_ERRORS, PartialAuthConfigError):
+        raise ValueError(
+            "Generation authentication failed. "
+            "Check project settings and auth status, or log in again."
+        ) from None

--- a/packages/nauro/src/nauro/cli/generation_reads.py
+++ b/packages/nauro/src/nauro/cli/generation_reads.py
@@ -1,0 +1,64 @@
+"""Route existing read and sync commands for migrated local replicas."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import typer
+
+from nauro.mcp.read_dispatch import GENERATION_READS, generation_response
+from nauro.store.generation_authority import GenerationAuthorityError
+from nauro.store.read_authority import observe_generation_marker
+from nauro.store.resolution import resolve_project_binding
+from nauro.sync.generation_refresh import recover_generation_refresh
+from nauro.sync.generation_session import GenerationTransferSession
+from nauro.sync.remote import TransferBoundaryError
+
+
+def read_command(name: str, project: str, options: dict[str, Any], *, text: bool) -> bool:
+    if name not in GENERATION_READS:
+        return False
+    try:
+        binding = resolve_project_binding(project, None, use_cwd=False)
+        if observe_generation_marker(binding) is None:
+            return False
+        response = generation_response(binding, name, options)
+        typer.echo(response.text if text else json.dumps(response.envelope, ensure_ascii=False))
+        if response.is_error:
+            raise typer.Exit(1)
+    except (GenerationAuthorityError, TransferBoundaryError, OSError) as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(1) from exc
+    return True
+
+
+def refresh_command(project: str, *, push_only: bool) -> bool:
+    try:
+        binding = resolve_project_binding(project, None, use_cwd=False)
+        if observe_generation_marker(binding) is None:
+            return False
+        if push_only:
+            typer.echo("Error: Generation replicas cannot push local files.", err=True)
+            raise typer.Exit(1)
+        with GenerationTransferSession(binding) as session:
+            store = recover_generation_refresh(binding, actor=session.actor, session=session)
+            session.credentials()
+            typer.echo(f"Refreshed generation {store.target.identity.generation_id}.")
+    except (GenerationAuthorityError, TransferBoundaryError, OSError) as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(1) from exc
+    return True
+
+
+def require_legacy_read(name: str, store_path: Path) -> None:
+    if name not in GENERATION_READS:
+        return
+    try:
+        binding = resolve_project_binding(store_path.name, None, use_cwd=False)
+        if binding.store_path != store_path or observe_generation_marker(binding) is not None:
+            raise GenerationAuthorityError("Project read authority changed during the read.")
+    except (ValueError, GenerationAuthorityError, OSError) as exc:
+        typer.echo("Error: Project read authority changed during the read.", err=True)
+        raise typer.Exit(1) from exc

--- a/packages/nauro/src/nauro/mcp/generation_decision.py
+++ b/packages/nauro/src/nauro/mcp/generation_decision.py
@@ -1,0 +1,111 @@
+"""Route the existing local decision tool without replacing the full server."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, cast
+
+from mcp.server.fastmcp import FastMCP
+from mcp.types import CallToolResult, TextContent
+from pydantic import create_model, model_validator
+
+from nauro.mcp.decision_reference import INSTRUCTIONS
+from nauro.mcp.resolution_errors import resolution_error_envelope
+from nauro.store.read_authority import observe_generation_marker
+from nauro.store.resolution import NoProjectError, StoreResolutionError, resolve_project_binding
+from nauro.sync.decision_reference_contract import CONTENT, reference_schema, validate_arguments
+from nauro.sync.generation_decision import (
+    REFUSED_STATUSES,
+    DecisionSession,
+    select_decision_connection,
+)
+
+decision_session = DecisionSession()
+
+REFERENCE_FIELDS = {"request_mode", "operation_id", "payload_digest", "after"}
+
+
+def _request(arguments: dict[str, Any], project: str) -> dict[str, Any]:
+    mode = arguments.get("request_mode") or "prepare"
+    fields = CONTENT if mode == "prepare" else REFERENCE_FIELDS
+    request = {
+        key: value for key, value in arguments.items() if key in fields and value is not None
+    }
+    request.update(project_id=project, request_mode=mode)
+    return request
+
+
+def generation_proposal(arguments: dict[str, Any]) -> CallToolResult | dict[str, Any] | None:
+    try:
+        selected = select_decision_connection(arguments.get("project_id"), arguments.get("cwd"))
+    except StoreResolutionError as error:
+        return resolution_error_envelope(error)
+    if selected is None:
+        if any(arguments.get(key) is not None for key in REFERENCE_FIELDS):
+            raise ValueError("Reference delivery requires a generation-backed project")
+        return None
+    if arguments.get("request_mode") not in {None, "prepare"}:
+        defaults = {"operation": "add"}
+        if any(arguments.get(key) != defaults.get(key) for key in CONTENT):
+            raise ValueError("Reference-only calls cannot replace content")
+    request = _request(arguments, selected[1])
+    result = decision_session.execute(selected, request, arguments.get("cwd"))
+    return CallToolResult(
+        content=[TextContent(type="text", text=json.dumps(result, ensure_ascii=False))],
+        isError=result.get("status") in REFUSED_STATUSES or result.get("unresolved") is True,
+    )
+
+
+def register_argument_validation(server: FastMCP) -> None:
+    tool = server._tool_manager.get_tool("propose_decision")
+    assert tool is not None
+
+    @model_validator(mode="before")
+    def validate_call(cls: Any, value: Any) -> Any:
+        if not isinstance(value, dict):
+            raise ValueError("Decision arguments must be an object")
+        try:
+            selected = select_decision_connection(value.get("project_id"), value.get("cwd"))
+        except StoreResolutionError:
+            return value
+        if selected is not None:
+            raw = {key: item for key, item in value.items() if key not in {"cwd", "mcp_ctx"}}
+            raw["project_id"] = selected[1]
+            validate_arguments(raw, selected[1])
+        elif any(key in value for key in REFERENCE_FIELDS):
+            raise ValueError("Reference delivery requires a generation-backed project")
+        elif not isinstance(value.get("rationale"), str):
+            raise ValueError("Legacy decisions require rationale")
+        return value
+
+    tool.fn_metadata.arg_model = create_model(
+        "NormalDecisionArguments",
+        __base__=tool.fn_metadata.arg_model,
+        __validators__={"validate_call": cast(Any, validate_call)},
+    )
+    schema = reference_schema()
+    for key in REFERENCE_FIELDS:
+        tool.parameters["properties"][key] = dict(schema["properties"][key])
+        tool.parameters["properties"][key].pop("default", None)
+    tool.parameters["properties"]["rationale"] = {
+        "type": "string",
+        "description": tool.parameters["properties"]["rationale"]["description"],
+    }
+    tool.parameters["properties"]["after"]["description"] = (
+        "Opaque cursor; discovery is not a snapshot."
+    )
+    tool.parameters["oneOf"] = schema["oneOf"]
+    tool.description += "\n\nFor generation-backed projects: " + INSTRUCTIONS
+
+
+def refuse_unadapted_write(project_id: str | None, cwd: str | None) -> dict[str, Any] | None:
+    try:
+        binding = resolve_project_binding(project_id, cwd or Path.cwd())
+    except NoProjectError:
+        return None
+    except StoreResolutionError as error:
+        return resolution_error_envelope(error)
+    if observe_generation_marker(binding) is not None:
+        raise ValueError("This mutation is not supported for a generation-backed project")
+    return None

--- a/packages/nauro/src/nauro/mcp/read_dispatch.py
+++ b/packages/nauro/src/nauro/mcp/read_dispatch.py
@@ -9,7 +9,7 @@ from typing import Literal
 from mcp.types import CallToolResult, TextContent
 from nauro_core.renderers import disconnected_reason_code
 
-from nauro.auth import ActiveUserReadError, read_active_user_id
+from nauro.auth import ActiveUserReadError
 from nauro.mcp import generation_responses as generation
 from nauro.mcp import tools as legacy
 from nauro.mcp.rendering import resolve_renderer_kwargs, try_render_envelope
@@ -24,6 +24,7 @@ from nauro.store.resolution import (
     StoreResolutionError,
     resolve_project_binding,
 )
+from nauro.sync.generation_session import GenerationTransferSession
 from nauro.sync.history_transport import HttpHistoryTransport
 from nauro.sync.remote import TransferBoundaryError
 
@@ -62,16 +63,52 @@ def _legacy_result(
     )
 
 
+GENERATION_READS = frozenset(
+    {
+        "get_context",
+        "get_raw_file",
+        "list_decisions",
+        "get_decision",
+        "search_decisions",
+        "check_decision",
+        "diff_since_last_session",
+    }
+)
+
+
+def generation_response(
+    binding: ResolvedProjectBinding,
+    name: str,
+    options: dict[str, object],
+    transport: HttpHistoryTransport | None = None,
+) -> generation.GenerationToolResponse:
+    if name not in GENERATION_READS:
+        raise ValueError("Unsupported generation read")
+    with GenerationTransferSession(binding) as session:
+        arguments = dict(options)
+        if name in {"search_decisions", "check_decision"}:
+            arguments["use_embeddings"] = resolve_embeddings_flag()
+        if name == "diff_since_last_session":
+            arguments["transport"] = transport or HttpHistoryTransport(
+                session.api_url, session.client, session.credentials
+            )
+        response: generation.GenerationToolResponse = getattr(generation, name)(
+            binding, **arguments, actor=session.actor, session=session
+        )
+        session.credentials()
+        return response
+
+
 def _read(
     name: str,
     project_id: str | None,
     cwd: str | None,
     flat: Callable[[Path], dict[str, object]],
-    projected: Callable[[ResolvedProjectBinding, str], generation.GenerationToolResponse],
     options: dict[str, object] | None = None,
+    transport: HttpHistoryTransport | None = None,
 ) -> CallToolResult:
     try:
-        binding = resolve_project_binding(project_id, cwd)
+        binding = resolve_project_binding(project_id, cwd or Path.cwd())
     except (NoProjectError, DisconnectedProjectError) as exc:
         return _legacy_result(name, resolution_error_envelope(exc), options or {}, None)
     except (StoreResolutionError, OSError):
@@ -79,9 +116,8 @@ def _read(
     try:
         marker = observe_generation_marker(binding)
         if marker is not None:
-            actor = read_active_user_id()
-            response = projected(binding, actor)
-            if read_active_user_id() != actor or observe_generation_marker(binding) != marker:
+            response = generation_response(binding, name, options or {}, transport)
+            if observe_generation_marker(binding) != marker:
                 return _unavailable()
             return _prepared(response)
         result = _legacy_result(name, flat(binding.store_path), options or {}, binding.store_path)
@@ -106,7 +142,6 @@ def get_context(
         project_id,
         cwd,
         lambda p: legacy.tool_get_context(p, level),
-        lambda b, a: generation.get_context(b, level, actor=a),
         {"level": level},
     )
 
@@ -115,12 +150,7 @@ def get_raw_file(
     path: str, project_id: str | None = None, cwd: str | None = None
 ) -> CallToolResult:
     return _read(
-        "get_raw_file",
-        project_id,
-        cwd,
-        lambda p: legacy.tool_get_raw_file(p, path),
-        lambda b, a: generation.get_raw_file(b, path, actor=a),
-        {"path": path},
+        "get_raw_file", project_id, cwd, lambda p: legacy.tool_get_raw_file(p, path), {"path": path}
     )
 
 
@@ -135,7 +165,7 @@ def list_decisions(
         project_id,
         cwd,
         lambda p: legacy.tool_list_decisions(p, limit, include_superseded),
-        lambda b, a: generation.list_decisions(b, limit, include_superseded, actor=a),
+        {"limit": limit, "include_superseded": include_superseded},
     )
 
 
@@ -150,8 +180,7 @@ def get_decision(
         project_id,
         cwd,
         lambda p: legacy.tool_get_decision(p, number, mode),
-        lambda b, a: generation.get_decision(b, number, mode, actor=a),
-        {"mode": mode},
+        {"number": number, "mode": mode},
     )
 
 
@@ -167,15 +196,7 @@ def search_decisions(
         project_id,
         cwd,
         lambda p: legacy.tool_search_decisions(p, query, limit, include_superseded),
-        lambda b, a: generation.search_decisions(
-            b,
-            query,
-            limit,
-            include_superseded,
-            actor=a,
-            use_embeddings=resolve_embeddings_flag(),
-        ),
-        {"query": query},
+        {"query": query, "limit": limit, "include_superseded": include_superseded},
     )
 
 
@@ -190,9 +211,7 @@ def check_decision(
         project_id,
         cwd,
         lambda p: legacy.tool_check_decision(p, proposed_approach, context),
-        lambda b, a: generation.check_decision(
-            b, proposed_approach, context, actor=a, use_embeddings=resolve_embeddings_flag()
-        ),
+        {"proposed_approach": proposed_approach, "context": context},
     )
 
 
@@ -207,7 +226,8 @@ def _history_diff(
         project_id,
         cwd,
         lambda p: legacy.tool_diff_since_last_session(p, days),
-        lambda b, a: generation.diff_since_last_session(b, days, actor=a, transport=transport),
+        {"days": days},
+        transport,
     )
 
 

--- a/packages/nauro/src/nauro/mcp/stdio_server.py
+++ b/packages/nauro/src/nauro/mcp/stdio_server.py
@@ -30,20 +30,14 @@ from nauro_core.renderers import disconnected_reason_code
 from pydantic import Field
 
 from nauro import __version__
+from nauro.mcp import read_dispatch
 from nauro.mcp.decision_reference import INSTRUCTIONS as REFERENCE_INSTRUCTIONS
 from nauro.mcp.generation_decision import decision_session, register_argument_validation
-from nauro.mcp.rendering import resolve_renderer_kwargs, try_render_envelope
+from nauro.mcp.rendering import try_render_envelope
 from nauro.mcp.resolution_errors import resolution_error_envelope
 from nauro.mcp.tools import (
-    tool_check_decision,
-    tool_diff_since_last_session,
     tool_flag_question,
-    tool_get_context,
-    tool_get_decision,
-    tool_get_raw_file,
-    tool_list_decisions,
     tool_propose_decision,
-    tool_search_decisions,
     tool_update_state,
 )
 from nauro.mcp.write_status import render_write_status
@@ -188,14 +182,10 @@ def get_context(
         Field(description=_param_desc("get_context", "level")),
     ] = "L0",
 ) -> CallToolResult:
-    store_path, err = _resolve_or_error(project_id, cwd)
-    # tool_get_context accepts both int and string levels.
-    result = err if err is not None else tool_get_context(store_path, level)
-    return _wrap_with_renderer(
-        "get_context",
-        result,
-        resolve_renderer_kwargs("get_context", {"level": level}, store_path),
-    )
+    _, error = _resolve_or_error(project_id, cwd)
+    if error is not None:
+        return _wrap_with_renderer("get_context", error)
+    return read_dispatch.get_context(project_id=project_id, cwd=cwd, level=level)
 
 
 @mcp.tool(**_spec_kwargs("get_raw_file"))
@@ -206,13 +196,10 @@ def get_raw_file(
     ] = None,
     cwd: _CWD_PARAM = None,
 ) -> CallToolResult:
-    store_path, err = _resolve_or_error(project_id, cwd)
-    result = err if err is not None else tool_get_raw_file(store_path, path)
-    return _wrap_with_renderer(
-        "get_raw_file",
-        result,
-        resolve_renderer_kwargs("get_raw_file", {"path": path}, store_path),
-    )
+    _, error = _resolve_or_error(project_id, cwd)
+    if error is not None:
+        return _wrap_with_renderer("get_raw_file", error)
+    return read_dispatch.get_raw_file(path=path, project_id=project_id, cwd=cwd)
 
 
 @mcp.tool(**_spec_kwargs("list_decisions"))
@@ -226,9 +213,12 @@ def list_decisions(
         bool, Field(description=_param_desc("list_decisions", "include_superseded"))
     ] = False,
 ) -> CallToolResult:
-    store_path, err = _resolve_or_error(project_id, cwd)
-    result = err if err is not None else tool_list_decisions(store_path, limit, include_superseded)
-    return _wrap_with_renderer("list_decisions", result)
+    _, error = _resolve_or_error(project_id, cwd)
+    if error is not None:
+        return _wrap_with_renderer("list_decisions", error)
+    return read_dispatch.list_decisions(
+        project_id=project_id, cwd=cwd, limit=limit, include_superseded=include_superseded
+    )
 
 
 @mcp.tool(**_spec_kwargs("get_decision"))
@@ -242,13 +232,10 @@ def get_decision(
     ] = None,
     cwd: _CWD_PARAM = None,
 ) -> CallToolResult:
-    store_path, err = _resolve_or_error(project_id, cwd)
-    result = err if err is not None else tool_get_decision(store_path, number, mode)
-    return _wrap_with_renderer(
-        "get_decision",
-        result,
-        resolve_renderer_kwargs("get_decision", {"mode": mode}, store_path),
-    )
+    _, error = _resolve_or_error(project_id, cwd)
+    if error is not None:
+        return _wrap_with_renderer("get_decision", error)
+    return read_dispatch.get_decision(number=number, mode=mode, project_id=project_id, cwd=cwd)
 
 
 @mcp.tool(**_spec_kwargs("diff_since_last_session"))
@@ -262,9 +249,10 @@ def diff_since_last_session(
         int | None, Field(description=_param_desc("diff_since_last_session", "days"))
     ] = None,
 ) -> CallToolResult:
-    store_path, err = _resolve_or_error(project_id, cwd)
-    result = err if err is not None else tool_diff_since_last_session(store_path, days)
-    return _wrap_with_renderer("diff_since_last_session", result)
+    _, error = _resolve_or_error(project_id, cwd)
+    if error is not None:
+        return _wrap_with_renderer("diff_since_last_session", error)
+    return read_dispatch.diff_since_last_session(project_id=project_id, cwd=cwd, days=days)
 
 
 @mcp.tool(**_spec_kwargs("search_decisions"))
@@ -279,19 +267,15 @@ def search_decisions(
     ] = None,
     cwd: _CWD_PARAM = None,
 ) -> CallToolResult:
-    store_path, err = _resolve_or_error(project_id, cwd)
-    result = (
-        err
-        if err is not None
-        else tool_search_decisions(store_path, query, limit, include_superseded)
-    )
-    # The kernel envelope omits the echoed query; thread it to the renderer
-    # so the local header shows the term, matching the remote transport,
-    # which carries query in its envelope.
-    return _wrap_with_renderer(
-        "search_decisions",
-        result,
-        resolve_renderer_kwargs("search_decisions", {"query": query}, store_path),
+    _, error = _resolve_or_error(project_id, cwd)
+    if error is not None:
+        return _wrap_with_renderer("search_decisions", error)
+    return read_dispatch.search_decisions(
+        query=query,
+        limit=limit,
+        include_superseded=include_superseded,
+        project_id=project_id,
+        cwd=cwd,
     )
 
 
@@ -308,9 +292,12 @@ def check_decision(
     ] = None,
     cwd: _CWD_PARAM = None,
 ) -> CallToolResult:
-    store_path, err = _resolve_or_error(project_id, cwd)
-    result = err if err is not None else tool_check_decision(store_path, proposed_approach, context)
-    return _wrap_with_renderer("check_decision", result)
+    _, error = _resolve_or_error(project_id, cwd)
+    if error is not None:
+        return _wrap_with_renderer("check_decision", error)
+    return read_dispatch.check_decision(
+        proposed_approach=proposed_approach, context=context, project_id=project_id, cwd=cwd
+    )
 
 
 @mcp.tool(**_spec_kwargs("propose_decision"))

--- a/packages/nauro/src/nauro/mcp/stdio_server.py
+++ b/packages/nauro/src/nauro/mcp/stdio_server.py
@@ -18,17 +18,20 @@ from __future__ import annotations
 import json
 import logging
 from pathlib import Path
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any, Literal, cast
 
 from mcp.server import FastMCP
 from mcp.server.fastmcp import Context
 from mcp.types import CallToolResult, TextContent, ToolAnnotations
 from nauro_core.constants import MCP_INSTRUCTIONS_STATIC
 from nauro_core.mcp_tools import ToolSpec, get_tool_spec
+from nauro_core.protocol import APPROVAL_BEFORE_PROPOSE
 from nauro_core.renderers import disconnected_reason_code
 from pydantic import Field
 
 from nauro import __version__
+from nauro.mcp.decision_reference import INSTRUCTIONS as REFERENCE_INSTRUCTIONS
+from nauro.mcp.generation_decision import decision_session, register_argument_validation
 from nauro.mcp.rendering import resolve_renderer_kwargs, try_render_envelope
 from nauro.mcp.resolution_errors import resolution_error_envelope
 from nauro.mcp.tools import (
@@ -55,7 +58,17 @@ from nauro.store.resolution import (
 )
 
 logger = logging.getLogger("nauro.stdio")
-mcp = FastMCP("nauro", instructions=MCP_INSTRUCTIONS_STATIC, log_level="WARNING")
+mcp = FastMCP(
+    "nauro",
+    instructions=MCP_INSTRUCTIONS_STATIC.replace(
+        APPROVAL_BEFORE_PROPOSE,
+        "For local and legacy projects: "
+        + APPROVAL_BEFORE_PROPOSE
+        + "\nFor generation-backed projects: "
+        + REFERENCE_INSTRUCTIONS,
+    ),
+    log_level="WARNING",
+)
 # FastMCP does not forward a version to the underlying low-level server, which
 # otherwise reports the mcp framework version in the initialize response. Set
 # the nauro package version so connecting clients see the release in use.
@@ -106,7 +119,7 @@ def _param_desc(tool_name: str, param: str) -> str:
             f"ToolSpec for {tool_name!r} has no description for {param!r}; "
             "either add one in nauro_core.mcp_tools or omit the Annotated."
         )
-    return props[param]["description"]
+    return cast(str, props[param]["description"])
 
 
 def _resolve_or_error(project_id, cwd) -> tuple[Path | None, dict | None]:
@@ -302,8 +315,12 @@ def check_decision(
 
 @mcp.tool(**_spec_kwargs("propose_decision"))
 def propose_decision(
-    rationale: Annotated[str, Field(description=_param_desc("propose_decision", "rationale"))],
-    title: Annotated[str, Field(description=_param_desc("propose_decision", "title"))] = "",
+    rationale: Annotated[
+        str | None, Field(description=_param_desc("propose_decision", "rationale"))
+    ] = None,
+    title: Annotated[
+        str | None, Field(description=_param_desc("propose_decision", "title"))
+    ] = None,
     operation: Annotated[
         Literal["add", "update", "supersede"],
         Field(description=_param_desc("propose_decision", "operation")),
@@ -352,14 +369,25 @@ def propose_decision(
         Field(description=_param_desc("propose_decision", "project_id")),
     ] = None,
     cwd: _CWD_PARAM = None,
+    request_mode: Literal["prepare", "submit", "recover", "discover", "retry"] | None = None,
+    operation_id: str | None = None,
+    payload_digest: str | None = None,
+    after: str | None = None,
     mcp_ctx: Context | None = None,
-) -> dict:
+) -> Any:
+    from nauro.mcp.generation_decision import generation_proposal
+
+    result = generation_proposal(locals())
+    if result is not None:
+        return result
+    if rationale is None:
+        raise ValueError("Legacy decisions require rationale")
     store_path, err = _resolve_or_error(project_id, cwd)
     if err is not None:
         return err
     return tool_propose_decision(
         store_path,
-        title=title,
+        title=title if title is not None else "",
         rationale=rationale,
         operation=operation,
         affected_decision_id=affected_decision_id,
@@ -394,6 +422,12 @@ def flag_question(
     cwd: _CWD_PARAM = None,
     mcp_ctx: Context | None = None,
 ) -> str | dict:
+    from nauro.mcp.generation_decision import refuse_unadapted_write
+
+    refusal = refuse_unadapted_write(project_id, cwd)
+    if refusal is not None:
+        return refusal if disconnected_reason_code(refusal) is not None else refusal["guidance"]
+
     store_path, err = _resolve_or_error(project_id, cwd)
     if err is not None:
         return err if disconnected_reason_code(err) is not None else err["guidance"]
@@ -426,6 +460,12 @@ def update_state(
     cwd: _CWD_PARAM = None,
     mcp_ctx: Context | None = None,
 ) -> str | dict:
+    from nauro.mcp.generation_decision import refuse_unadapted_write
+
+    refusal = refuse_unadapted_write(project_id, cwd)
+    if refusal is not None:
+        return refusal if disconnected_reason_code(refusal) is not None else refusal["guidance"]
+
     store_path, err = _resolve_or_error(project_id, cwd)
     if err is not None:
         return err if disconnected_reason_code(err) is not None else err["guidance"]
@@ -437,6 +477,9 @@ def update_state(
         return f"State updated. {warning}" if warning else "State updated."
 
     return render_write_status(result, updated)
+
+
+register_argument_validation(mcp)
 
 
 def _pull_on_startup() -> None:
@@ -467,4 +510,7 @@ def _pull_on_startup() -> None:
 def run_stdio() -> None:
     """Run the MCP server over stdio (called by `nauro serve --stdio`)."""
     _pull_on_startup()
-    mcp.run(transport="stdio")
+    try:
+        mcp.run(transport="stdio")
+    finally:
+        decision_session.close()

--- a/packages/nauro/src/nauro/mcp/stdio_server.py
+++ b/packages/nauro/src/nauro/mcp/stdio_server.py
@@ -300,7 +300,7 @@ def check_decision(
     )
 
 
-@mcp.tool(**_spec_kwargs("propose_decision"))
+@mcp.tool(**_spec_kwargs("propose_decision"), structured_output=False)
 def propose_decision(
     rationale: Annotated[
         str | None, Field(description=_param_desc("propose_decision", "rationale"))

--- a/packages/nauro/src/nauro/store/resolution.py
+++ b/packages/nauro/src/nauro/store/resolution.py
@@ -558,10 +558,12 @@ def _store_path_or_raise(connection: RepoResolution | DisconnectedProject) -> Pa
 def resolve_project_binding(
     project_id: str | None,
     cwd: str | Path | None,
+    *,
+    use_cwd: bool = True,
 ) -> ResolvedProjectBinding:
     """Resolve and validate a local or cloud project binding."""
     cwd_path = Path(cwd) if cwd else Path.cwd()
-    cfg = _strict_repo_config_from_cwd(cwd_path)
+    cfg = _strict_repo_config_from_cwd(cwd_path) if use_cwd else None
     target_id = cfg.id if cfg is not None else project_id
     entries = _strict_registry_entries(target_id, cfg).projects
 
@@ -605,7 +607,7 @@ def resolve_project_binding(
             "NAURO_HOME if you expected an existing project."
         )
 
-    if cwd:
+    if cwd and use_cwd:
         resolved_cwd = cwd_path.resolve()
         path_matches = {
             pid: entry

--- a/packages/nauro/src/nauro/sync/generation_acquisition.py
+++ b/packages/nauro/src/nauro/sync/generation_acquisition.py
@@ -25,6 +25,7 @@ from nauro.store.generation_projection import (
     verify_generation_projection,
 )
 from nauro.store.resolution import ResolvedProjectBinding
+from nauro.sync.generation_session import GenerationTransferSession
 from nauro.sync.remote import (
     _DEFAULT_API_TIMEOUT,
     _DEFAULT_TRANSFER_TIMEOUT,
@@ -121,7 +122,13 @@ def _api_response(
         )
         return response
 
-    response = with_token_refresh(call, client=session.client)
+    if isinstance(session, GenerationTransferSession):
+        if endpoint not in {session.api_url + _PROJECTION_ROUTE, session.api_url + _PRESIGN_ROUTE}:
+            raise GenerationAcquisitionError("Generation endpoint differs from the connection.")
+        response = call(session.credentials().access_token)
+        session.credentials()
+    else:
+        response = with_token_refresh(call, client=session.client)
     if response.status_code == 200:
         return response
     # Typed refusals are mapped ahead of the status classifier because a
@@ -308,7 +315,11 @@ def acquire_generation_projection(
     except ValueError as exc:
         raise ReplicaActorMismatchError(_NO_ACTOR) from exc
     with operation_session(session) as active:
-        api_url = resolve_api_url()
+        if isinstance(active, GenerationTransferSession):
+            active.require_binding(binding)
+        api_url = (
+            active.api_url if isinstance(active, GenerationTransferSession) else resolve_api_url()
+        )
         attempts = 0
         while True:
             attempts += 1
@@ -329,7 +340,12 @@ def check_generation_projection(
         raise GenerationAcquisitionError("Generation acquisition requires a cloud project binding.")
     user_id = validate_identifier(IdentifierKind.ulid, active_user_id, field="active_user_id")
     with operation_session(session) as active:
-        target, manifest = _fetch_projection(active, resolve_api_url(), binding, user_id)
+        if isinstance(active, GenerationTransferSession):
+            active.require_binding(binding)
+        api_url = (
+            active.api_url if isinstance(active, GenerationTransferSession) else resolve_api_url()
+        )
+        target, manifest = _fetch_projection(active, api_url, binding, user_id)
         _parse_manifest(target, manifest)
         return target
 

--- a/packages/nauro/src/nauro/sync/generation_connection.py
+++ b/packages/nauro/src/nauro/sync/generation_connection.py
@@ -9,7 +9,7 @@ from urllib.parse import urlsplit
 from nauro.auth import resolve_auth_config
 from nauro.store.config import load_config
 from nauro.store.read_authority import observe_generation_marker
-from nauro.store.resolution import NoProjectError, resolve_project_binding
+from nauro.store.resolution import NoProjectError, ResolvedProjectBinding, resolve_project_binding
 from nauro.sync.generation_credentials import GenerationConnection
 
 
@@ -43,6 +43,12 @@ def selected_connection(
         return None
     if observe_generation_marker(binding) is None:
         return None
+    return connection_for(binding, redirect_uri), binding.project_id
+
+
+def connection_for(binding: ResolvedProjectBinding, redirect_uri: str) -> GenerationConnection:
+    if observe_generation_marker(binding) is None:
+        raise ValueError("Generation authority required")
     domain, client, api, audience = resolve_auth_config(os.environ, load_config())
     if binding.server_url is None or _origin(binding.server_url) != _origin(api):
         raise ValueError("Project and trusted authentication endpoints differ")
@@ -52,4 +58,4 @@ def selected_connection(
         client_id=client,
         audience=audience,
         redirect_uri=redirect_uri,
-    ), binding.project_id
+    )

--- a/packages/nauro/src/nauro/sync/generation_connection.py
+++ b/packages/nauro/src/nauro/sync/generation_connection.py
@@ -1,0 +1,55 @@
+"""Bind generation delivery to the resolved project and trusted connection."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from urllib.parse import urlsplit
+
+from nauro.auth import resolve_auth_config
+from nauro.store.config import load_config
+from nauro.store.read_authority import observe_generation_marker
+from nauro.store.resolution import NoProjectError, resolve_project_binding
+from nauro.sync.generation_credentials import GenerationConnection
+
+
+def _origin(value: str) -> str:
+    url = urlsplit(value)
+    if (
+        url.scheme != "https"
+        or not url.hostname
+        or url.username
+        or url.password
+        or url.query
+        or url.fragment
+        or url.path not in {"", "/"}
+    ):
+        raise ValueError("Trusted HTTPS API origin required")
+    return value.rstrip("/")
+
+
+def selected_connection(
+    redirect_uri: str,
+    project_id: str | None = None,
+    cwd: str | Path | None = None,
+    *,
+    use_cwd: bool = True,
+) -> tuple[GenerationConnection, str] | None:
+    try:
+        binding = resolve_project_binding(
+            project_id=project_id, cwd=cwd or Path.cwd(), use_cwd=use_cwd
+        )
+    except NoProjectError:
+        return None
+    if observe_generation_marker(binding) is None:
+        return None
+    domain, client, api, audience = resolve_auth_config(os.environ, load_config())
+    if binding.server_url is None or _origin(binding.server_url) != _origin(api):
+        raise ValueError("Project and trusted authentication endpoints differ")
+    return GenerationConnection(
+        endpoint=_origin(api) + "/mcp",
+        issuer=f"https://{domain}/",
+        client_id=client,
+        audience=audience,
+        redirect_uri=redirect_uri,
+    ), binding.project_id

--- a/packages/nauro/src/nauro/sync/generation_credentials.py
+++ b/packages/nauro/src/nauro/sync/generation_credentials.py
@@ -1,0 +1,226 @@
+"""Normal account credentials for projects on generation authority."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import secrets
+import time
+from collections.abc import Callable
+from pathlib import Path
+from typing import Literal
+from urllib.parse import urlsplit
+
+import httpx
+from nauro_core.identifiers import IdentifierKind, validate_identifier
+from pydantic import BaseModel, ConfigDict, model_validator
+
+from nauro.auth import ActiveCredentials
+from nauro.store.home import nauro_home
+from nauro.sync.decision_profile import _private_json
+from nauro.sync.decision_reference import DecisionReferenceTransport
+from nauro.sync.reference_auth import AUTH_ERRORS, renew_credentials
+from nauro.sync.reference_credentials import CredentialRecord, CredentialStore
+from nauro.sync.reference_oauth import (
+    callback_code,
+    exchange_tokens,
+    response_json,
+    verified_claims,
+)
+
+
+class GenerationConnection(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
+
+    endpoint: str
+    issuer: str
+    client_id: str
+    audience: str
+    redirect_uri: str
+
+    @model_validator(mode="after")
+    def validate_urls(self) -> GenerationConnection:
+        for value, path in ((self.endpoint, "/mcp"), (self.issuer, "/")):
+            url = urlsplit(value)
+            if (
+                url.scheme != "https"
+                or not url.hostname
+                or url.username
+                or url.password
+                or url.query
+                or url.fragment
+                or url.path != path
+            ):
+                raise ValueError("Trusted HTTPS connection required")
+        redirect = urlsplit(self.redirect_uri)
+        if (
+            redirect.scheme != "http"
+            or redirect.hostname not in {"127.0.0.1", "localhost"}
+            or not redirect.port
+            or redirect.path != "/callback"
+            or redirect.username
+            or redirect.password
+            or redirect.query
+            or redirect.fragment
+        ):
+            raise ValueError("Loopback callback required")
+        if not self.client_id or not self.audience:
+            raise ValueError("Authentication pins required")
+        return self
+
+    def binding(self) -> str:
+        return hashlib.sha256(json.dumps(self.model_dump(), sort_keys=True).encode()).hexdigest()
+
+    def store(self) -> AccountStore:
+        return AccountStore(
+            nauro_home() / f"generation-credentials-{self.binding()}.json", self.binding()
+        )
+
+
+class AccountRecord(CredentialRecord):
+    version: Literal[3] = 3  # type: ignore[assignment]
+    subject: str = ""
+
+    @model_validator(mode="after")
+    def validate_identity(self) -> AccountRecord:
+        if self.user_id:
+            validate_identifier(IdentifierKind.ulid, self.user_id, field="user_id")
+        if self.state == "active" and not all(
+            (self.user_id, self.subject, self.access_token, self.refresh_token)
+        ):
+            raise ValueError("Verified account identity required")
+        return self
+
+
+class AccountStore(CredentialStore):
+    def __init__(self, path: Path, binding: str) -> None:
+        super().__init__(path, binding, "")
+
+    def read(self) -> AccountRecord | None:
+        try:
+            if self.path.lstat().st_nlink != 1:
+                raise ValueError("Credential hard links are refused")
+            record = AccountRecord.model_validate(_private_json(self.path))
+        except FileNotFoundError:
+            return None
+        if record.binding != self.binding:
+            raise ValueError("Credentials differ from the selected connection")
+        return record
+
+    def empty(self, state: Literal["logged_out", "renewal_in_progress"]) -> AccountRecord:
+        before = self.read()
+        return AccountRecord(
+            revision=secrets.token_hex(32),
+            binding=self.binding,
+            state=state,
+            user_id=before.user_id if before else "",
+            subject=before.subject if before else "",
+        )
+
+
+def generation_credentials(connection: GenerationConnection, actor: str) -> ActiveCredentials:
+    store = connection.store()
+    with store.locked():
+        record = store.read()
+        if (
+            store.incomplete()
+            or record is None
+            or record.state != "active"
+            or record.expires_at <= time.time()
+            or record.user_id != actor
+        ):
+            raise ValueError("Generation login or explicit refresh required")
+        return ActiveCredentials(record.user_id, record.access_token)
+
+
+class GenerationAuth:
+    def __init__(
+        self, connection: GenerationConnection, project: str, client: httpx.Client
+    ) -> None:
+        validate_identifier(IdentifierKind.ulid, project, field="project")
+        self.connection, self.project, self.client = connection, project, client
+        self.store = connection.store()
+
+    def _tokens(self, grant: dict[str, str]) -> tuple[str, str, dict]:
+        access, refresh = exchange_tokens(self.connection, self.client, grant)
+        return access, refresh, verified_claims(self.connection, access, self.client)
+
+    def _record(self, access: str, refresh: str, claims: dict, actor: str) -> AccountRecord:
+        return AccountRecord(
+            revision=secrets.token_hex(32),
+            binding=self.store.binding,
+            state="active",
+            user_id=actor,
+            subject=claims["sub"],
+            access_token=access,
+            refresh_token=refresh,
+            expires_at=claims["exp"],
+        )
+
+    def login(self, present_url: Callable[[str], None]) -> None:
+        with self.store.locked():
+            before = self.store.read()
+            revision = before.revision if before else None
+        code, verifier = callback_code(self.connection, present_url)
+        access, refresh, claims = self._tokens(
+            {
+                "grant_type": "authorization_code",
+                "code": code,
+                "code_verifier": verifier,
+                "redirect_uri": self.connection.redirect_uri,
+            }
+        )
+        identity = response_json(
+            self.client,
+            "GET",
+            self.connection.endpoint.removesuffix("/mcp") + "/me",
+            headers={"Authorization": "Bearer " + access},
+        )
+        actor = validate_identifier(IdentifierKind.ulid, identity.get("user_id"), field="user_id")
+        record = self._record(access, refresh, claims, actor)
+        transport = DecisionReferenceTransport(
+            self.connection.endpoint,
+            self.project,
+            actor,
+            self.client,
+            lambda: ActiveCredentials(actor, access),
+        )
+        transport.propose_decision(project_id=self.project, request_mode="discover")
+        with self.store.locked():
+            current = self.store.read()
+            if (current.revision if current else None) != revision:
+                raise ValueError("Credentials changed during login; login again")
+            self.store.begin()
+            try:
+                self.store.write(record)
+                self.store.finish()
+            except AUTH_ERRORS:
+                self.store.begin()
+                raise
+
+    def refresh(self) -> None:
+        def replacement(before: CredentialRecord) -> AccountRecord:
+            if not isinstance(before, AccountRecord):
+                raise ValueError("Generation login required")
+            access, refresh, claims = self._tokens(
+                {"grant_type": "refresh_token", "refresh_token": before.refresh_token}
+            )
+            if claims["sub"] != before.subject:
+                raise ValueError("Account changed during renewal")
+            return self._record(access, refresh, claims, before.user_id)
+
+        renew_credentials(self.store, replacement)
+
+    def logout(self) -> None:
+        with self.store.locked():
+            self.store.write(self.store.empty("logged_out"))
+            self.store.finish()
+
+    def status(self) -> str:
+        with self.store.locked():
+            record = self.store.read()
+            if self.store.incomplete() or (record and record.state == "renewal_in_progress"):
+                return "reauthentication_required"
+            if record is None or record.state == "logged_out":
+                return "logged_out"
+            return "active" if record.expires_at > time.time() else "expired"

--- a/packages/nauro/src/nauro/sync/generation_decision.py
+++ b/packages/nauro/src/nauro/sync/generation_decision.py
@@ -1,0 +1,92 @@
+"""Prepared-reference delivery for normal generation-backed decision calls."""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from nauro.auth import DEFAULT_AUTH_REDIRECT_URI, ActiveCredentials, PartialAuthConfigError
+from nauro.sync.decision_reference import DecisionReferenceTransport
+from nauro.sync.generation_connection import selected_connection
+from nauro.sync.generation_credentials import GenerationConnection, generation_credentials
+
+REFUSED_STATUSES = {"stale", "unresolved", "pending", "expired", "conflict", "disposed"}
+Selection = tuple[GenerationConnection, str]
+
+
+def select_decision_connection(
+    project: str | None = None, cwd: str | Path | None = None, *, use_cwd: bool = True
+) -> Selection | None:
+    try:
+        return selected_connection(DEFAULT_AUTH_REDIRECT_URI, project, cwd, use_cwd=use_cwd)
+    except PartialAuthConfigError:
+        raise ValueError("Trusted authentication configuration is incomplete") from None
+
+
+def reference_client() -> httpx.Client:
+    return httpx.Client(trust_env=False)
+
+
+class DecisionSession:
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._client: httpx.Client | None = None
+        self._transport: DecisionReferenceTransport | None = None
+        self._key: tuple[str, str, str] | None = None
+
+    def close(self) -> None:
+        with self._lock:
+            if self._client is not None:
+                self._client.close()
+            self._client = self._transport = self._key = None
+
+    def execute(
+        self,
+        selected: Selection,
+        request: dict[str, Any],
+        cwd: str | Path | None = None,
+        *,
+        use_cwd: bool = True,
+    ) -> dict[str, Any]:
+        with self._lock:
+            connection, project = selected
+            store = connection.store()
+            with store.locked():
+                record = store.read()
+                if record is None:
+                    raise ValueError("Run nauro auth login in this project")
+                actor = record.user_id
+
+            def credentials() -> ActiveCredentials:
+                if select_decision_connection(project, cwd, use_cwd=use_cwd) != selected:
+                    raise ValueError("Project authority or connection changed")
+                return generation_credentials(connection, actor)
+
+            key = (connection.binding(), project, actor)
+            if self._key != key:
+                self.close()
+                self._client = reference_client()
+                self._transport = DecisionReferenceTransport(
+                    connection.endpoint, project, actor, self._client, credentials
+                )
+                self._key = key
+            assert self._transport is not None
+            self._transport.credentials = credentials
+            return self._transport.propose_decision(**request)
+
+
+def execute_decision(
+    selected: Selection,
+    request: dict[str, Any],
+    cwd: str | Path | None = None,
+    *,
+    use_cwd: bool = True,
+) -> dict[str, Any]:
+    session = DecisionSession()
+    try:
+        return session.execute(selected, request, cwd, use_cwd=use_cwd)
+    finally:
+        session.close()

--- a/packages/nauro/src/nauro/sync/generation_refresh.py
+++ b/packages/nauro/src/nauro/sync/generation_refresh.py
@@ -55,6 +55,7 @@ from nauro.sync.generation_acquisition import (
     acquire_generation_projection,
     check_generation_projection,
 )
+from nauro.sync.generation_session import GenerationTransferSession
 from nauro.sync.remote import TransferSession
 
 
@@ -71,14 +72,25 @@ class PreparedGenerationRefresh:
     prior_intent: bytes | None
 
 
+def _require_actor(actor: str, session: TransferSession | None) -> None:
+    if isinstance(session, GenerationTransferSession):
+        session.require_actor(actor)
+    else:
+        _require_active_actor(actor)
+
+
 @contextmanager
-def _locked(binding: ResolvedProjectBinding, actor: str) -> Iterator[RefreshPaths]:
+def _locked(
+    binding: ResolvedProjectBinding, actor: str, session: TransferSession | None
+) -> Iterator[RefreshPaths]:
+    if isinstance(session, GenerationTransferSession):
+        session.require_binding(binding)
     paths = refresh_paths(binding, actor)
     lock_path = paths.store / ".replica-control.lock"
     _validate_managed_path(paths.store, lock_path)
     try:
         with _native_control_lock(paths.store, lock_path, -1):
-            _require_active_actor(actor)
+            _require_actor(actor, session)
             yield paths
     except OSError as exc:
         raise GenerationRefreshDurabilityError("Refresh persistence requires recovery.") from exc
@@ -119,9 +131,9 @@ def _target(binding: ResolvedProjectBinding, intent: RefreshIntent) -> Generatio
 
 def _authorize(target: GenerationProjectionTarget, session: TransferSession | None) -> None:
     actor = target.identity.installed_for_user_id
-    _require_active_actor(actor)
+    _require_actor(actor, session)
     current = check_generation_projection(target.binding, active_user_id=actor, session=session)
-    _require_active_actor(actor)
+    _require_actor(actor, session)
     if current != target:
         raise RefreshRequiredError("The current authorized projection requires reconciliation.")
 
@@ -129,7 +141,7 @@ def _authorize(target: GenerationProjectionTarget, session: TransferSession | No
 def _prepare(
     binding: ResolvedProjectBinding, actor: str, session: TransferSession | None, *, bootstrap: bool
 ) -> PreparedGenerationRefresh:
-    with _locked(binding, actor) as paths:
+    with _locked(binding, actor, session) as paths:
         marker, pointer, carrier = _controls(paths)
         raw = read_evidence(paths, paths.intent)
         if bootstrap:
@@ -235,13 +247,13 @@ def _resume(
     _authorize(projection.target, session)
     state = intent.classify(*_controls(paths))
     if state == "base_present":
-        _require_active_actor(projection.target.identity.installed_for_user_id)
+        _require_actor(projection.target.identity.installed_for_user_id, session)
         durable_replace(paths, paths.carrier, intent.target_authorization_json.encode())
         state = intent.classify(*_controls(paths))
     if state == "carrier_published":
         sync_file(paths, paths.carrier)
         sync_parents(paths, paths.actor)
-        _require_active_actor(projection.target.identity.installed_for_user_id)
+        _require_actor(projection.target.identity.installed_for_user_id, session)
         durable_replace(paths, paths.pointer, intent.target_pointer_json.encode())
     return _complete(paths, intent, projection, session)
 
@@ -258,7 +270,7 @@ def commit_generation_refresh(
     actor = target.identity.installed_for_user_id
     _authorize(target, session)
     install_generation_root(projection)
-    with _locked(target.binding, actor) as paths:
+    with _locked(target.binding, actor, session) as paths:
         if _controls(paths) != (prepared.marker, prepared.pointer, prepared.carrier):
             raise GenerationRefreshEvidenceError("The prepared refresh base is stale.")
         if read_evidence(paths, paths.intent) != prepared.prior_intent:
@@ -284,7 +296,7 @@ def commit_generation_refresh(
 def admit_generation_store(
     binding: ResolvedProjectBinding, *, actor: str, session: TransferSession | None = None
 ) -> GenerationSnapshotStore:
-    with _locked(binding, actor) as paths:
+    with _locked(binding, actor, session) as paths:
         _, intent = _intent(paths)
         if intent.classify(*_controls(paths)) != "target_present":
             raise RefreshRequiredError("Explicit refresh recovery is required before admission.")

--- a/packages/nauro/src/nauro/sync/generation_session.py
+++ b/packages/nauro/src/nauro/sync/generation_session.py
@@ -1,0 +1,69 @@
+"""Normal credentials for one resolved generation replica operation."""
+
+from __future__ import annotations
+
+import httpx
+
+from nauro.auth import DEFAULT_AUTH_REDIRECT_URI, ActiveCredentials, PartialAuthConfigError
+from nauro.store.generation_authority import GenerationAuthorityError
+from nauro.store.read_authority import observe_generation_marker
+from nauro.store.resolution import ResolvedProjectBinding, resolve_project_binding
+from nauro.sync.generation_connection import connection_for
+from nauro.sync.generation_credentials import generation_credentials
+from nauro.sync.remote import TransferSession
+
+
+class GenerationConnectionError(GenerationAuthorityError):
+    code = "generation_connection_unavailable"
+
+
+class GenerationTransferSession(TransferSession):
+    def __init__(self, binding: ResolvedProjectBinding, client: httpx.Client | None = None) -> None:
+        self.binding = binding
+        try:
+            self.marker = observe_generation_marker(binding)
+            self.connection = connection_for(binding, DEFAULT_AUTH_REDIRECT_URI)
+            store = self.connection.store()
+            with store.locked():
+                record = store.read()
+                if record is None:
+                    raise ValueError("Generation login required")
+                self.actor = record.user_id
+            self.credentials()
+        except (ValueError, OSError, PartialAuthConfigError) as exc:
+            raise GenerationConnectionError(
+                "Check generation login and project connection."
+            ) from exc
+        super().__init__(client or httpx.Client(trust_env=False))
+        self._owned = client is None
+
+    def __enter__(self) -> GenerationTransferSession:
+        return self
+
+    @property
+    def api_url(self) -> str:
+        return self.connection.endpoint.removesuffix("/mcp")
+
+    def require_binding(self, binding: ResolvedProjectBinding) -> None:
+        if binding != self.binding:
+            raise GenerationConnectionError("The replica operation changed project binding.")
+        self.credentials()
+
+    def credentials(self) -> ActiveCredentials:
+        try:
+            binding = resolve_project_binding(self.binding.project_id, None, use_cwd=False)
+            if (
+                binding != self.binding
+                or observe_generation_marker(binding) != self.marker
+                or connection_for(binding, DEFAULT_AUTH_REDIRECT_URI) != self.connection
+            ):
+                raise ValueError("Generation connection changed")
+            return generation_credentials(self.connection, self.actor)
+        except (ValueError, OSError, PartialAuthConfigError) as exc:
+            raise GenerationConnectionError(
+                "Generation login or connection recovery required."
+            ) from exc
+
+    def require_actor(self, actor: str) -> None:
+        if self.credentials().user_id != actor:
+            raise GenerationConnectionError("The replica belongs to another account.")

--- a/packages/nauro/src/nauro/sync/history_transport.py
+++ b/packages/nauro/src/nauro/sync/history_transport.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 
 import httpx
 
-from nauro.auth import read_active_credentials
+from nauro.auth import ActiveCredentials, read_active_credentials
 from nauro.store.generation_authority import GenerationAuthorityError
 from nauro.store.generation_projection import GenerationProjectionTarget, _target_parts
 from nauro.store.resolution import ResolvedProjectBinding
@@ -85,9 +86,15 @@ def verify_history_response(
 class HttpHistoryTransport:
     """Use a caller-owned HTTP client without redirects or automatic resends."""
 
-    def __init__(self, base_url: str, client: httpx.Client) -> None:
+    def __init__(
+        self,
+        base_url: str,
+        client: httpx.Client,
+        credentials: Callable[[], ActiveCredentials] | None = None,
+    ) -> None:
         self._origin = _origin(base_url)
         self._client = client
+        self._credentials = credentials or (lambda: read_active_credentials())
 
     def require_binding(self, binding: ResolvedProjectBinding, api_url: str | None = None) -> None:
         if (
@@ -104,7 +111,7 @@ class HttpHistoryTransport:
         self.require_binding(binding)
         if days is not None and type(days) is not int:
             raise HistoryTransportError("History days must be an integer.")
-        credentials = read_active_credentials()
+        credentials = self._credentials()
         if credentials.user_id != identity.installed_for_user_id:
             raise HistoryTransportError("The active account differs from the installed projection.")
         body = {
@@ -135,6 +142,6 @@ class HttpHistoryTransport:
         except (httpx.HTTPError, ValueError) as exc:
             raise HistoryTransportError("Authorized history is unavailable.") from exc
         result = verify_history_response(bytes(raw), target, days)
-        if read_active_credentials().user_id != identity.installed_for_user_id:
+        if self._credentials().user_id != identity.installed_for_user_id:
             raise HistoryTransportError("The active account changed during the history read.")
         return result

--- a/packages/nauro/src/nauro/sync/reference_auth.py
+++ b/packages/nauro/src/nauro/sync/reference_auth.py
@@ -84,20 +84,9 @@ class ReferenceAuth:
                 raise
 
     def refresh(self) -> None:
-        with self.store.locked():
-            record = self.store.read()
-            if (
-                self.store.incomplete()
-                or record is None
-                or record.state != "active"
-                or not record.refresh_token
-            ):
-                raise ValueError("Reference login required")
-            pending = self.store.empty("renewal_in_progress")
-            self.store.begin()
-            self.store.write(pending)
-            try:
-                tokens = exchange(
+        def replacement(record: CredentialRecord) -> CredentialRecord:
+            return self._record(
+                exchange(
                     self.profile,
                     self.client,
                     {
@@ -105,12 +94,9 @@ class ReferenceAuth:
                         "refresh_token": record.refresh_token,
                     },
                 )
-                self.store.write(self._record(tokens))
-                self.store.finish()
-            except AUTH_ERRORS:
-                self.store.begin()
-                self.store.write(pending)
-                raise ValueError("Renewal incomplete; reference login required") from None
+            )
+
+        renew_credentials(self.store, replacement)
 
     def logout(self) -> None:
         with self.store.locked():
@@ -151,3 +137,27 @@ def run_reference_auth(action: str, path: Path, present_url: Callable[[str], Non
         raise ValueError(
             "Reference authentication failed; inspect profile auth status or log in again"
         ) from None
+
+
+def renew_credentials(
+    store: CredentialStore, replacement: Callable[[CredentialRecord], CredentialRecord]
+) -> None:
+    with store.locked():
+        record = store.read()
+        if (
+            store.incomplete()
+            or record is None
+            or record.state != "active"
+            or not record.refresh_token
+        ):
+            raise ValueError("Reference login required")
+        pending = store.empty("renewal_in_progress")
+        store.begin()
+        store.write(pending)
+        try:
+            store.write(replacement(record))
+            store.finish()
+        except AUTH_ERRORS:
+            store.begin()
+            store.write(pending)
+            raise ValueError("Renewal incomplete; reference login required") from None

--- a/packages/nauro/src/nauro/sync/reference_oauth.py
+++ b/packages/nauro/src/nauro/sync/reference_oauth.py
@@ -8,7 +8,7 @@ import secrets
 import time
 from collections.abc import Callable
 from http.server import BaseHTTPRequestHandler, HTTPServer
-from typing import Any
+from typing import Any, Protocol
 from urllib.parse import parse_qs, urlencode, urlsplit
 
 import httpx
@@ -16,6 +16,13 @@ import jwt
 
 from nauro.sync.decision_profile import RenewalProfile
 from nauro.sync.decision_reference_contract import _json
+
+
+class OAuthSettings(Protocol):
+    issuer: str
+    client_id: str
+    audience: str
+    redirect_uri: str
 
 
 def response_json(client: httpx.Client, method: str, url: str, **kwargs: Any) -> Any:
@@ -33,7 +40,7 @@ def response_json(client: httpx.Client, method: str, url: str, **kwargs: Any) ->
         return value
 
 
-def verify_access(profile: RenewalProfile, token: str, client: httpx.Client) -> int:
+def verified_claims(profile: OAuthSettings, token: str, client: httpx.Client) -> dict[str, Any]:
     header = jwt.get_unverified_header(token)
     if header.get("alg") != "RS256" or not isinstance(header.get("kid"), str):
         raise ValueError("Unsupported token signing key")
@@ -61,19 +68,30 @@ def verify_access(profile: RenewalProfile, token: str, client: httpx.Client) -> 
         audience=profile.audience,
         options={"require": ["exp", "iat", "iss", "aud", "sub", "azp", "scope"]},
     )
-    if claims["sub"] != profile.expected_subject or claims["azp"] != profile.client_id:
+    if (
+        not isinstance(claims["sub"], str)
+        or not claims["sub"]
+        or claims["azp"] != profile.client_id
+    ):
         raise ValueError("Token identity differs from profile")
     scope = claims["scope"]
     if not isinstance(scope, str) or not {"read:context", "write:context"} <= set(scope.split()):
         raise ValueError("Required token scopes missing")
     if type(claims["exp"]) is not int:
         raise ValueError("Invalid token expiry")
+    return claims
+
+
+def verify_access(profile: RenewalProfile, token: str, client: httpx.Client) -> int:
+    claims = verified_claims(profile, token, client)
+    if claims["sub"] != profile.expected_subject:
+        raise ValueError("Token identity differs from profile")
     return int(claims["exp"])
 
 
-def exchange(
-    profile: RenewalProfile, client: httpx.Client, grant: dict[str, str]
-) -> tuple[str, str, int]:
+def exchange_tokens(
+    profile: OAuthSettings, client: httpx.Client, grant: dict[str, str]
+) -> tuple[str, str]:
     body = response_json(
         client,
         "POST",
@@ -90,11 +108,18 @@ def exchange(
         or body["token_type"].lower() != "bearer"
     ):
         raise ValueError("Incomplete rotating credentials")
+    return access, refresh
+
+
+def exchange(
+    profile: RenewalProfile, client: httpx.Client, grant: dict[str, str]
+) -> tuple[str, str, int]:
+    access, refresh = exchange_tokens(profile, client, grant)
     return access, refresh, verify_access(profile, access, client)
 
 
 def callback_code(
-    profile: RenewalProfile,
+    profile: OAuthSettings,
     present_url: Callable[[str], None],
     timeout: float = 120,
 ) -> tuple[str, str]:

--- a/packages/nauro/src/nauro/sync/reference_reads.py
+++ b/packages/nauro/src/nauro/sync/reference_reads.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import copy
 from typing import Any
 
-from nauro_core.mcp_tools import GET_CONTEXT, GET_DECISION
+from nauro_core.mcp_tools import GET_CONTEXT, GET_DECISION, HOSTED_TOOLS
 
 from nauro.sync.decision_reference_contract import (
     MAX_RESPONSE,
@@ -35,6 +35,14 @@ def negotiate_registry(result: Any) -> bool:
     tools = result["tools"]
     if len(tools) == 3:
         schemas.update({name: read_schema(name) for name in READ_SPECS})
+    if len(tools) == len(HOSTED_TOOLS):
+        schemas.update(
+            {
+                spec["name"]: spec["input_schema"]
+                for spec in HOSTED_TOOLS
+                if spec["name"] != "propose_decision"
+            }
+        )
     if len(tools) != len(schemas):
         raise DecisionReferenceError("Unexpected isolated tool registry")
     for tool in tools:

--- a/packages/nauro/tests/generation_account.py
+++ b/packages/nauro/tests/generation_account.py
@@ -1,0 +1,42 @@
+"""Synthetic normal credentials for replica integration tests."""
+
+import time
+
+from nauro.auth import DEFAULT_AUTH_REDIRECT_URI
+from nauro.store.config import save_config
+from nauro.sync.generation_connection import connection_for
+from nauro.sync.generation_credentials import AccountRecord
+
+
+def seed_generation_account(binding, actor, monkeypatch):
+    for key in (
+        "NAURO_AUTH0_DOMAIN",
+        "NAURO_AUTH0_CLIENT_ID",
+        "NAURO_API_URL",
+        "NAURO_AUTH0_AUDIENCE",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    save_config(
+        {
+            "api_url": binding.server_url,
+            "auth0_domain": "issuer.example",
+            "auth0_client_id": "client",
+            "auth0_audience": binding.server_url + "/mcp",
+        }
+    )
+    connection = connection_for(binding, DEFAULT_AUTH_REDIRECT_URI)
+    account = connection.store()
+    with account.locked():
+        account.write(
+            AccountRecord(
+                revision="initial",
+                binding=account.binding,
+                state="active",
+                user_id=actor,
+                subject="synthetic-owner",
+                access_token="normal-generation-token",
+                refresh_token="synthetic-refresh",
+                expires_at=int(time.time()) + 600,
+            )
+        )
+    return connection

--- a/packages/nauro/tests/snapshots/public_contract_v1.json
+++ b/packages/nauro/tests/snapshots/public_contract_v1.json
@@ -188,7 +188,7 @@
                 ],
                 "kind": "option",
                 "name": "reference_profile",
-                "required": true,
+                "required": false,
                 "type": "path"
               }
             ]

--- a/packages/nauro/tests/test_decision_reference_transport.py
+++ b/packages/nauro/tests/test_decision_reference_transport.py
@@ -104,12 +104,13 @@ def test_http_failure_does_not_retry_or_follow_redirect():
     assert seen == ["https://probe.example/mcp"]
 
 
-def test_reference_import_does_not_change_normal_tool_schema():
+def test_normal_tool_adds_reference_modes_without_new_tools():
     from nauro.mcp.stdio_server import mcp
 
     tool = mcp._tool_manager.get_tool("propose_decision")
-    assert "request_mode" not in tool.parameters["properties"]
-    assert "rationale" in tool.parameters["required"]
+    assert "request_mode" in tool.parameters["properties"]
+    assert "rationale" not in tool.parameters.get("required", [])
+    assert tool.parameters["oneOf"][0]["required"] == ["rationale"]
     assert len(mcp._tool_manager.list_tools()) == 10
     assert reference_schema()["properties"]["request_mode"]["default"] == "prepare"
 

--- a/packages/nauro/tests/test_generation_credentials.py
+++ b/packages/nauro/tests/test_generation_credentials.py
@@ -1,0 +1,360 @@
+from __future__ import annotations
+
+import json
+import socket
+import time
+from types import SimpleNamespace
+
+import httpx
+import jwt
+import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa
+from typer.testing import CliRunner
+
+from nauro.cli.main import app
+from nauro.store.config import load_config, save_config
+from nauro.store.generation_authority import GenerationAuthorityMarker
+from nauro.store.registry import register_project_v2
+from nauro.sync import generation_credentials as module
+from nauro.sync.decision_reference import DecisionReferenceTransport
+from nauro.sync.decision_reference_contract import reference_schema
+
+ACTOR = "01K33333333333333333333333"
+OTHER = "01K44444444444444444444444"
+
+
+@pytest.fixture
+def account(tmp_path, monkeypatch):
+    def forbidden(*args, **kwargs):
+        raise AssertionError("External network forbidden")
+
+    monkeypatch.setattr(socket.socket, "connect", forbidden)
+    home = tmp_path / "home"
+    home.mkdir(mode=0o700)
+    monkeypatch.setenv("NAURO_HOME", str(home))
+    for key in (
+        "NAURO_AUTH0_DOMAIN",
+        "NAURO_AUTH0_CLIENT_ID",
+        "NAURO_API_URL",
+        "NAURO_AUTH0_AUDIENCE",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.chdir(repo)
+    project, store = register_project_v2(
+        "Generation", [repo], mode="cloud", server_url="https://api.example"
+    )
+    (store / ".replica").mkdir(parents=True)
+    marker = store / ".replica" / "authority.json"
+    marker.write_bytes(
+        GenerationAuthorityMarker(
+            schema_version=1, authority="generation", project_id=project, store_format_version=1
+        ).canonical_bytes()
+    )
+    save_config(
+        {
+            "auth0_domain": "issuer.example",
+            "auth0_client_id": "client",
+            "api_url": "https://api.example",
+            "auth0_audience": "https://api.example/mcp",
+            "auth": {
+                "access_token": "legacy-token",
+                "refresh_token": "legacy-refresh",
+                "user_id": ACTOR,
+            },
+        }
+    )
+    config_before = load_config()
+    connection = module.GenerationConnection(
+        endpoint="https://api.example/mcp",
+        issuer="https://issuer.example/",
+        client_id="client",
+        audience="https://api.example/mcp",
+        redirect_uri="http://localhost:18457/callback",
+    )
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    jwk = jwt.algorithms.RSAAlgorithm.to_jwk(key.public_key(), as_dict=True)
+    jwk["kid"] = "key"
+    calls = []
+    control = {"changes": {}, "me": ACTOR, "status": 200, "rpc_status": 200, "count": 0}
+
+    def wire(request):
+        calls.append(request)
+        if request.url.path == "/oauth/token":
+            control["count"] += 1
+            if control["status"] == "lost":
+                raise httpx.ReadError("secret provider detail")
+            claims = {
+                "iss": connection.issuer,
+                "aud": connection.audience,
+                "azp": connection.client_id,
+                "sub": "owner",
+                "iat": int(time.time()),
+                "exp": int(time.time()) + 600,
+                "scope": "read:context write:context",
+            }
+            claims.update(control["changes"])
+            token = jwt.encode(claims, key, algorithm="RS256", headers={"kid": "key"})
+            return httpx.Response(
+                control["status"],
+                json={
+                    "access_token": token,
+                    "refresh_token": f"rotated-{control['count']}",
+                    "token_type": "Bearer",
+                },
+            )
+        if request.url.path == "/.well-known/jwks.json":
+            return httpx.Response(200, json={"keys": [jwk]})
+        if request.url.path == "/me":
+            return httpx.Response(200, json={"user_id": control["me"]})
+        assert request.url == connection.endpoint
+        body = json.loads(request.content)
+        if control["rpc_status"] != 200:
+            return httpx.Response(control["rpc_status"])
+        if body["method"] == "notifications/initialized":
+            return httpx.Response(202)
+        if body["method"] == "initialize":
+            result = {"protocolVersion": "2025-06-18"}
+        elif body["method"] == "tools/list":
+            result = {"tools": [{"name": "propose_decision", "inputSchema": reference_schema()}]}
+        else:
+            assert body["params"]["arguments"]["request_mode"] == "discover"
+            result = {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": json.dumps({"version": 1, "requests": [], "next_after": None}),
+                    }
+                ]
+            }
+        return httpx.Response(200, json={"jsonrpc": "2.0", "id": body["id"], "result": result})
+
+    original_client = httpx.Client
+
+    def client(**kwargs):
+        return original_client(transport=httpx.MockTransport(wire), **kwargs)
+
+    monkeypatch.setattr("nauro.cli.generation_auth.httpx.Client", client)
+    monkeypatch.setattr(module, "callback_code", lambda *_: ("code", "verifier"))
+    yield SimpleNamespace(
+        connection=connection,
+        project=project,
+        store=store,
+        marker=marker,
+        calls=calls,
+        control=control,
+        client=client,
+        config_before=config_before,
+    )
+
+
+def command(action):
+    return CliRunner().invoke(app, ["auth", action])
+
+
+def test_normal_lifecycle_preserves_legacy_credentials(account):
+    assert command("login").exit_code == 0
+    record = account.connection.store().read()
+    assert record.subject == "owner"
+    assert record.user_id == ACTOR
+    assert record.version == 3
+    assert load_config() == account.config_before
+    assert command("status").stdout.strip() == "active"
+    with account.client() as client:
+        transport = DecisionReferenceTransport(
+            account.connection.endpoint,
+            account.project,
+            ACTOR,
+            client,
+            lambda: module.generation_credentials(account.connection, ACTOR),
+        )
+        transport.initialize()
+        assert command("refresh").exit_code == 0
+        transport.propose_decision(project_id=account.project, request_mode="discover")
+        assert (
+            account.calls[-1].headers["Authorization"]
+            == "Bearer " + account.connection.store().read().access_token
+        )
+        assert command("logout").exit_code == 0
+        before = len(account.calls)
+        with pytest.raises(ValueError, match="login or explicit refresh"):
+            transport.propose_decision(project_id=account.project, request_mode="discover")
+        assert len(account.calls) == before
+    assert command("status").stdout.strip() == "logged_out"
+    assert load_config() == account.config_before
+
+
+@pytest.mark.parametrize(
+    "change",
+    [
+        {"iss": "https://other.example/"},
+        {"aud": "other"},
+        {"azp": "other"},
+        {"sub": ""},
+        {"scope": "read:context"},
+        {"exp": 1},
+    ],
+)
+def test_invalid_token_never_reaches_identity_endpoint(account, change):
+    account.control["changes"] = change
+    assert command("login").exit_code == 1
+    assert [r.url.path for r in account.calls] == ["/oauth/token", "/.well-known/jwks.json"]
+    assert account.connection.store().read() is None
+    assert load_config() == account.config_before
+
+
+@pytest.mark.parametrize("identity", [None, "", "owner", OTHER.lower()])
+def test_missing_canonical_identity_installs_nothing(account, identity):
+    account.control["me"] = identity
+    assert command("login").exit_code == 1
+    assert account.connection.store().read() is None
+    assert len([r for r in account.calls if r.url.path == "/mcp"]) == 0
+
+
+@pytest.mark.parametrize("problem", ["endpoint", "marker"])
+def test_invalid_selection_refuses_before_authentication(account, problem):
+    if problem == "endpoint":
+        config = load_config()
+        config["api_url"] = "https://other.example"
+        save_config(config)
+    else:
+        account.marker.write_text("broken")
+    assert command("login").exit_code == 1
+    assert account.calls == []
+
+
+def test_no_marker_keeps_legacy_status_and_refresh_contract(account):
+    account.marker.unlink()
+    assert "Authenticated as:" in command("status").stdout
+    assert command("refresh").exit_code == 2
+    assert account.calls == []
+    assert account.connection.store().read() is None
+
+
+@pytest.mark.parametrize("status", [401, 429, 503, "lost"])
+def test_uncertain_normal_renewal_is_fenced_without_retry(account, status):
+    assert command("login").exit_code == 0
+    account.calls.clear()
+    account.control["status"] = status
+    assert command("refresh").exit_code == 1
+    assert len(account.calls) == 1
+    assert command("status").stdout.strip() == "reauthentication_required"
+    assert command("refresh").exit_code == 1
+    assert len(account.calls) == 1
+    assert account.connection.store().read().state == "renewal_in_progress"
+
+
+def test_expiry_status_and_restart_do_not_renew(account):
+    assert command("login").exit_code == 0
+    store = account.connection.store()
+    with store.locked():
+        record = store.read()
+        record.expires_at = 1
+        store.write(record)
+    account.calls.clear()
+    assert command("status").stdout.strip() == "expired"
+    with pytest.raises(ValueError, match="login or explicit refresh"):
+        module.generation_credentials(account.connection, ACTOR)
+    assert account.calls == []
+    assert command("refresh").exit_code == 0
+    assert module.generation_credentials(account.connection, ACTOR).user_id == ACTOR
+    with pytest.raises(ValueError):
+        module.generation_credentials(account.connection, OTHER)
+
+
+def test_changed_subject_fences_renewal(account):
+    assert command("login").exit_code == 0
+    account.control["changes"] = {"sub": "other"}
+    assert command("refresh").exit_code == 1
+    assert account.connection.store().read().state == "renewal_in_progress"
+
+
+def test_logout_during_normal_login_prevents_resurrection(account, monkeypatch):
+    assert command("login").exit_code == 0
+
+    def callback(*_):
+        assert command("logout").exit_code == 0
+        return "code", "verifier"
+
+    monkeypatch.setattr(module, "callback_code", callback)
+    assert command("login").exit_code == 1
+    assert account.connection.store().read().state == "logged_out"
+
+
+def test_failed_project_admission_preserves_old_record(account):
+    assert command("login").exit_code == 0
+    before = account.connection.store().path.read_bytes()
+    account.control["rpc_status"] = 403
+    assert command("login").exit_code == 1
+    assert account.connection.store().path.read_bytes() == before
+
+
+def test_two_projects_share_one_normal_credential_store(account, tmp_path, monkeypatch):
+    assert command("login").exit_code == 0
+    second_repo = tmp_path / "second"
+    second_repo.mkdir()
+    project, store = register_project_v2(
+        "Second", [second_repo], mode="cloud", server_url="https://api.example"
+    )
+    (store / ".replica").mkdir(parents=True)
+    (store / ".replica" / "authority.json").write_bytes(
+        GenerationAuthorityMarker(
+            schema_version=1, authority="generation", project_id=project, store_format_version=1
+        ).canonical_bytes()
+    )
+    monkeypatch.chdir(second_repo)
+    before = len(account.calls)
+    assert command("status").stdout.strip() == "active"
+    assert len(account.calls) == before
+    assert command("refresh").exit_code == 0
+    assert account.connection.store().read().refresh_token == "rotated-2"
+    assert (
+        len(list(account.connection.store().path.parent.glob("generation-credentials-*.json"))) == 1
+    )
+
+
+@pytest.mark.parametrize("failure", ["marker", "completion"])
+def test_normal_renewal_durability_failure_closes_admission(account, monkeypatch, failure):
+    assert command("login").exit_code == 0
+    account.calls.clear()
+
+    def fail(*_):
+        raise OSError("durability failure")
+
+    monkeypatch.setattr(module.AccountStore, "begin" if failure == "marker" else "finish", fail)
+    assert command("refresh").exit_code == 1
+    if failure == "marker":
+        assert account.calls == []
+    else:
+        assert account.connection.store().incomplete() is True
+        assert command("status").stdout.strip() == "reauthentication_required"
+        with pytest.raises(ValueError):
+            module.generation_credentials(account.connection, ACTOR)
+
+
+def test_normal_credentials_do_not_refresh_or_resend_a_submission(account):
+    assert command("login").exit_code == 0
+    with account.client() as client:
+        transport = DecisionReferenceTransport(
+            account.connection.endpoint,
+            account.project,
+            ACTOR,
+            client,
+            lambda: module.generation_credentials(account.connection, ACTOR),
+        )
+        transport.initialize()
+        account.calls.clear()
+        account.control["rpc_status"] = 401
+        with pytest.raises(ValueError):
+            transport.propose_decision(
+                project_id=account.project,
+                request_mode="submit",
+                operation_id="decision-request:01K55555555555555555555555",
+                payload_digest="a" * 64,
+            )
+        assert len(account.calls) == 1
+        assert (
+            json.loads(account.calls[0].content)["params"]["arguments"]["request_mode"] == "submit"
+        )
+        assert account.connection.store().read().refresh_token == "rotated-1"

--- a/packages/nauro/tests/test_generation_cutover_reads.py
+++ b/packages/nauro/tests/test_generation_cutover_reads.py
@@ -1,0 +1,63 @@
+"""Read results are discarded when generation authority appears during rendering."""
+
+import pytest
+from typer.testing import CliRunner
+
+from nauro.cli import autogen
+from nauro.cli.main import app
+from nauro.mcp import read_dispatch, stdio_server
+from nauro.store.registry import register_project_v2
+
+
+@pytest.mark.parametrize(
+    "surface,phase",
+    [
+        ("stdio", "adapter"),
+        ("stdio", "renderer"),
+        ("cli-json", "adapter"),
+        ("cli-text", "adapter"),
+        ("cli-text", "renderer"),
+    ],
+)
+def test_cutover_discards_legacy_content(tmp_path, monkeypatch, surface, phase):
+    monkeypatch.setenv("NAURO_HOME", str(tmp_path / "home"))
+    monkeypatch.chdir(tmp_path)
+    project, store = register_project_v2("Cutover", [])
+    store.mkdir(parents=True, exist_ok=True)
+    (store / "state.md").write_text("SENSITIVE OLD CONTENT")
+
+    def cutover():
+        root = store / ".replica"
+        root.mkdir()
+        (root / "authority.json").write_text("INCOMPLETE CUTOVER")
+
+    if phase == "adapter":
+        original = read_dispatch.legacy.tool_get_raw_file
+
+        def read(*args, **kwargs):
+            value = original(*args, **kwargs)
+            cutover()
+            return value
+
+        monkeypatch.setattr(read_dispatch.legacy, "tool_get_raw_file", read)
+    else:
+        module = read_dispatch if surface == "stdio" else autogen
+        original = module.try_render_envelope
+
+        def render(*args, **kwargs):
+            value = original(*args, **kwargs)
+            cutover()
+            return value
+
+        monkeypatch.setattr(module, "try_render_envelope", render)
+    if surface == "stdio":
+        result = stdio_server.get_raw_file("state.md", project_id=project)
+        assert result.isError is True
+        assert "SENSITIVE OLD CONTENT" not in str(result)
+    else:
+        result = CliRunner().invoke(
+            app, ["get-raw-file", "state.md", "--project", "Cutover", "--format", surface[4:]]
+        )
+        assert result.exit_code == 1, result.output
+        assert result.stdout == ""
+        assert "SENSITIVE OLD CONTENT" not in result.output

--- a/packages/nauro/tests/test_generation_decision_routing.py
+++ b/packages/nauro/tests/test_generation_decision_routing.py
@@ -376,7 +376,9 @@ run_stdio()
             await session.initialize()
             listing = await session.list_tools()
             assert len(listing.tools) == 10
-            schema = next(t.inputSchema for t in listing.tools if t.name == "propose_decision")
+            decision_tool = next(t for t in listing.tools if t.name == "propose_decision")
+            assert decision_tool.outputSchema is None
+            schema = decision_tool.inputSchema
             assert "cwd" in schema["properties"]
             assert "request_mode" in schema["properties"]
             found = await session.call_tool("propose_decision", {"request_mode": "discover"})

--- a/packages/nauro/tests/test_generation_decision_routing.py
+++ b/packages/nauro/tests/test_generation_decision_routing.py
@@ -1,0 +1,547 @@
+from __future__ import annotations
+
+import asyncio
+import copy
+import hashlib
+import json
+import socket
+import time
+from types import SimpleNamespace
+
+import httpx
+import pytest
+from mcp.server.fastmcp.exceptions import ToolError
+from nauro_core.operations.commit_plan import canonical_judgment_payload_bytes
+from typer.testing import CliRunner
+
+from nauro.cli.main import app
+from nauro.mcp.generation_decision import decision_session
+from nauro.mcp.stdio_server import mcp
+from nauro.store.config import save_config
+from nauro.store.generation_authority import GenerationAuthorityMarker
+from nauro.store.registry import register_project_v2
+from nauro.store.submission_records import SubmissionScope
+from nauro.sync import generation_decision as routing
+from nauro.sync.decision_reference_contract import reference_schema
+from nauro.sync.generation_credentials import AccountRecord
+from tests.test_judgment_submission import USER, _payload
+from tests.test_judgment_transport import _encoded_receipt, _receipt
+
+
+class Authority:
+    def __init__(self, project):
+        self.project, self.records, self.calls = project, {}, []
+        self.counter, self.commits = 4, 0
+        self.loss = None
+        self.rpc_methods = []
+
+    def prepare(self, args):
+        payload = json.loads(_payload())
+        payload["base_decision_counter"] = self.counter
+        payload["content"].update({k: v for k, v in args.items() if k in payload["content"]})
+        raw = canonical_judgment_payload_bytes(payload)
+        op = "decision-request:01K" + str(len(self.records) + 1).zfill(23)
+        row = {
+            "version": 1,
+            "request": {
+                "project_id": self.project,
+                "actor_id": USER,
+                "operation_id": op,
+                "created_at": "2026-09-05T00:00:00.000000Z",
+                "payload_digest": hashlib.sha256(raw).hexdigest(),
+                "payload_json": raw.decode(),
+            },
+            "effective_draft": json.loads(raw),
+            "admission": "never_admitted",
+            "admitted_at": None,
+            "deadline": None,
+            "status": "prepared",
+            "unresolved": False,
+            "execution": None,
+        }
+        self.records[op] = row
+        return row
+
+    def call(self, args):
+        self.calls.append(copy.deepcopy(args))
+        mode = args.get("request_mode", "prepare")
+        if mode == "prepare":
+            result = self.prepare(args)
+        elif mode == "discover":
+            result = {"version": 1, "requests": list(self.records.values()), "next_after": None}
+        else:
+            result = self.records[args["operation_id"]]
+            assert args["payload_digest"] == result["request"]["payload_digest"]
+            if mode == "submit" and result["status"] == "prepared":
+                if result["effective_draft"]["base_decision_counter"] != self.counter:
+                    result["status"] = "stale"
+                else:
+                    self.counter += 1
+                    self.commits += 1
+                    scope = SubmissionScope(
+                        project_id=self.project,
+                        user_id=USER,
+                        operation_kind="judgment_commit",
+                        operation_id=args["operation_id"],
+                    )
+                    raw_receipt = _encoded_receipt(_receipt(SimpleNamespace(scope=scope)))
+                    result.update(
+                        admission="admitted",
+                        admitted_at="2026-09-05T00:00:00.000000Z",
+                        deadline="2026-09-06T00:00:00.000000Z",
+                        status="committed",
+                        execution={
+                            "version": 1,
+                            "scope": scope.model_dump(),
+                            "payload_digest": args["payload_digest"],
+                            "status": "committed",
+                            "receipt_json": raw_receipt,
+                        },
+                    )
+        if mode == self.loss:
+            self.loss = None
+            raise httpx.ReadError("response lost")
+        return copy.deepcopy(result)
+
+    def wire(self, request):
+        body = json.loads(request.content)
+        self.rpc_methods.append(body["method"])
+        if body["method"] == "notifications/initialized":
+            return httpx.Response(202)
+        if body["method"] == "initialize":
+            result = {"protocolVersion": "2025-06-18"}
+        elif body["method"] == "tools/list":
+            result = {"tools": [{"name": "propose_decision", "inputSchema": reference_schema()}]}
+        else:
+            value = self.call(body["params"]["arguments"])
+            result = {
+                "content": [{"type": "text", "text": json.dumps(value)}],
+                "isError": value.get("status") in {"stale", "pending"},
+            }
+        return httpx.Response(200, json={"jsonrpc": "2.0", "id": body["id"], "result": result})
+
+
+@pytest.fixture
+def route(tmp_path, monkeypatch):
+    def forbidden(*_args, **_kwargs):
+        raise AssertionError("Unapproved path")
+
+    monkeypatch.setattr(socket.socket, "connect", forbidden)
+    home = tmp_path / "home"
+    home.mkdir(mode=0o700)
+    monkeypatch.setenv("NAURO_HOME", str(home))
+    for name in (
+        "NAURO_API_URL",
+        "NAURO_AUTH0_DOMAIN",
+        "NAURO_AUTH0_CLIENT_ID",
+        "NAURO_AUTH0_AUDIENCE",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.chdir(repo)
+    project, store = register_project_v2(
+        "Routing", [repo], mode="cloud", server_url="https://api.example"
+    )
+    (store / ".replica").mkdir(parents=True)
+    marker = store / ".replica" / "authority.json"
+    marker.write_bytes(
+        GenerationAuthorityMarker(
+            schema_version=1, authority="generation", project_id=project, store_format_version=1
+        ).canonical_bytes()
+    )
+    save_config(
+        {
+            "api_url": "https://api.example",
+            "auth0_domain": "issuer.example",
+            "auth0_client_id": "client",
+            "auth0_audience": "https://api.example/mcp",
+        }
+    )
+    connection, _ = routing.select_decision_connection()
+    account = connection.store()
+    with account.locked():
+        account.write(
+            AccountRecord(
+                revision="initial",
+                binding=account.binding,
+                state="active",
+                user_id=USER,
+                subject="owner",
+                access_token="synthetic",
+                refresh_token="synthetic-refresh",
+                expires_at=int(time.time()) + 600,
+            )
+        )
+    authority = Authority(project)
+    decision_session.close()
+    monkeypatch.setattr(
+        routing,
+        "reference_client",
+        lambda: httpx.Client(transport=httpx.MockTransport(authority.wire)),
+    )
+    for name in ("tool_propose_decision", "tool_flag_question", "tool_update_state"):
+        monkeypatch.setattr("nauro.mcp.stdio_server." + name, forbidden)
+    monkeypatch.setattr("nauro.cli.autogen._resolve_adapter", forbidden)
+    monkeypatch.setattr("nauro.sync.hooks.pull_before_session", forbidden)
+    before = {str(p.relative_to(store)): p.read_bytes() for p in store.rglob("*") if p.is_file()}
+    decision_session.close()
+    yield SimpleNamespace(
+        project=project,
+        store=store,
+        repo=repo,
+        home=home,
+        marker=marker,
+        account=account,
+        authority=authority,
+        before=before,
+    )
+    decision_session.close()
+    assert {
+        str(p.relative_to(store)): p.read_bytes() for p in store.rglob("*") if p.is_file()
+    } == before
+
+
+def cli(*args):
+    return CliRunner().invoke(app, ["propose-decision", *args])
+
+
+def tool(name="propose_decision", **args):
+    return asyncio.run(mcp._tool_manager.get_tool(name).run(args))
+
+
+def value(result):
+    return json.loads(result.content[0].text)
+
+
+def reference(row):
+    return {key: row["request"][key] for key in ("operation_id", "payload_digest")}
+
+
+def test_ordinary_cli_to_full_stdio_lost_response_recovery(route):
+    route.authority.loss = "prepare"
+    assert cli("Retain exact intent", "--title", "Draft").exit_code == 1
+    draft = value(tool(request_mode="discover"))["requests"][0]
+    assert draft["admission"] == "never_admitted"
+    assert route.authority.commits == 0
+    selected = reference(draft)
+    route.authority.loss = "submit"
+    submitted = cli(
+        "--request-mode",
+        "submit",
+        "--operation-id",
+        selected["operation_id"],
+        "--payload-digest",
+        selected["payload_digest"],
+    )
+    assert submitted.exit_code == 1
+    discovered = value(tool(request_mode="discover"))["requests"][0]
+    recovered = tool(request_mode="recover", **reference(discovered))
+    assert recovered.isError is False
+    assert value(recovered)["execution"]["receipt_json"] == discovered["execution"]["receipt_json"]
+    assert route.authority.commits == 1
+    repeated = tool(request_mode="submit", **selected)
+    assert (
+        value(repeated)["execution"]["receipt_json"]
+        == value(recovered)["execution"]["receipt_json"]
+    )
+    assert route.authority.commits == 1
+    assert [r.get("request_mode", "prepare") for r in route.authority.calls] == [
+        "prepare",
+        "discover",
+        "submit",
+        "discover",
+        "recover",
+        "submit",
+    ]
+
+
+def test_same_base_stale_requires_fresh_reference(route):
+    first = value(tool(rationale="First", title="First"))
+    second = value(tool(rationale="Second", title="Second"))
+    assert tool(request_mode="submit", **reference(first)).isError is False
+    stale = tool(request_mode="submit", **reference(second))
+    assert stale.isError is True
+    assert value(stale)["status"] == "stale"
+    assert value(tool(request_mode="recover", **reference(second)))["status"] == "stale"
+    fresh = value(tool(rationale="Second", title="Second"))
+    assert reference(fresh) != reference(second)
+    assert tool(request_mode="submit", **reference(fresh)).isError is False
+    assert route.authority.commits == 2
+
+
+@pytest.mark.parametrize(
+    "extra",
+    [{"title": ""}, {"rationale": None}, {"operation": "add"}, {"base_generation_id": "new"}],
+)
+def test_raw_reference_arguments_cannot_change_content(route, extra):
+    draft = value(tool(rationale="Draft"))
+    before = len(route.authority.calls)
+    with pytest.raises(ToolError):
+        tool(request_mode="submit", **reference(draft), **extra)
+    assert len(route.authority.calls) == before
+    assert route.authority.commits == 0
+
+
+@pytest.mark.parametrize(
+    "name,args",
+    [("flag_question", {"question": "Question"}), ("update_state", {"delta": "Change"})],
+)
+def test_other_stdio_writes_refuse_before_local_adapter(route, name, args):
+    with pytest.raises(ToolError, match="not supported"):
+        tool(name, **args)
+    assert route.authority.calls == []
+
+
+def test_full_inventory_cwd_and_cli_project_selection(route, tmp_path, monkeypatch):
+    assert len(mcp._tool_manager.list_tools()) == 10
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)
+    result = tool(cwd=str(route.repo), rationale="With cwd")
+    assert value(result)["request"]["project_id"] == route.project
+    result = cli("--project", "Routing", "--request-mode", "discover")
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout)["requests"][0]["request"]["project_id"] == route.project
+
+
+def test_missing_credentials_never_fall_back(route):
+    with route.account.locked():
+        route.account.write(route.account.empty("logged_out"))
+    assert cli("Draft").exit_code == 1
+    with pytest.raises(ToolError):
+        tool(rationale="Draft")
+    assert route.authority.calls == []
+
+
+def test_unreferenced_repetitions_only_create_inert_drafts(route):
+    for _ in range(2):
+        assert cli("Identical", "--title", "Same").exit_code == 0
+    assert len(route.authority.records) == 2
+    assert route.authority.commits == 0
+    assert {r["status"] for r in route.authority.records.values()} == {"prepared"}
+
+
+def test_full_stdio_process_discovers_and_recovers_existing_receipt(route, tmp_path):
+    import os
+    import sys
+    from pathlib import Path
+
+    from mcp import ClientSession, StdioServerParameters
+    from mcp.client.stdio import stdio_client
+
+    draft = value(tool(rationale="Before restart"))
+    committed = value(tool(request_mode="submit", **reference(draft)))
+    state = tmp_path / "authority.json"
+    state.write_text(json.dumps(route.authority.records))
+    source = Path(__file__).resolve().parents[3]
+    env = {
+        **os.environ,
+        "PYTHONPATH": os.pathsep.join(
+            str(p)
+            for p in (
+                source / "packages/nauro/src",
+                source / "packages/nauro-core/src",
+                source / "packages/nauro",
+            )
+        ),
+    }
+    script = """
+import json, socket, sys
+from pathlib import Path
+import httpx
+from tests.test_generation_decision_routing import Authority
+from nauro.sync import generation_decision as routing
+from nauro.mcp.stdio_server import run_stdio
+import nauro.sync.hooks
+
+def forbidden(*args, **kwargs):
+    raise AssertionError("External connection or pull forbidden")
+socket.socket.connect = forbidden
+nauro.sync.hooks.pull_before_session = forbidden
+authority = Authority(sys.argv[1])
+authority.records = json.loads(Path(sys.argv[2]).read_text())
+routing.reference_client = lambda: httpx.Client(transport=httpx.MockTransport(authority.wire))
+run_stdio()
+"""
+
+    async def exercise():
+        params = StdioServerParameters(
+            command=sys.executable,
+            args=["-c", script, route.project, str(state)],
+            env=env,
+            cwd=str(route.repo),
+        )
+        async with stdio_client(params) as streams, ClientSession(*streams) as session:
+            await session.initialize()
+            listing = await session.list_tools()
+            assert len(listing.tools) == 10
+            schema = next(t.inputSchema for t in listing.tools if t.name == "propose_decision")
+            assert "cwd" in schema["properties"]
+            assert "request_mode" in schema["properties"]
+            found = await session.call_tool("propose_decision", {"request_mode": "discover"})
+            assert found.isError is False
+            recovered = await session.call_tool(
+                "propose_decision",
+                {"request_mode": "recover", **reference(value(found)["requests"][0])},
+            )
+            assert recovered.isError is False
+            assert (
+                value(recovered)["execution"]["receipt_json"]
+                == committed["execution"]["receipt_json"]
+            )
+            invalid = await session.call_tool(
+                "propose_decision", {"request_mode": "submit", **reference(draft), "title": ""}
+            )
+            assert invalid.isError is True
+            refused = await session.call_tool("update_state", {"delta": "Forbidden"})
+            assert refused.isError is True
+
+    asyncio.run(exercise())
+
+
+@pytest.mark.parametrize("operation", ["update", "supersede"])
+def test_existing_decision_prepare_omits_unsupplied_fields(route, operation):
+    result = tool(
+        rationale="Approved change",
+        operation=operation,
+        affected_decision_id="005-durable-identity",
+    )
+    assert value(result)["status"] == "prepared"
+    assert route.authority.calls == [
+        {
+            "project_id": route.project,
+            "request_mode": "prepare",
+            "rationale": "Approved change",
+            "operation": operation,
+            "affected_decision_id": "005-durable-identity",
+        }
+    ]
+
+
+def test_explicit_cli_project_overrides_another_repository(route, tmp_path, monkeypatch):
+    from nauro.store.repo_config import save_repo_config
+
+    other = tmp_path / "other"
+    other.mkdir()
+    pid, store = register_project_v2("Other", [other], mode="local")
+    store.mkdir(parents=True, exist_ok=True)
+    save_repo_config(other, {"mode": "local", "id": pid, "name": "Other"})
+    monkeypatch.chdir(other)
+    result = cli("--project", "Routing", "--request-mode", "discover")
+    assert result.exit_code == 0, result.output
+    assert route.authority.calls == [{"project_id": route.project, "request_mode": "discover"}]
+
+
+def test_authority_change_during_negotiation_refuses_before_tool_call(route, monkeypatch):
+    raw = route.marker.read_bytes()
+
+    def wire(request):
+        response = route.authority.wire(request)
+        if json.loads(request.content)["method"] == "tools/list":
+            route.marker.write_bytes(b"corrupt")
+        return response
+
+    decision_session.close()
+    monkeypatch.setattr(
+        routing, "reference_client", lambda: httpx.Client(transport=httpx.MockTransport(wire))
+    )
+    try:
+        assert cli("Draft").exit_code == 1
+        assert route.authority.calls == []
+    finally:
+        route.marker.write_bytes(raw)
+
+
+def test_logout_after_commit_rejects_response_and_allows_later_lookup(route, monkeypatch):
+    draft = value(tool(rationale="Before logout"))
+    active = route.account.read()
+
+    def wire(request):
+        response = route.authority.wire(request)
+        args = json.loads(request.content).get("params", {}).get("arguments", {})
+        if args.get("request_mode") == "submit":
+            with route.account.locked():
+                route.account.write(route.account.empty("logged_out"))
+        return response
+
+    decision_session.close()
+    monkeypatch.setattr(
+        routing, "reference_client", lambda: httpx.Client(transport=httpx.MockTransport(wire))
+    )
+    with pytest.raises(ToolError):
+        tool(request_mode="submit", **reference(draft))
+    assert route.authority.commits == 1
+    with route.account.locked():
+        route.account.write(active)
+    recovered = tool(request_mode="recover", **reference(draft))
+    assert recovered.isError is False
+    assert value(recovered)["status"] == "committed"
+    assert [r["request_mode"] for r in route.authority.calls] == ["prepare", "submit", "recover"]
+
+
+def test_pending_recovery_is_an_error_without_resubmission(route):
+    draft = value(tool(rationale="Pending"))
+    row = route.authority.records[draft["request"]["operation_id"]]
+    scope = SubmissionScope(
+        project_id=route.project,
+        user_id=USER,
+        operation_kind="judgment_commit",
+        operation_id=draft["request"]["operation_id"],
+    )
+    row.update(
+        admission="admitted",
+        admitted_at="2026-09-05T00:00:00.000000Z",
+        deadline="2026-09-06T00:00:00.000000Z",
+        status="pending",
+        unresolved=True,
+        execution={
+            "version": 1,
+            "scope": scope.model_dump(),
+            "payload_digest": row["request"]["payload_digest"],
+            "status": "pending",
+            "receipt_json": None,
+        },
+    )
+    assert tool(request_mode="recover", **reference(draft)).isError is True
+    args = reference(draft)
+    result = cli(
+        "--request-mode",
+        "recover",
+        "--operation-id",
+        args["operation_id"],
+        "--payload-digest",
+        args["payload_digest"],
+    )
+    assert result.exit_code == 1
+    assert json.loads(result.stdout)["unresolved"] is True
+    assert [r.get("request_mode", "prepare") for r in route.authority.calls] == [
+        "prepare",
+        "recover",
+        "recover",
+    ]
+
+
+def test_stdio_reuses_negotiation_but_cli_owns_separate_sessions(route):
+    tool(request_mode="discover")
+    tool(request_mode="discover")
+    assert route.authority.rpc_methods == [
+        "initialize",
+        "notifications/initialized",
+        "tools/list",
+        "tools/call",
+        "tools/call",
+    ]
+    assert cli("--request-mode", "discover").exit_code == 0
+    assert route.authority.rpc_methods[-4:] == [
+        "initialize",
+        "notifications/initialized",
+        "tools/list",
+        "tools/call",
+    ]
+    assert len(route.authority.rpc_methods) == 9
+    previous = decision_session._client
+    decision_session.close()
+    assert previous.is_closed is True
+    tool(request_mode="discover")
+    assert len(route.authority.rpc_methods) == 13

--- a/packages/nauro/tests/test_generation_refresh.py
+++ b/packages/nauro/tests/test_generation_refresh.py
@@ -498,7 +498,7 @@ refresh.commit_generation_refresh(prepared)
     )
 
 
-def test_refresh_executor_has_no_runtime_consumer():
+def test_refresh_executor_has_only_named_runtime_consumers():
     import ast
     from pathlib import Path
 
@@ -512,4 +512,8 @@ def test_refresh_executor_has_no_runtime_consumer():
                 consumers.extend(
                     a.name for a in node.names if a.name == "nauro.sync.generation_refresh"
                 )
-    assert sorted(consumers) == ["mcp/generation_reads.py", "mcp/generation_responses.py"]
+    assert sorted(consumers) == [
+        "cli/generation_reads.py",
+        "mcp/generation_reads.py",
+        "mcp/generation_responses.py",
+    ]

--- a/packages/nauro/tests/test_normal_generation_reads.py
+++ b/packages/nauro/tests/test_normal_generation_reads.py
@@ -1,0 +1,330 @@
+"""Ordinary reads and explicit replica refresh use one normal credential binding."""
+
+import json
+import socket
+
+import httpx
+import pytest
+from typer.testing import CliRunner
+
+from nauro.cli import generation_reads as cli
+from nauro.cli.main import app
+from nauro.mcp import read_dispatch, stdio_server
+from nauro.store import generation_installation as installation
+from nauro.store.generation_projection import (
+    GenerationProjectionIdentity,
+    GenerationProjectionTarget,
+    verify_generation_projection,
+)
+from nauro.store.registry import register_project_v2
+from nauro.store.resolution import resolve_project_binding
+from nauro.sync import generation_acquisition, generation_refresh
+from nauro.sync.generation_session import GenerationTransferSession
+from tests.generation_account import seed_generation_account
+from tests.test_sync.test_generation_acquisition import PROJECT_ID, USER_ID, FakeServer
+
+
+def forbidden(*_args, **_kwargs):
+    pytest.fail("Legacy, automatic or external path executed")
+
+
+@pytest.fixture
+def normal(tmp_path, monkeypatch):
+    monkeypatch.setenv("NAURO_HOME", str(tmp_path / "home"))
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(socket.socket, "connect", forbidden)
+    register_project_v2(
+        "Nauro", [], project_id=PROJECT_ID, mode="cloud", server_url="https://api.test"
+    )
+    binding = resolve_project_binding(PROJECT_ID, None)
+    binding.store_path.mkdir(parents=True, exist_ok=True)
+    server = FakeServer(
+        {"project.md": b"# Project\n", "state.md": b"# State\nInitial generation\n"}
+    )
+    projection = verify_generation_projection(
+        GenerationProjectionTarget(binding, GenerationProjectionIdentity(**server.identity())),
+        manifest_json=server.envelope(),
+        artifacts=tuple(server.artifacts.items()),
+    )
+    monkeypatch.setattr(installation, "read_active_user_id", lambda: USER_ID)
+    installation.publish_generation_control(installation.install_generation_root(projection))
+    connection = seed_generation_account(binding, USER_ID, monkeypatch)
+    monkeypatch.setattr(installation, "read_active_user_id", forbidden)
+    monkeypatch.setattr(generation_acquisition, "with_token_refresh", forbidden)
+
+    def factory(b):
+        return GenerationTransferSession(b, server.session.client)
+
+    monkeypatch.setattr(read_dispatch, "GenerationTransferSession", factory)
+    monkeypatch.setattr(cli, "GenerationTransferSession", factory)
+    with factory(binding) as session:
+        generation_refresh.commit_generation_refresh(
+            generation_refresh.prepare_initial_generation_refresh(
+                binding, actor=USER_ID, session=session
+            ),
+            session=session,
+        )
+    for name in read_dispatch.GENERATION_READS:
+        monkeypatch.setattr(read_dispatch.legacy, f"tool_{name}", forbidden)
+    server.requests.clear()
+    yield binding, server, connection
+    server.session.client.close()
+
+
+def test_cli_and_full_stdio_read_verified_generation(normal):
+    binding, server, _ = normal
+    (binding.store_path / "state.md").write_text("STALE FLAT CONTENT")
+    response = stdio_server.get_raw_file("state.md", project_id=PROJECT_ID)
+    assert response.isError is False
+    assert "Initial generation" in response.content[0].text
+    assert "STALE" not in response.content[0].text
+    assert server.generation_id in response.content[0].text
+    result = CliRunner().invoke(app, ["get-raw-file", "state.md", "--project", "Nauro"])
+    assert result.exit_code == 0, result.output
+    envelope = json.loads(result.stdout)
+    assert envelope["read_authority"]["generation_id"] == server.generation_id
+    assert "Initial generation" in result.stdout
+    assert "STALE" not in result.stdout
+    text = CliRunner().invoke(
+        app, ["get-raw-file", "state.md", "--project", "Nauro", "--format", "text"]
+    )
+    assert text.exit_code == 0, text.output
+    assert "Authorization checked for this read." in text.stdout
+    assert {bearer for _, route, _, bearer in server.requests if route.startswith("api.test/")} == {
+        "Bearer normal-generation-token"
+    }
+
+
+def test_explicit_sync_refreshes_and_never_writes_flat_store_or_runs_hooks(normal, monkeypatch):
+    from nauro.cli.commands import sync as sync_command
+
+    binding, server, _ = normal
+    flat = binding.store_path / "state.md"
+    flat.write_text("legacy retained")
+    server.generation_id = "01K66666666666666666666666"
+    server.artifacts["state.md"] = b"# State\nNew committed generation\n"
+    assert stdio_server.get_raw_file("state.md", project_id=PROJECT_ID).isError is True
+    for name in ("capture_snapshot", "warn_then_regen", "push_store_to_cloud", "_pull_from_cloud"):
+        monkeypatch.setattr(sync_command, name, forbidden)
+    result = CliRunner().invoke(app, ["sync", "--project", "Nauro"])
+    assert result.exit_code == 0, result.output
+    assert result.stdout == f"Refreshed generation {server.generation_id}.\n"
+    response = stdio_server.get_raw_file("state.md", project_id=PROJECT_ID)
+    assert response.isError is False
+    assert "New committed generation" in response.content[0].text
+    assert flat.read_text() == "legacy retained"
+    assert all(
+        bearer is None
+        for _, route, _, bearer in server.requests
+        if route.startswith("objects.test/")
+    )
+    assert all("/oauth/token" not in route for _, route, _, _ in server.requests)
+
+
+@pytest.mark.parametrize("change", ["expired", "logout", "actor", "marker", "endpoint"])
+def test_changed_authority_refuses_without_legacy_fallback(normal, change):
+    from nauro.store.config import load_config, save_config
+
+    binding, server, connection = normal
+    if change in {"expired", "logout", "actor"}:
+        store = connection.store()
+        with store.locked():
+            before = store.read()
+            changes = {
+                "expired": {"expires_at": 1},
+                "logout": {"state": "logged_out"},
+                "actor": {"user_id": "01K44444444444444444444444"},
+            }[change]
+            store.write(before.model_copy(update=changes))
+    elif change == "marker":
+        (binding.store_path / ".replica/authority.json").write_text("corrupt")
+    else:
+        config = load_config()
+        config["api_url"] = "https://untrusted.test"
+        save_config(config)
+    assert stdio_server.get_raw_file("state.md", project_id=PROJECT_ID).isError is True
+    assert (
+        CliRunner().invoke(app, ["get-raw-file", "state.md", "--project", "Nauro"]).exit_code == 1
+    )
+    assert server.requests == []
+
+
+def test_401_does_not_refresh_or_repeat_request(normal):
+    _, server, _ = normal
+    server.projection_hook = lambda *_: httpx.Response(401)
+    result = stdio_server.get_raw_file("state.md", project_id=PROJECT_ID)
+    assert result.isError is True
+    assert len(server.requests) == 1
+    assert server.requests[0][1] == "api.test/generations/projection"
+
+
+def test_logout_during_projection_discards_response(normal):
+    _, server, connection = normal
+
+    def logout(_count, payload):
+        store = connection.store()
+        with store.locked():
+            store.write(store.empty("logged_out"))
+        return payload
+
+    server.projection_hook = logout
+    result = stdio_server.get_raw_file("state.md", project_id=PROJECT_ID)
+    assert result.isError is True
+    assert "Initial generation" not in str(result)
+    assert len(server.requests) == 1
+
+
+def test_missing_refresh_intent_does_not_bootstrap_automatically(normal):
+    binding, server, _ = normal
+    (binding.store_path / f".replica/v1/actors/{USER_ID}/refresh-intent.json").unlink()
+    result = CliRunner().invoke(app, ["sync", "--project", "Nauro"])
+    assert result.exit_code == 1
+    assert "bootstrap" in result.output
+    assert server.requests == []
+
+
+def test_push_only_is_refused_for_generation_replica(normal):
+    _, server, _ = normal
+    result = CliRunner().invoke(app, ["sync", "--project", "Nauro", "--push-only"])
+    assert result.exit_code == 1
+    assert "cannot push local files" in result.output
+    assert server.requests == []
+
+
+def test_partial_refresh_requires_explicit_recovery_and_keeps_old_evidence(normal, monkeypatch):
+    binding, server, _ = normal
+    server.generation_id = "01K66666666666666666666666"
+    server.artifacts["state.md"] = b"# State\nRecovered generation\n"
+    replace = generation_refresh.durable_replace
+    failed = []
+
+    def interrupt(paths, path, raw):
+        if path == paths.pointer and not failed:
+            failed.append(True)
+            raise OSError("Synthetic pointer publication failure")
+        return replace(paths, path, raw)
+
+    monkeypatch.setattr(generation_refresh, "durable_replace", interrupt)
+    result = CliRunner().invoke(app, ["sync", "--project", "Nauro"])
+    assert result.exit_code == 1
+    assert failed == [True]
+    paths = generation_refresh.refresh_paths(binding, USER_ID)
+    intent = paths.intent.read_bytes()
+    retained = sorted(paths.history.glob("*.json"))
+    assert len(retained) == 1
+    assert stdio_server.get_raw_file("state.md", project_id=PROJECT_ID).isError is True
+    assert paths.intent.read_bytes() == intent
+    result = CliRunner().invoke(app, ["sync", "--project", "Nauro"])
+    assert result.exit_code == 0, result.output
+    assert sorted(paths.history.glob("*.json")) == retained
+    assert paths.intent.read_bytes() == intent
+    assert (
+        "Recovered generation"
+        in stdio_server.get_raw_file("state.md", project_id=PROJECT_ID).content[0].text
+    )
+
+
+def test_full_stdio_process_reopens_normal_credentials_and_replica(normal, tmp_path):
+    import asyncio
+    import os
+    import sys
+    from pathlib import Path
+
+    from mcp import ClientSession, StdioServerParameters
+    from mcp.client.stdio import stdio_client
+
+    binding, server, connection = normal
+    state = tmp_path / "server.json"
+    state.write_text(json.dumps({path: body.decode() for path, body in server.artifacts.items()}))
+    source = Path(__file__).resolve().parents[3]
+    env = {
+        **os.environ,
+        "PYTHONPATH": os.pathsep.join(
+            str(p)
+            for p in (
+                source / "packages/nauro/src",
+                source / "packages/nauro-core/src",
+                source / "packages/nauro",
+            )
+        ),
+    }
+    script = """
+import json, socket, sys
+from pathlib import Path
+from tests.test_sync.test_generation_acquisition import FakeServer
+from nauro.mcp import read_dispatch
+from nauro.sync.generation_session import GenerationTransferSession
+from nauro.mcp.stdio_server import run_stdio
+import nauro.sync.hooks
+
+
+def forbidden(*args, **kwargs):
+    raise AssertionError("External connection or startup pull forbidden")
+
+
+socket.socket.connect = forbidden
+nauro.sync.hooks.pull_before_session = forbidden
+server = FakeServer(
+    {p: text.encode() for p, text in json.loads(Path(sys.argv[1]).read_text()).items()}
+)
+read_dispatch.GenerationTransferSession = lambda b: GenerationTransferSession(
+    b, server.session.client
+)
+run_stdio()
+"""
+
+    async def exercise(error):
+        params = StdioServerParameters(
+            command=sys.executable, args=["-c", script, str(state)], env=env, cwd=str(tmp_path)
+        )
+        async with stdio_client(params) as streams, ClientSession(*streams) as session:
+            await session.initialize()
+            assert len((await session.list_tools()).tools) == 10
+            result = await session.call_tool(
+                "get_raw_file", {"project_id": PROJECT_ID, "path": "state.md"}
+            )
+            assert result.isError is error
+            assert ("Initial generation" in result.content[0].text) is (not error)
+
+    asyncio.run(exercise(False))
+    store = connection.store()
+    with store.locked():
+        store.write(store.empty("logged_out"))
+    asyncio.run(exercise(True))
+
+
+@pytest.mark.parametrize("changed_scope", [False, True])
+def test_ordinary_history_uses_normal_credentials_and_verifies_scope(
+    normal, monkeypatch, changed_scope
+):
+    from nauro.sync import history_transport
+    from tests.test_history_transport import response_body
+
+    binding, server, _ = normal
+    target = GenerationProjectionTarget(binding, GenerationProjectionIdentity(**server.identity()))
+    calls = []
+
+    def wire(request):
+        if request.url.path == "/generations/history":
+            calls.append(request)
+            body = response_body(target)
+            if changed_scope:
+                body["projection_scope_id"] = "b" * 64
+            return httpx.Response(200, json=body)
+        return server.handle(request)
+
+    monkeypatch.setattr(history_transport, "read_active_credentials", forbidden)
+    with httpx.Client(transport=httpx.MockTransport(wire)) as client:
+        monkeypatch.setattr(
+            read_dispatch,
+            "GenerationTransferSession",
+            lambda b: GenerationTransferSession(b, client),
+        )
+        result = stdio_server.diff_since_last_session(project_id=PROJECT_ID)
+    assert result.isError is changed_scope
+    assert len(calls) == 1
+    assert calls[0].headers["Authorization"] == "Bearer normal-generation-token"
+    if not changed_scope:
+        assert result.content[0].text == response_body(target)["text"]
+    else:
+        assert "Removed file" not in result.content[0].text

--- a/packages/nauro/tests/test_normal_reference_registry.py
+++ b/packages/nauro/tests/test_normal_reference_registry.py
@@ -1,0 +1,46 @@
+"""Exact normal-registry negotiation without granting hosted read integration."""
+
+import copy
+
+import pytest
+from nauro_core.mcp_tools import HOSTED_TOOLS
+
+from nauro.sync.decision_reference_contract import DecisionReferenceError, reference_schema
+from nauro.sync.reference_reads import negotiate_registry
+
+
+def registry():
+    return {
+        "tools": [
+            {
+                "name": spec["name"],
+                "inputSchema": reference_schema()
+                if spec["name"] == "propose_decision"
+                else copy.deepcopy(spec["input_schema"]),
+            }
+            for spec in HOSTED_TOOLS
+        ]
+    }
+
+
+def test_exact_normal_registry_admits_decisions_but_not_probe_reads():
+    assert negotiate_registry(registry()) is False
+
+
+@pytest.mark.parametrize("change", ["legacy", "extra", "missing", "duplicate", "other_schema"])
+def test_changed_normal_registry_is_refused(change):
+    value = registry()
+    if change == "legacy":
+        next(t for t in value["tools"] if t["name"] == "propose_decision")["inputSchema"] = {
+            "required": ["rationale"]
+        }
+    elif change == "extra":
+        value["tools"].append({"name": "new_tool", "inputSchema": {}})
+    elif change == "missing":
+        value["tools"].pop()
+    elif change == "duplicate":
+        value["tools"][-1] = value["tools"][0]
+    else:
+        next(t for t in value["tools"] if t["name"] == "get_context")["inputSchema"] = {}
+    with pytest.raises(DecisionReferenceError):
+        negotiate_registry(value)

--- a/packages/nauro/tests/test_read_dispatch.py
+++ b/packages/nauro/tests/test_read_dispatch.py
@@ -5,6 +5,7 @@ import inspect
 import json
 from pathlib import Path
 
+import httpx
 import pytest
 from mcp.types import CallToolResult, TextContent
 
@@ -15,6 +16,8 @@ from nauro.store import read_authority
 from nauro.store.config import save_config
 from nauro.store.registry import register_project_v2
 from nauro.store.resolution import resolve_project_binding
+from nauro.sync.generation_session import GenerationTransferSession
+from tests.generation_account import seed_generation_account
 from tests.test_generation_installation import USER_ID
 from tests.test_generation_reads import POSIX
 from tests.test_generation_reads import admitted as admitted
@@ -42,7 +45,7 @@ def isolated_home(tmp_path, monkeypatch):
 
 
 @pytest.fixture
-def cloud(admitted):
+def cloud(admitted, monkeypatch):
     binding, current, checks = admitted
     register_project_v2(
         binding.display_name,
@@ -51,8 +54,12 @@ def cloud(admitted):
         project_id=binding.project_id,
         server_url=binding.server_url,
     )
-    save_config({"auth": {"user_id": USER_ID, "access_token": "synthetic"}})
-    return binding, current, checks
+    seed_generation_account(binding, USER_ID, monkeypatch)
+    with httpx.Client(transport=httpx.MockTransport(lambda _: httpx.Response(404))) as client:
+        monkeypatch.setattr(
+            dispatch, "GenerationTransferSession", lambda b: GenerationTransferSession(b, client)
+        )
+        yield binding, current, checks
 
 
 @pytest.fixture
@@ -74,7 +81,8 @@ def test_generation_uses_prepared_text_without_legacy_render(cloud, monkeypatch,
     binding, _, checks = cloud
     assert resolve_project_binding(binding.project_id, None) == binding
     assert read_authority.observe_generation_marker(binding) is not None
-    assert dispatch.read_active_user_id() == USER_ID
+    with GenerationTransferSession(binding) as session:
+        assert session.credentials().user_id == USER_ID
     expected = getattr(generation, name)(binding, **kwargs, actor=USER_ID)
     assert expected.is_error is False
     monkeypatch.setattr(dispatch, "_legacy_result", forbidden)
@@ -90,7 +98,7 @@ def test_generation_uses_prepared_text_without_legacy_render(cloud, monkeypatch,
 
 @pytest.mark.parametrize("name,kwargs", CASES + [("diff_since_last_session", {})])
 def test_flat_matches_live_stdio_without_credentials(flat, monkeypatch, name, kwargs):
-    monkeypatch.setattr(dispatch, "read_active_user_id", forbidden)
+    monkeypatch.setattr(dispatch, "GenerationTransferSession", forbidden)
     expected = getattr(stdio_server, name)(project_id=flat.project_id, **kwargs)
     actual = getattr(dispatch, name)(project_id=flat.project_id, **kwargs)
     assert actual == expected
@@ -173,7 +181,7 @@ def test_generation_history_never_reads_flat_snapshots(cloud, monkeypatch):
     binding, _, _ = cloud
     monkeypatch.setattr(dispatch.legacy, "tool_diff_since_last_session", forbidden)
     result = dispatch.diff_since_last_session(project_id=binding.project_id)
-    assert result == dispatch._prepared(generation.diff_since_last_session(binding, actor=USER_ID))
+    assert "Generation read unavailable" in result.content[0].text
     assert result.isError is True
 
 
@@ -237,9 +245,11 @@ def test_resolution_failure_never_calls_legacy(monkeypatch):
     assert dispatch.get_context(project_id="missing") == ERROR
 
 
-def test_dispatch_is_dormant_and_keeps_public_arguments():
+def test_dispatch_has_only_named_consumers_and_keeps_public_arguments():
     root = Path(dispatch.__file__).parents[1]
     for path in root.rglob("*.py"):
+        if path.relative_to(root).as_posix() in {"cli/generation_reads.py", "mcp/stdio_server.py"}:
+            continue
         for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
             if isinstance(node, ast.Import):
                 assert all(a.name != "nauro.mcp.read_dispatch" for a in node.names)

--- a/packages/nauro/tests/test_read_dispatch.py
+++ b/packages/nauro/tests/test_read_dispatch.py
@@ -97,11 +97,15 @@ def test_generation_uses_prepared_text_without_legacy_render(cloud, monkeypatch,
 
 
 @pytest.mark.parametrize("name,kwargs", CASES + [("diff_since_last_session", {})])
-def test_flat_matches_live_stdio_without_credentials(flat, monkeypatch, name, kwargs):
+def test_flat_matches_legacy_adapter_without_credentials(flat, monkeypatch, name, kwargs):
     monkeypatch.setattr(dispatch, "GenerationTransferSession", forbidden)
-    expected = getattr(stdio_server, name)(project_id=flat.project_id, **kwargs)
+    envelope = getattr(dispatch.legacy, f"tool_{name}")(flat.store_path, **kwargs)
+    expected = stdio_server._wrap_with_renderer(
+        name, envelope, dispatch.resolve_renderer_kwargs(name, kwargs, flat.store_path)
+    )
     actual = getattr(dispatch, name)(project_id=flat.project_id, **kwargs)
     assert actual == expected
+    assert getattr(stdio_server, name)(project_id=flat.project_id, **kwargs) == expected
 
 
 @pytest.mark.parametrize("phase", ["handler", "renderer"])

--- a/packages/nauro/tests/test_read_dispatch_diagnostics.py
+++ b/packages/nauro/tests/test_read_dispatch_diagnostics.py
@@ -51,7 +51,7 @@ def test_binding_diagnostic_matches_live_result(tmp_path, monkeypatch, name, kwa
         save_repo_config(repo, config)
     expected = getattr(stdio_server, name)(cwd=str(repo), **kwargs)
     monkeypatch.setattr(dispatch, "observe_generation_marker", forbidden)
-    monkeypatch.setattr(dispatch, "read_active_user_id", forbidden)
+    monkeypatch.setattr(dispatch, "GenerationTransferSession", forbidden)
     monkeypatch.setattr(dispatch.legacy, f"tool_{name}", forbidden)
     monkeypatch.setattr(dispatch.generation, name, forbidden)
     actual = getattr(dispatch, name)(cwd=str(repo), **kwargs)
@@ -114,8 +114,7 @@ def test_post_binding_error_never_becomes_diagnostic(tmp_path, monkeypatch, phas
         monkeypatch.setattr(dispatch, "observe_generation_marker", Mock(side_effect=error))
     else:
         monkeypatch.setattr(dispatch, "observe_generation_marker", lambda *args: b"marker")
-        monkeypatch.setattr(dispatch, "read_active_user_id", lambda: "actor")
-        monkeypatch.setattr(dispatch.generation, "get_context", Mock(side_effect=error))
+        monkeypatch.setattr(dispatch, "generation_response", Mock(side_effect=error))
     result = dispatch.get_context(project_id=pid)
     assert result.isError is True
     assert result.structuredContent is None


### PR DESCRIPTION
## Why

Generation-backed projects need the existing client commands and MCP tools to use saved decision requests and verified replicas through the configured server connection.

## What changed

- Bind normal authentication to the trusted connection and verified account, with durable renewal and logout handling.
- Route the existing decision command and local MCP tool through preparation, saved-reference submission, discovery and lookup-only recovery. Extend the existing tool schema; add no tools or browser approval workflow.
- Accept the exact full hosted reference registry. Route local reads to verified generations and use explicit `nauro sync` for replica refresh and interrupted-refresh recovery.

## Test plan

Local suite with absolute candidate source paths: 6,864 passed, 120 skipped. Server and explicit cross-repository checks: 184 passed, no skips. The final output-handling correction passed 101 tests on Python 3.10 and 101 on Python 3.12, including the actual stdio subprocess and legacy tool tests. Lint, formatting, risk/source guards and targeted typing passed. All 17 CI checks passed on the final candidate, including Python 3.10 through 3.14 client/core tests, platform controls, distribution, import checks, lint and typing.

## Risk / what to review

Review account and endpoint binding, authority changes during a read, and refusal without legacy write fallback. Another writer's commit makes stale local reads refuse until explicit sync. Submission errors never cause an automatic resend. Stale proposals need new preparation and fresh approval.

## Deferred

Concurrent writing remains incomplete and production activation is unchanged. Normal cloud reads, credential longevity, ordinary read/refresh timing, required mutation coverage and migration rehearsal remain open. The server prerequisite will follow separately. Its reference flag affects the whole deployment and refuses legacy-project decision calls, so installation and rollout compatibility must be verified before enablement.
