### PR TITLE
Stop nauro status executing repo-recorded commands

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/status.py
+++ b/packages/nauro/src/nauro/cli/commands/status.py
@@ -352,13 +352,10 @@ def _collect_wiring(repo_paths: list[Path]) -> _WiringSnapshot:
 
 
 def _untrusted_commands(commands: frozenset[str], repo_paths: list[Path]) -> frozenset[str]:
-    """Recorded commands status must never execute. Any doubt counts as untrusted."""
-    try:
-        return frozenset(
-            command for command in commands if not nauro_command.is_probe_safe(command, repo_paths)
-        )
-    except Exception:
-        return commands
+    """Recorded commands status must never execute."""
+    return frozenset(
+        command for command in commands if not nauro_command.is_probe_safe(command, repo_paths)
+    )
 
 
 def _probe_wiring(snapshot: _WiringSnapshot, *, no_probe: bool) -> _WiringProbeResults:

--- a/packages/nauro/src/nauro/cli/commands/status.py
+++ b/packages/nauro/src/nauro/cli/commands/status.py
@@ -2,7 +2,7 @@
 
 import json
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -212,6 +212,7 @@ class _WiringSnapshot:
     hook_states: tuple[_CodexHookState, ...]
     agents_generated: int
     workflow: _WorkflowArtifacts
+    untrusted_commands: frozenset[str] = frozenset()
 
     @property
     def configured_hooks(self) -> tuple[_CodexHookState, ...]:
@@ -225,6 +226,14 @@ class _WiringSnapshot:
             for command in state.recorded_commands
             if command
         )
+
+    @property
+    def untrusted_mcp_commands(self) -> frozenset[str]:
+        return self.mcp_commands & self.untrusted_commands
+
+    @property
+    def untrusted_hook_commands(self) -> frozenset[str]:
+        return self.hook_commands & self.untrusted_commands
 
 
 @dataclass(frozen=True)
@@ -329,7 +338,7 @@ def _collect_wiring(repo_paths: list[Path]) -> _WiringSnapshot:
     mcp_commands = {command for commands in repo_commands for command in commands if command}
     if codex_command:
         mcp_commands.add(codex_command)
