### PR TITLE
Add reference snapshots and generation-bound context inputs

### DIFF
--- a/packages/nauro-core/src/nauro_core/operations/_commit_prepare.py
+++ b/packages/nauro-core/src/nauro_core/operations/_commit_prepare.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 from . import commit_plan as contract
 
 
@@ -165,7 +167,10 @@ def _derive_snapshot_bytes_impl(
     *,
     payload: contract.ApprovedPayload,
     effective_at: str,
+    snapshot_format: Literal["serialized", "references"] = "serialized",
 ) -> bytes:
+    if snapshot_format not in {"serialized", "references"}:
+        raise ValueError("unsupported snapshot format")
     snapshot_files = {
         artifact.path: artifact.content.decode("utf-8")
         for artifact in artifacts
@@ -177,6 +182,12 @@ def _derive_snapshot_bytes_impl(
         "update": "update: ",
         "supersede": f"supersede: {title}",
     }[payload.content.operation]
+    if snapshot_format == "references":
+        from nauro_core.snapshot_references import snapshot_descriptor
+
+        return snapshot_descriptor(
+            {a.path: a.content for a in artifacts}, timestamp=effective_at, trigger=trigger
+        )
     snapshot = contract.serialize_snapshot(
         timestamp=effective_at,
         trigger=trigger,
@@ -200,6 +211,7 @@ def _build_artifacts_impl(
     evaluation: contract.ProposalEvaluation,
     target: contract.Decision | None,
     target_stem: str | None,
+    snapshot_format: Literal["serialized", "references"] = "serialized",
 ) -> tuple[
     tuple[contract.PlannedArtifact, ...],
     contract.PlannedSnapshot,
@@ -300,7 +312,7 @@ def _build_artifacts_impl(
     )
     snapshot = contract.PlannedSnapshot(
         content=contract._derive_snapshot_bytes(
-            artifacts, payload=payload, effective_at=effective_at
+            artifacts, payload=payload, effective_at=effective_at, snapshot_format=snapshot_format
         )
     )
     primary_bytes = planned[primary_path]
@@ -451,6 +463,8 @@ def prepare_judgment_commit_impl(
     approval_attestation: contract.ApprovalAttestation,
     committed_generation: contract.CommittedGeneration,
     expected_payload_digest: str | None = None,
+    *,
+    snapshot_format: Literal["serialized", "references"] = "serialized",
 ) -> contract.PreparedJudgmentCommit:
     """Prepare immutable artifacts and semantic claim reads without I/O."""
     payload_bytes = bytes(payload_bytes)
@@ -522,6 +536,7 @@ def prepare_judgment_commit_impl(
             evaluation=evaluation,
             target=target,
             target_stem=target_stem,
+            snapshot_format=snapshot_format,
         )
     )
     probes, intents = contract._claim_contract(payload.content.operation, target, primary_model)
@@ -541,6 +556,7 @@ def prepare_judgment_commit_impl(
         new_decision_counter=new_counter,
         planned_artifacts=artifacts,
         snapshot=snapshot,
+        snapshot_format=snapshot_format,
         primary_decision=primary,
         claim_probes=probes,
         claim_intents=intents,

--- a/packages/nauro-core/src/nauro_core/operations/commit_plan.py
+++ b/packages/nauro-core/src/nauro_core/operations/commit_plan.py
@@ -593,6 +593,7 @@ class PreparedJudgmentCommit(_FrozenModel):
     new_decision_counter: StrictInt = Field(ge=0)
     planned_artifacts: tuple[PlannedArtifact, ...]
     snapshot: PlannedSnapshot
+    snapshot_format: Literal["serialized", "references"] = "serialized"
     primary_decision: PrimaryDecision
     claim_probes: tuple[ClaimProbe, ...]
     claim_intents: ClaimIntents
@@ -658,6 +659,7 @@ class PreparedJudgmentCommit(_FrozenModel):
                 self.planned_artifacts,
                 payload=self.payload,
                 effective_at=self.effective_at,
+                snapshot_format=self.snapshot_format,
             )
             != self.snapshot.content
         ):
@@ -792,6 +794,7 @@ def _derive_snapshot_bytes(
     *,
     payload: ApprovedPayload,
     effective_at: str,
+    snapshot_format: Literal["serialized", "references"] = "serialized",
 ) -> bytes:
     from . import _commit_prepare
 
@@ -799,6 +802,7 @@ def _derive_snapshot_bytes(
         artifacts,
         payload=payload,
         effective_at=effective_at,
+        snapshot_format=snapshot_format,
     )
 
 
@@ -812,6 +816,7 @@ def _build_artifacts(
     evaluation: ProposalEvaluation,
     target: Decision | None,
     target_stem: str | None,
+    snapshot_format: Literal["serialized", "references"] = "serialized",
 ) -> tuple[
     tuple[PlannedArtifact, ...],
     PlannedSnapshot,
@@ -832,6 +837,7 @@ def _build_artifacts(
         evaluation=evaluation,
         target=target,
         target_stem=target_stem,
+        snapshot_format=snapshot_format,
     )
 
 
@@ -850,6 +856,8 @@ def prepare_judgment_commit(
     approval_attestation: ApprovalAttestation,
     committed_generation: CommittedGeneration,
     expected_payload_digest: str | None = None,
+    *,
+    snapshot_format: Literal["serialized", "references"] = "serialized",
 ) -> PreparedJudgmentCommit:
     """Prepare immutable artifacts and semantic claim reads without I/O."""
     from . import _commit_prepare
@@ -859,6 +867,7 @@ def prepare_judgment_commit(
         approval_attestation,
         committed_generation,
         expected_payload_digest,
+        snapshot_format=snapshot_format,
     )
 
 

--- a/packages/nauro-core/src/nauro_core/operations/l0_inputs.py
+++ b/packages/nauro-core/src/nauro_core/operations/l0_inputs.py
@@ -1,0 +1,44 @@
+"""Capture the immutable inputs used by the existing L0 renderer."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from nauro_core.operations.get_context import get_context
+
+
+class _CapturedStore:
+    def __init__(self, files: dict[str, str]) -> None:
+        self.files = dict(files)
+        self.captured: dict[str, str] = {}
+
+    def read_file(self, path: str) -> str | None:
+        body = self.files.get(path)
+        if body is not None:
+            self.captured[path] = body
+        return body
+
+    def list_decisions(self) -> list[str]:
+        return sorted(
+            path[10:-3]
+            for path in self.files
+            if path.startswith("decisions/") and path.endswith(".md")
+        )
+
+    def write_file(self, path: str, content: str) -> None:
+        raise TypeError("L0 capture is read-only")
+
+    def delete_file(self, path: str) -> None:
+        raise TypeError("L0 capture is read-only")
+
+    def read_decision(self, stem: str) -> str | None:
+        return self.read_file(f"decisions/{stem}.md")
+
+    def read_decisions(self, stems: list[str]) -> dict[str, str | None]:
+        return {stem: self.read_decision(stem) for stem in stems}
+
+
+def capture_l0_inputs(files: Mapping[str, bytes]) -> dict[str, str]:
+    store = _CapturedStore({path: body.decode("utf-8") for path, body in files.items()})
+    get_context(store, 0)
+    return dict(sorted(store.captured.items()))

--- a/packages/nauro-core/src/nauro_core/snapshot_references.py
+++ b/packages/nauro-core/src/nauro_core/snapshot_references.py
@@ -1,0 +1,28 @@
+"""Canonical archive descriptors over retained immutable file bytes."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+
+from nauro_core.protected_generation_membership import is_hosted_snapshot_content_member
+
+
+def snapshot_descriptor(files: Mapping[str, bytes], *, timestamp: str, trigger: str) -> bytes:
+    return json.dumps(
+        {
+            "schema": "nauro.snapshot.references.v1",
+            "timestamp": timestamp,
+            "trigger": trigger,
+            "files": {
+                path: {"sha256": hashlib.sha256(body).hexdigest(), "length": len(body)}
+                for path, body in sorted(files.items())
+                if is_hosted_snapshot_content_member(path)
+            },
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")

--- a/packages/nauro-core/tests/operations/test_commit_plan.py
+++ b/packages/nauro-core/tests/operations/test_commit_plan.py
@@ -14,6 +14,7 @@ from nauro_core.decision_model import (
     format_decision,
     parse_decision,
 )
+from nauro_core.operations._in_memory_store import InMemoryStore
 from nauro_core.operations.commit_plan import (
     AbsentContentClaimObservation,
     AbsentTitleClaimObservation,
@@ -45,8 +46,11 @@ from nauro_core.operations.commit_plan import (
     finalize_judgment_commit,
     prepare_judgment_commit,
 )
+from nauro_core.operations.get_context import get_context
+from nauro_core.operations.l0_inputs import capture_l0_inputs
 from nauro_core.operations.results import ProposeDecisionResult
 from nauro_core.snapshot import serialize_snapshot
+from nauro_core.snapshot_references import snapshot_descriptor
 
 GENERATION_ID = "01K00000000000000000000000"
 PROPOSAL_ID = "01K00000000000000000000001"
@@ -1041,14 +1045,17 @@ _MOVED_FUNCTION_METADATA = {
     ),
     "_derive_snapshot_bytes": (
         "(artifacts: 'tuple[PlannedArtifact, ...]', *, payload: 'ApprovedPayload', "
-        "effective_at: 'str') -> 'bytes'",
+        "effective_at: 'str', "
+        "snapshot_format: \"Literal['serialized', 'references']\" = 'serialized') -> 'bytes'",
         None,
     ),
     "_build_artifacts": (
         "(*, payload: 'ApprovedPayload', provenance: 'DecisionProvenance | None', "
         "effective_at: 'str', generation: 'CommittedGeneration', current: 'dict[str, bytes]', "
         "evaluation: 'ProposalEvaluation', target: 'Decision | None', "
-        "target_stem: 'str | None') -> 'tuple[tuple[PlannedArtifact, ...], PlannedSnapshot, "
+        "target_stem: 'str | None', "
+        "snapshot_format: \"Literal['serialized', 'references']\" = 'serialized') "
+        "-> 'tuple[tuple[PlannedArtifact, ...], PlannedSnapshot, "
         "PrimaryDecision, ProposeDecisionResult, int | None, int, Decision]'",
         None,
     ),
@@ -1060,7 +1067,9 @@ _MOVED_FUNCTION_METADATA = {
     "prepare_judgment_commit": (
         "(payload_bytes: 'bytes', approval_attestation: 'ApprovalAttestation', "
         "committed_generation: 'CommittedGeneration', expected_payload_digest: 'str | None' = "
-        "None) -> 'PreparedJudgmentCommit'",
+        "None, *, "
+        "snapshot_format: \"Literal['serialized', 'references']\" = 'serialized') "
+        "-> 'PreparedJudgmentCommit'",
         "Prepare immutable artifacts and semantic claim reads without I/O.",
     ),
     "_probe_key": ("(probe: 'ClaimProbe') -> 'tuple[str, str]'", None),
@@ -1400,7 +1409,7 @@ def test_commit_plan_facade_model_contract_digest_is_stable() -> None:
         }
     ]
     assert hashlib.sha256(projection_bytes).hexdigest() == (
-        "762393c65fc7098fb5835077de6a23815160845e02a5dd2ad9c2986bf0a8440a"
+        "b63af3167830ec9d0fdd17a5ab946b547707f23bf209078c3b3c4294e523a7b7"
     )
 
 
@@ -1584,3 +1593,56 @@ def test_commit_plan_import_order_is_cycle_free_in_clean_subprocess(
     assert importlib.import_module("nauro_core.operations.commit_plan").PreparedJudgmentCommit is (
         PreparedJudgmentCommit
     )
+
+
+def test_reference_snapshot_is_bound_to_exact_plan_without_changing_judgment():
+    generation = _generation(("project.md", b"# Test\n"))
+    payload = _preteam_payload(generation)
+    old = prepare_judgment_commit(payload, _preteam_attestation(), generation)
+    new = prepare_judgment_commit(
+        payload, _preteam_attestation(), generation, snapshot_format="references"
+    )
+    assert new.planned_artifacts == old.planned_artifacts
+    assert new.payload_bytes == old.payload_bytes
+    descriptor = json.loads(new.snapshot.content)
+    assert descriptor["schema"] == "nauro.snapshot.references.v1"
+    assert descriptor["files"] == {
+        a.path: {"sha256": a.sha256, "length": len(a.content)} for a in new.planned_artifacts
+    }
+    raw = {name: getattr(new, name) for name in type(new).model_fields}
+    raw["snapshot"] = old.snapshot
+    with pytest.raises(ValueError, match="snapshot bytes"):
+        PreparedJudgmentCommit.model_validate(raw)
+
+
+def test_archive_membership_excludes_control_and_api_material():
+    body = snapshot_descriptor(
+        {
+            "project.md": b"abc",
+            ".decision-hashes.json": b"{}",
+            "snapshots/x.json": b"{}",
+            "question-provenance.json": b"{}",
+        },
+        timestamp="2026-09-09T00:00:00Z",
+        trigger="test",
+    )
+    assert set(json.loads(body)["files"]) == {"project.md"}
+
+
+def test_l0_inputs_preserve_output_without_retaining_full_corpus():
+    files = {"project.md": b"# Project\n", "state_history.md": b"private history"}
+    for number in range(1, 101):
+        path, body = _decision(number, f"Choice {number}")
+        files[path] = body
+    inputs = capture_l0_inputs(files)
+    original = InMemoryStore(
+        decisions={p[10:-3]: b.decode() for p, b in files.items() if p.startswith("decisions/")},
+        files={p: b.decode() for p, b in files.items() if not p.startswith("decisions/")},
+    )
+    reduced = InMemoryStore(
+        decisions={p[10:-3]: b for p, b in inputs.items() if p.startswith("decisions/")},
+        files={p: b for p, b in inputs.items() if not p.startswith("decisions/")},
+    )
+    assert get_context(original, 0).content == get_context(reduced, 0).content
+    assert len(inputs) == 33
+    assert "state_history.md" not in inputs

--- a/packages/nauro-core/tests/snapshots/hosted_consumer_contract_v1.json
+++ b/packages/nauro-core/tests/snapshots/hosted_consumer_contract_v1.json
@@ -681,7 +681,7 @@
       "kind": "function",
       "module": "nauro_core.operations.commit_plan",
       "qualname": "prepare_judgment_commit",
-      "signature": "(payload_bytes: bytes, approval_attestation: ApprovalAttestation, committed_generation: CommittedGeneration, expected_payload_digest: str | None = None) -> PreparedJudgmentCommit"
+      "signature": "(payload_bytes: bytes, approval_attestation: ApprovalAttestation, committed_generation: CommittedGeneration, expected_payload_digest: str | None = None, *, snapshot_format: Literal['serialized', 'references'] = 'serialized') -> PreparedJudgmentCommit"
     },
     "nauro_core.operations.decision_lookup.scan_decisions": {
       "kind": "function",

--- a/packages/nauro/tests/test_sync/test_generation_acquisition.py
+++ b/packages/nauro/tests/test_sync/test_generation_acquisition.py
@@ -265,6 +265,32 @@ def test_legacy_authority_refusal_is_typed_and_leaves_the_origin_open() -> None:
     assert server.counts["projection"] == 2
 
 
+def test_shared_format_server_refusal_does_not_fall_back_to_legacy_reads() -> None:
+    server = FakeServer()
+    server.projection_hook = lambda _n, _p: _json(500, {"error": "project_data_unavailable"})
+    with pytest.raises(TransferBoundaryError):
+        acquire(server)
+    assert server.calls() == [PROJECTION]
+
+
+def test_shared_fields_are_rejected_even_with_a_matching_envelope_digest() -> None:
+    server = FakeServer()
+
+    def shared(_count, payload):
+        envelope = json.loads(server.envelope())
+        envelope["representation"] = "shared.v1"
+        envelope["planning_packs"] = {}
+        body = json.dumps(envelope, sort_keys=True, separators=(",", ":")).encode()
+        payload["manifest_base64"] = base64.b64encode(body).decode()
+        payload["projection"]["manifest_digest"] = hashlib.sha256(body).hexdigest()
+        return payload
+
+    server.projection_hook = shared
+    with pytest.raises(GenerationProjectionVerificationError):
+        acquire(server)
+    assert server.calls() == [PROJECTION]
+
+
 def test_wrong_manifest_digest_is_refused_before_presign() -> None:
     # Without the digest check the envelope parses and the raises assertion fails.
     server = FakeServer()


### PR DESCRIPTION
## Why

Generation storage needs a snapshot representation that can reference retained immutable files without serializing every body into each archive. This is the core prerequisite for that server change.

## What changed

Add opt-in reference snapshot descriptors, bound to the prepared judgment plan, and capture the existing core inputs needed for generation-bound L0 rendering. Serialized snapshots remain the default. Add client checks that refuse unsupported shared-format responses without legacy fallback.

## Test plan

1,922 core/public-contract tests, 43 replica-acquisition tests and 22 explicit cross-repository reference tests passed without skips. Repository lint/format, risk and source guards passed; strict typing passed for both new core modules. The additive hosted-consumer snapshot correction was independently reviewed.

## Risk / what to review

A descriptor is a complete archive only while all referenced objects remain retained and verifiable. The server must release against the matching core API and establish retention and format compatibility before enabling it. Concurrent writing remains incomplete; this PR does not change production activation or enable shared storage.