-    return _WiringSnapshot(
+    snapshot = _WiringSnapshot(
         repo_count=len(repo_paths),
         mcp_wired=sum(1 for commands in repo_commands if commands),
         codex_global=codex_global,
@@ -338,13 +347,26 @@ def _collect_wiring(repo_paths: list[Path]) -> _WiringSnapshot:
         agents_generated=agents_generated,
         workflow=workflow,
     )
+    recorded = snapshot.mcp_commands | snapshot.hook_commands
+    return replace(snapshot, untrusted_commands=_untrusted_commands(recorded, repo_paths))
+
+
+def _untrusted_commands(commands: frozenset[str], repo_paths: list[Path]) -> frozenset[str]:
+    """Recorded commands status must never execute. Any doubt counts as untrusted."""
+    try:
+        return frozenset(
+            command for command in commands if not nauro_command.is_probe_safe(command, repo_paths)
+        )
+    except Exception:
+        return commands
 
 
 def _probe_wiring(snapshot: _WiringSnapshot, *, no_probe: bool) -> _WiringProbeResults:
     if no_probe:
         return _WiringProbeResults(True, None, None)
-    mcp_results = _probe_commands(snapshot.mcp_commands, args=("--version",))
-    hook_results = _probe_commands(snapshot.hook_commands, args=_CODEX_HOOK_PROBE_ARGS)
+    untrusted = snapshot.untrusted_commands
+    mcp_results = _probe_commands(snapshot.mcp_commands - untrusted, args=("--version",))
+    hook_results = _probe_commands(snapshot.hook_commands - untrusted, args=_CODEX_HOOK_PROBE_ARGS)
     return _WiringProbeResults(False, mcp_results, hook_results)
 
 
@@ -373,12 +395,20 @@ def _mcp_status_line(snapshot: _WiringSnapshot, probes: _WiringProbeResults) -> 
     healthy = probes.mcp is None or all(
         probes.mcp.get(command, True) for command in snapshot.mcp_commands
     )
-    if healthy:
-        return f"  MCP           active ({detail})"
-    return (
-        f"  MCP           BROKEN - {detail} but the recorded command won't run; "
-        "re-run 'nauro setup all'"
-    )
+    if not healthy:
+        return (
+            f"  MCP           BROKEN - {detail} but the recorded command won't run; "
+            "re-run 'nauro setup all'"
+        )
+    if snapshot.untrusted_mcp_commands:
+        untrusted = _untrusted_detail(snapshot.untrusted_mcp_commands)
+        return f"  MCP           active ({detail}; {untrusted})"
+    return f"  MCP           active ({detail})"
+
+
+def _untrusted_detail(commands: frozenset[str]) -> str:
+    listed = ", ".join(repr(command) for command in sorted(commands))
+    return f"{listed} is not a nauro install, not probed"
 
 
 def _codex_hooks_status_line(snapshot: _WiringSnapshot, probes: _WiringProbeResults) -> str:
@@ -395,17 +425,22 @@ def _codex_hooks_status_line(snapshot: _WiringSnapshot, probes: _WiringProbeResu
             f"  Codex hooks   BROKEN - {detail} but the lifecycle wiring is incomplete; "
             "re-run 'nauro setup all --with-hooks'"
         )
+    healthy = probes.hooks is None or all(
+        probes.hooks.get(command, True) for command in snapshot.hook_commands
+    )
+    if not healthy:
+        return (
+            f"  Codex hooks   BROKEN - {detail} but the recorded command won't run; "
+            "re-run 'nauro setup all --with-hooks'"
+        )
+    if snapshot.untrusted_hook_commands:
+        untrusted = _untrusted_detail(snapshot.untrusted_hook_commands)
+        return f"  Codex hooks   configured ({detail}; {untrusted})"
     if probes.skipped:
         return f"  Codex hooks   configured ({detail}; liveness not probed)"
     if probes.hooks is None:
         return f"  Codex hooks   configured ({detail}; liveness unknown)"
-    healthy = all(probes.hooks.get(command, True) for command in snapshot.hook_commands)
-    if healthy:
-        return f"  Codex hooks   configured ({detail}; command healthy)"
-    return (
-        f"  Codex hooks   BROKEN - {detail} but the recorded command won't run; "
-        "re-run 'nauro setup all --with-hooks'"
-    )
+    return f"  Codex hooks   configured ({detail}; command healthy)"
 
 
 def _agents_status_line(snapshot: _WiringSnapshot) -> str:
@@ -718,6 +753,7 @@ class _McpPayload(BaseModel):
     codex_global: bool
     probed: bool
     healthy: bool | None
+    untrusted_commands: int
 
 
 class _CodexHooksPayload(BaseModel):
@@ -726,6 +762,7 @@ class _CodexHooksPayload(BaseModel):
     complete: bool | None
     probed: bool
     healthy: bool | None
+    untrusted_commands: int
 
 
 class _SkillsPayload(BaseModel):
@@ -833,6 +870,7 @@ def _build_status_payload(facts: _StatusFacts) -> StatusPayload:
             codex_global=snapshot.codex_global,
             probed=mcp_probed,
             healthy=mcp_healthy,
+            untrusted_commands=len(snapshot.untrusted_mcp_commands),
         ),
         codex_hooks=_CodexHooksPayload(
             repo_count=snapshot.repo_count,
@@ -840,6 +878,7 @@ def _build_status_payload(facts: _StatusFacts) -> StatusPayload:
             complete=hooks_complete,
             probed=hooks_probed,
             healthy=hooks_healthy,
+            untrusted_commands=len(snapshot.untrusted_hook_commands),
         ),
         skills=_SkillsPayload(
             core=_surface_counts_payload(workflow.core_skills),

--- a/packages/nauro/src/nauro/cli/nauro_command.py
+++ b/packages/nauro/src/nauro/cli/nauro_command.py
@@ -1,4 +1,9 @@
-"""Resolve and validate the durable nauro command for recorded MCP/hook wiring."""
+"""Resolve and validate the durable nauro command for recorded MCP/hook wiring.
+
+Wiring files arrive with a clone, so a command read back from one is evidence of wiring,
+never an instruction: status executes a recorded command only when ``is_probe_safe`` says
+it is Nauro's own entrypoint and not a file the repo itself ships.
+"""
 
 from __future__ import annotations
 
@@ -6,11 +11,16 @@ import functools
 import shutil
 import subprocess
 import sys
+from collections.abc import Iterable
 from pathlib import Path
 
 import typer
 
 from nauro.cli._codex_hooks import _CODEX_HOOK_PROBE_ARGS
+from nauro.cli.git_hygiene import wiring_path_is_tracked
+from nauro.store.write_safety import find_symlink
+
+_ENTRYPOINT_NAMES = frozenset({"nauro", "nauro.exe"})
 
 
 def probe_nauro_command(
@@ -33,6 +43,48 @@ def probe_nauro_command(
     except (OSError, subprocess.TimeoutExpired):
         return False
     return proc.returncode == 0
+
+
+def is_nauro_entrypoint(command: str) -> bool:
+    """True when ``command`` is bare ``nauro`` or an absolute path to a ``nauro`` console script.
+    A relative path or any other program is never Nauro's own entrypoint.
+    """
+    if command.lower() in _ENTRYPOINT_NAMES:
+        return True
+    path = Path(command)
+    return path.is_absolute() and path.name.lower() in _ENTRYPOINT_NAMES
+
+
+def is_probe_safe(command: str, repo_roots: Iterable[Path]) -> bool:
+    """True when status may execute a recorded ``command``.
+    It must be Nauro's entrypoint and must not be a file that any of ``repo_roots`` ships.
+    """
+    if not is_nauro_entrypoint(command):
+        return False
+    target = command if Path(command).is_absolute() else shutil.which(command)
+    if target is None:
+        return True
+    roots = list(repo_roots)
+    try:
+        candidates = {Path(target), Path(target).resolve()}
+    except OSError:
+        return False
+    return not any(_is_repo_shipped(path, root) for path in candidates for root in roots)
+
+
+def _is_repo_shipped(target: Path, root: Path) -> bool:
+    """True when ``target`` lies inside ``root`` and is git-tracked or reached through a symlink.
+    Either shape arrived with the clone, so it is the repo author's program, not a Nauro install.
+    """
+    try:
+        rel = target.relative_to(root)
+    except ValueError:
+        try:
+            rel = target.relative_to(root.resolve())
+        except (OSError, ValueError):
+            return False
+    relative = rel.as_posix()
+    return find_symlink(root, relative) is not None or wiring_path_is_tracked(root, relative)
 
 
 _DURABLE_PATH_MARKERS: tuple[tuple[str, str], ...] = (("pipx", "venvs"), ("uv", "tools"))

--- a/packages/nauro/src/nauro/cli/nauro_command.py
+++ b/packages/nauro/src/nauro/cli/nauro_command.py
@@ -58,6 +58,7 @@ def is_nauro_entrypoint(command: str) -> bool:
 def is_probe_safe(command: str, repo_roots: Iterable[Path]) -> bool:
     """True when status may execute a recorded ``command``.
     It must be Nauro's entrypoint and must not be a file that any of ``repo_roots`` ships.
+    A path that cannot be resolved (NUL bytes, symlink loops, unreadable parents) is unsafe.
     """
     if not is_nauro_entrypoint(command):
         return False
@@ -67,9 +68,9 @@ def is_probe_safe(command: str, repo_roots: Iterable[Path]) -> bool:
     roots = list(repo_roots)
     try:
         candidates = {Path(target), Path(target).resolve()}
-    except OSError:
+        return not any(_is_repo_shipped(path, root) for path in candidates for root in roots)
+    except (OSError, RuntimeError, ValueError):
         return False
-    return not any(_is_repo_shipped(path, root) for path in candidates for root in roots)
 
 
 def _is_repo_shipped(target: Path, root: Path) -> bool:

--- a/packages/nauro/tests/test_cli_status.py
+++ b/packages/nauro/tests/test_cli_status.py
@@ -1,6 +1,7 @@
 """Tests for nauro status command."""
 
 import json
+import subprocess
 from pathlib import Path
 
 from typer.testing import CliRunner
@@ -20,6 +21,9 @@ from nauro.templates.agents_md import FOOTER_MARKER
 from nauro.templates.scaffolds import scaffold_project_store
 
 runner = CliRunner()
+
+# The real subprocess seam, captured before the autouse fixture stubs it.
+_REAL_PROBE = nauro_command.probe_nauro_command
 
 
 def _setup_project(tmp_path, monkeypatch, repos=None):
@@ -533,6 +537,116 @@ def test_status_treats_empty_windows_override_as_inactive(tmp_path, monkeypatch)
 
     assert result.exit_code == 0
     assert "Codex hooks   inactive" in result.output
+
+
+def test_status_never_executes_a_non_nauro_recorded_command(tmp_path, monkeypatch):
+    """A repo's own .mcp.json / .codex/hooks.json command is reported, never run."""
+    _setup_project(tmp_path, monkeypatch)
+    (tmp_path / ".mcp.json").write_text(
+        json.dumps({"mcpServers": {"nauro": {"command": "./setup-helper.sh"}}})
+    )
+    _wire_codex_hooks(tmp_path, command="./setup-helper.sh")
+    calls: list[str] = []
+    monkeypatch.setattr(
+        nauro_command, "probe_nauro_command", lambda cmd, **kwargs: calls.append(cmd) or True
+    )
+
+    result = runner.invoke(app, ["status"])
+
+    assert result.exit_code == 0
+    assert calls == []
+    assert (
+        "MCP           active (wired in 1/1 repos; './setup-helper.sh' is not a nauro install, "
+        "not probed)"
+    ) in result.output
+    assert (
+        "Codex hooks   configured (wired in 1/1 repos; './setup-helper.sh' is not a nauro "
+        "install, not probed)"
+    ) in result.output
+
+
+def test_status_leaves_a_repo_shipped_script_unexecuted_end_to_end(tmp_path, monkeypatch):
+    """With the real subprocess seam in place, a cloned repo's script still never runs."""
+    _setup_project(tmp_path, monkeypatch)
+    marker = tmp_path / "executed"
+    script = tmp_path / "setup-helper.sh"
+    script.write_text(f"#!/bin/sh\ntouch {marker}\nexit 0\n")
+    script.chmod(0o755)
+    (tmp_path / ".mcp.json").write_text(
+        json.dumps({"mcpServers": {"nauro": {"command": "./setup-helper.sh"}}})
+    )
+    monkeypatch.setattr(nauro_command, "probe_nauro_command", _REAL_PROBE)
+
+    result = runner.invoke(app, ["status"])
+
+    assert result.exit_code == 0
+    assert not marker.exists()
+    assert "not probed" in result.output
+
+
+def test_status_does_not_probe_nauro_tracked_inside_the_repo(tmp_path, monkeypatch):
+    """An absolute path to a git-tracked file is the repo author's program, not this machine's."""
+    _setup_project(tmp_path, monkeypatch)
+    shipped = tmp_path / "tools" / "nauro"
+    shipped.parent.mkdir()
+    shipped.write_text("#!/bin/sh\nexit 0\n")
+    git = ["git", "-c", "user.name=t", "-c", "user.email=t@example.com"]
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run([*git, "add", "tools/nauro"], cwd=tmp_path, check=True)
+    subprocess.run([*git, "commit", "-q", "-m", "ship"], cwd=tmp_path, check=True)
+    (tmp_path / ".mcp.json").write_text(
+        json.dumps({"mcpServers": {"nauro": {"command": str(shipped)}}})
+    )
+    calls: list[str] = []
+    monkeypatch.setattr(
+        nauro_command, "probe_nauro_command", lambda cmd, **kwargs: calls.append(cmd) or True
+    )
+
+    result = runner.invoke(app, ["status"])
+
+    assert result.exit_code == 0
+    assert calls == []
+    assert "is not a nauro install, not probed" in result.output
+
+
+def test_status_still_probes_an_untracked_project_venv_nauro(tmp_path, monkeypatch):
+    """The fragile project-venv install keeps its liveness row."""
+    _setup_project(tmp_path, monkeypatch)
+    venv_nauro = tmp_path / ".venv" / "bin" / "nauro"
+    venv_nauro.parent.mkdir(parents=True)
+    venv_nauro.write_text("#!/bin/sh\nexit 0\n")
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    (tmp_path / ".mcp.json").write_text(
+        json.dumps({"mcpServers": {"nauro": {"command": str(venv_nauro)}}})
+    )
+    calls: list[str] = []
+    monkeypatch.setattr(
+        nauro_command, "probe_nauro_command", lambda cmd, **kwargs: calls.append(cmd) or True
+    )
+
+    result = runner.invoke(app, ["status"])
+
+    assert result.exit_code == 0
+    assert calls == [str(venv_nauro)]
+    assert "MCP           active (wired in 1/1 repos)" in result.output
+
+
+def test_status_dead_trusted_command_still_wins_over_untrusted_caveat(tmp_path, monkeypatch):
+    repo1 = tmp_path / "repo1"
+    repo2 = tmp_path / "repo2"
+    repo1.mkdir()
+    repo2.mkdir()
+    _setup_project(tmp_path, monkeypatch, repos=[repo1, repo2])
+    _wire_repo_mcp(repo1)
+    (repo2 / ".mcp.json").write_text(
+        json.dumps({"mcpServers": {"nauro": {"command": "./setup-helper.sh"}}})
+    )
+    monkeypatch.setattr(nauro_command, "probe_nauro_command", lambda cmd, **kwargs: False)
+
+    result = runner.invoke(app, ["status"])
+
+    assert result.exit_code == 0
+    assert "MCP           BROKEN" in result.output
 
 
 def test_status_dedupes_shared_command_to_one_probe(tmp_path, monkeypatch):

--- a/packages/nauro/tests/test_cli_status_json.py
+++ b/packages/nauro/tests/test_cli_status_json.py
@@ -18,6 +18,7 @@ import pytest
 from typer.testing import CliRunner
 
 from nauro.agents import AGENT_NAMES
+from nauro.cli import nauro_command
 from nauro.cli.integrations import codex_config
 from nauro.cli.integrations.agents import materialize_agents_cursor_for_repo
 from nauro.cli.integrations.skills import OPT_IN_SKILL_NAMES, SKILL_NAMES
@@ -89,6 +90,7 @@ def test_status_json_happy_path_golden_payload(tmp_path, monkeypatch):
             "codex_global": False,
             "probed": False,
             "healthy": None,
+            "untrusted_commands": 0,
         },
         # No hooks configured: completeness is not applicable.
         "codex_hooks": {
@@ -97,6 +99,7 @@ def test_status_json_happy_path_golden_payload(tmp_path, monkeypatch):
             "complete": None,
             "probed": False,
             "healthy": None,
+            "untrusted_commands": 0,
         },
         "skills": {
             "core": {
@@ -341,3 +344,33 @@ def test_status_json_reports_null_when_quarantines_cannot_be_listed(tmp_path, mo
 
     payload = json.loads(result.stdout)
     assert payload["decisions"]["quarantined_collisions"] is None
+
+
+def test_status_json_counts_untrusted_commands_and_never_probes_them(tmp_path, monkeypatch):
+    """A non-nauro recorded command is counted, not executed; healthy stays null."""
+    _, repo = _setup_project(tmp_path, monkeypatch)
+    (repo / ".mcp.json").write_text(
+        json.dumps({"mcpServers": {"nauro": {"command": "./setup-helper.sh"}}})
+    )
+    _wire_codex_hooks(repo, command="./setup-helper.sh")
+    calls: list[str] = []
+    monkeypatch.setattr(
+        nauro_command, "probe_nauro_command", lambda cmd, **kwargs: calls.append(cmd) or True
+    )
+
+    result = runner.invoke(app, ["status", "--json"])
+    assert result.exit_code == 0, result.output
+
+    payload = json.loads(result.stdout)
+    assert calls == []
+    assert payload["mcp"] == {
+        "repo_count": 1,
+        "wired_repos": 1,
+        "codex_global": False,
+        "probed": False,
+        "healthy": None,
+        "untrusted_commands": 1,
+    }
+    assert payload["codex_hooks"]["untrusted_commands"] == 1
+    assert payload["codex_hooks"]["probed"] is False
+    assert payload["codex_hooks"]["healthy"] is None

--- a/packages/nauro/tests/test_command_resolution.py
+++ b/packages/nauro/tests/test_command_resolution.py
@@ -368,3 +368,7 @@ def test_probe_safe_rejects_a_symlinked_ancestor_inside_the_repo(tmp_path):
     (repo / ".venv").symlink_to(tmp_path / "outside")
 
     assert not nauro_command.is_probe_safe(str(repo / ".venv" / "bin" / "nauro"), [repo])
+
+
+def test_probe_safe_treats_an_unresolvable_path_as_unsafe(tmp_path):
+    assert not nauro_command.is_probe_safe("/opt/nauro\0/bin/nauro", [tmp_path])

--- a/packages/nauro/tests/test_command_resolution.py
+++ b/packages/nauro/tests/test_command_resolution.py
@@ -274,3 +274,97 @@ def test_setup_all_resolves_command_once(tmp_path, monkeypatch):
     # Two repos × two JSON surfaces + codex would be five _find_nauro_command
     # calls; memoization collapses them to a single probe.
     assert len(calls) == 1
+
+
+# ── is_nauro_entrypoint / is_probe_safe ────────────────────────────────────────
+
+
+def _git_commit_file(repo, rel: str, content: str = "#!/bin/sh\nexit 0\n"):
+    path = repo / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+    path.chmod(0o755)
+    git = ["git", "-c", "user.name=t", "-c", "user.email=t@example.com"]
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run([*git, "add", rel], cwd=repo, check=True)
+    subprocess.run([*git, "commit", "-q", "-m", "ship"], cwd=repo, check=True)
+    return path
+
+
+@pytest.mark.parametrize(
+    "command",
+    ["nauro", "NAURO", "nauro.exe", "/opt/pipx/venvs/nauro/bin/nauro", "/x/Nauro.EXE"],
+)
+def test_entrypoint_accepts_bare_nauro_and_absolute_nauro_paths(command):
+    assert nauro_command.is_nauro_entrypoint(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    ["./nauro", "tools/nauro", "./setup-helper.sh", "uvx", "/usr/bin/python3", "/bin/sh", ""],
+)
+def test_entrypoint_rejects_relative_paths_and_other_programs(command):
+    assert not nauro_command.is_nauro_entrypoint(command)
+
+
+def test_probe_safe_rejects_non_entrypoint_without_touching_disk(tmp_path):
+    assert not nauro_command.is_probe_safe("./setup-helper.sh", [tmp_path])
+
+
+def test_probe_safe_accepts_absolute_nauro_outside_every_repo(tmp_path):
+    assert nauro_command.is_probe_safe("/opt/pipx/venvs/nauro/bin/nauro", [tmp_path])
+
+
+def test_probe_safe_rejects_nauro_tracked_inside_a_repo(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    shipped = _git_commit_file(repo, "tools/nauro")
+
+    assert not nauro_command.is_probe_safe(str(shipped), [repo])
+
+
+def test_probe_safe_accepts_untracked_nauro_inside_a_repo(tmp_path):
+    """A project-venv install lives inside the repo but did not arrive with the clone."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git_commit_file(repo, "README.md", "hi\n")
+    venv_nauro = repo / ".venv" / "bin" / "nauro"
+    venv_nauro.parent.mkdir(parents=True)
+    venv_nauro.write_text("#!/bin/sh\nexit 0\n")
+
+    assert nauro_command.is_probe_safe(str(venv_nauro), [repo])
+
+
+def test_probe_safe_resolves_bare_nauro_through_path_before_judging(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    shipped = _git_commit_file(repo, "nauro")
+    monkeypatch.setattr(nauro_command.shutil, "which", lambda name: str(shipped))
+
+    assert not nauro_command.is_probe_safe("nauro", [repo])
+
+    monkeypatch.setattr(nauro_command.shutil, "which", lambda name: "/opt/uv/tools/nauro/bin/nauro")
+    assert nauro_command.is_probe_safe("nauro", [repo])
+
+
+def test_probe_safe_rejects_a_repo_symlink_named_nauro_even_when_it_points_outside(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git_commit_file(repo, "README.md", "hi\n")
+    link = repo / "tools" / "nauro"
+    link.parent.mkdir()
+    link.symlink_to("/bin/sh")
+
+    assert not nauro_command.is_probe_safe(str(link), [repo])
+
+
+def test_probe_safe_rejects_a_symlinked_ancestor_inside_the_repo(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git_commit_file(repo, "README.md", "hi\n")
+    outside = tmp_path / "outside" / "bin"
+    outside.mkdir(parents=True)
+    (outside / "nauro").write_text("#!/bin/sh\nexit 0\n")
+    (repo / ".venv").symlink_to(tmp_path / "outside")
+
+    assert not nauro_command.is_probe_safe(str(repo / ".venv" / "bin" / "nauro"), [repo])


### PR DESCRIPTION
## Why

`nauro status` liveness-probed every command string it read back from a repo's `.mcp.json`, `.cursor/mcp.json` and `.codex/hooks.json` by running it. Those files arrive with a clone, so a repository could commit `"command": "./setup-helper.sh"` and have `nauro adopt` followed by `nauro status` (which the bundled skills and generated `AGENTS.md` tell agents to run) execute it as the user. Nauro already refuses to *write* wiring into git-tracked files; it still trusted what it read back.

## What changed

- A recorded command is evidence of wiring, never an instruction. Status executes it only when `is_probe_safe` holds: the command is Nauro's own entrypoint (bare `nauro`, or an absolute path whose basename is `nauro`/`nauro.exe`) and it is not a file the repo ships (git-tracked inside a registered repo, or reached through a symlink component inside one). Bare `nauro` is resolved through PATH before the repo check. An untracked project-venv install keeps its liveness row.
- Untrusted commands render as `'<cmd>' is not a nauro install, not probed` on the MCP and Codex hooks rows and as an `untrusted_commands` count in `--json`. A dead trusted command still renders BROKEN. Any classification error counts as untrusted.

## Test plan

- New unit tests for the entrypoint shape rule and the repo-shipped rule (tracked file, tracked symlink, symlinked ancestor, untracked venv, bare `nauro` resolved through PATH).
- New end-to-end status tests, including one that restores the real subprocess seam and asserts a repo-shipped script leaves no marker file.
- `ruff check`, `ruff format --check`, `check_ruff_budget.py`, `check_docstring_budget.py`, and the public-contract snapshot all pass.
- Full `packages/nauro/tests` suite: 4960 passed; the 12 failures are pre-existing read-only-directory tests that fail identically on `main` when run as root.

## Risk / what to review

The probe-eligibility rule in `nauro_command.is_probe_safe` and `_is_repo_shipped`: the literal and the resolved path are both checked against every registered repo root, and a symlinked component inside a repo is refused before the git-tracked check so `wiring_path_is_tracked`'s own `resolve()` cannot be bypassed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnF3K3WpeaMt6M44UbGwEy

---
_Generated by [Claude Code](https://claude.ai/code/session_01WnF3K3WpeaMt6M44UbGwEy)_