### PR TITLE
Bound untrusted store bytes on parse and pull

### DIFF
--- a/packages/nauro-core/src/nauro_core/decision_model.py
+++ b/packages/nauro-core/src/nauro_core/decision_model.py
@@ -289,13 +289,25 @@ _H1_FORMAT = "# {num:03d} \u2014 {title}"
 _FAST_YAML_LOADER = getattr(yaml, "CSafeLoader", yaml.SafeLoader)
 _PLAIN_KEY_CHARS = string.ascii_lowercase + string.digits + "_"
 _PLAIN_VALUE_CHARS = string.ascii_letters + string.digits + " -_./:~(),+"
+# A frontmatter block is a few dozen short lines; this bounds parse work per file.
+MAX_FRONTMATTER_CHARS = 64 * 1024
+
+
+class _NoAliasSafeLoader(yaml.SafeLoader):
+    """SafeLoader that refuses alias nodes, so a block can never expand beyond its own size."""
+
+    def compose_node(self, parent: yaml.Node | None, index: object) -> yaml.Node:
+        if self.check_event(yaml.AliasEvent):
+            mark = self.peek_event().start_mark
+            raise yaml.composer.ComposerError(None, None, "aliases are not allowed", mark)
+        return super().compose_node(parent, index)
 
 
 def _load_frontmatter_mapping(frontmatter_block: str) -> object:
     """Parse a frontmatter block with the fast loader when it is plain enough for
-    both loaders to agree, else with the pure loader. Raises ``yaml.YAMLError``.
+    both loaders to agree, else with the alias-free pure loader. Raises ``yaml.YAMLError``.
     """
-    loader = _FAST_YAML_LOADER if _is_plain_block(frontmatter_block) else yaml.SafeLoader
+    loader = _FAST_YAML_LOADER if _is_plain_block(frontmatter_block) else _NoAliasSafeLoader
     return yaml.load(frontmatter_block, Loader=loader)
 
 
@@ -400,6 +412,10 @@ def _split_frontmatter(text: str, filename: str) -> tuple[str, str]:
     fm_end = text.find(_FM_CLOSE_FENCE, len(_FM_OPEN_FENCE))
     if fm_end == -1:
         raise ValueError(f"{filename}: unterminated YAML frontmatter")
+    if fm_end - len(_FM_OPEN_FENCE) > MAX_FRONTMATTER_CHARS:
+        raise ValueError(
+            f"{filename}: YAML frontmatter exceeds {MAX_FRONTMATTER_CHARS} characters"
+        )
     return text[len(_FM_OPEN_FENCE) : fm_end], text[fm_end + len(_FM_CLOSE_FENCE) :]
 
 

--- a/packages/nauro-core/src/nauro_core/questions.py
+++ b/packages/nauro-core/src/nauro_core/questions.py
@@ -54,22 +54,33 @@ class InvalidLegacyQuestionIdentifier(ValueError):
         super().__init__(f"{field} must use valid YYYY-MM-DD HH:MM UTC form.")
 
 
+# Question numbers are allocated sequentially, so a bounded width costs nothing and
+# keeps every parse, format, and JSON round-trip linear in a store's real size.
+MAX_QUESTION_ID_DIGITS = 18
+MAX_QUESTION_NUMBER = 10**MAX_QUESTION_ID_DIGITS - 1
+
+
 def format_question_id(number: object, *, field: str = "question_number") -> str:
-    """Return the canonical unpadded Q-form for a positive integer."""
+    """Return the canonical unpadded Q-form for a positive integer within the width bound."""
     if isinstance(number, bool) or not isinstance(number, int) or number < 1:
         raise InvalidQuestionIdentifier(field, "a positive integer")
+    if number > MAX_QUESTION_NUMBER:
+        raise InvalidQuestionIdentifier(field, f"at most {MAX_QUESTION_ID_DIGITS} digits")
     return "Q" + _format_positive_ascii_decimal(number)
 
 
 def parse_question_id(value: object, *, field: str = "question_id") -> int:
-    """Return the numeric identity of a compatible Q-form input."""
+    """Return the numeric identity of a compatible Q-form input within the width bound."""
     if not isinstance(value, str) or len(value) < 2 or value[0] != "Q":
         raise InvalidQuestionIdentifier(field, "Q followed by positive ASCII decimal digits")
     digits = value[1:]
     if not is_ascii_decimal(digits):
         raise InvalidQuestionIdentifier(field, "Q followed by positive ASCII decimal digits")
+    significant = digits.lstrip("0")
+    if len(significant) > MAX_QUESTION_ID_DIGITS:
+        raise InvalidQuestionIdentifier(field, f"at most {MAX_QUESTION_ID_DIGITS} digits")
     number = 0
-    for digit in digits:
+    for digit in significant:
         number = number * 10 + ord(digit) - ord("0")
     if number < 1:
         raise InvalidQuestionIdentifier(field, "Q followed by positive ASCII decimal digits")
@@ -147,7 +158,7 @@ class QuestionEntry(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    num: int | None = Field(default=None, ge=1)
+    num: int | None = Field(default=None, ge=1, le=MAX_QUESTION_NUMBER)
     timestamp: datetime | None = None
     body: str
     continuation: list[str] = Field(default_factory=list)

--- a/packages/nauro-core/tests/test_decision_model.py
+++ b/packages/nauro-core/tests/test_decision_model.py
@@ -559,6 +559,35 @@ class TestNegativeValidation:
         with pytest.raises(ValueError, match="invalid YAML"):
             parse_decision(text, "001-test.md")
 
+    def test_yaml_aliases_are_refused_before_expansion(self) -> None:
+        # A merge-key bomb: each level references the previous one many times.
+        levels = ["a0: &a0 [x, x, x, x, x, x, x, x]"]
+        for depth in range(1, 9):
+            refs = ", ".join([f"*a{depth - 1}"] * 8)
+            levels.append(f"a{depth}: &a{depth} [{refs}]")
+        text = "---\ndate: 2026-04-01\n" + "\n".join(levels) + "\n---\n\n# 001 \u2014 Bomb\n\n"
+        with pytest.raises(ValueError, match="invalid YAML.*alias"):
+            parse_decision(text, "001-test.md")
+
+    def test_quoted_asterisks_still_parse_without_the_fast_loader(self) -> None:
+        text = (
+            "---\n"
+            "date: 2026-04-01\n"
+            "confidence: high\n"
+            "files_affected:\n"
+            "- 'src/**/*.py'\n"
+            "---\n\n"
+            "# 001 \u2014 Globs\n\n"
+            "## Decision\n\nSomething.\n"
+        )
+        assert parse_decision(text, "001-test.md").files_affected == ["src/**/*.py"]
+
+    def test_oversized_frontmatter_is_refused_before_parsing(self) -> None:
+        padding = "".join(f"k{i}: v\n" for i in range(20_000))
+        text = "---\n" + padding + "---\n\n# 001 \u2014 Big\n\n## Decision\n\nx.\n"
+        with pytest.raises(ValueError, match="frontmatter exceeds"):
+            parse_decision(text, "001-test.md")
+
     def test_missing_frontmatter_raises(self) -> None:
         text = "# 001 \u2014 No frontmatter\n\n## Decision\n\nSomething.\n"
         with pytest.raises(ValueError, match="missing YAML frontmatter"):

--- a/packages/nauro-core/tests/test_questions.py
+++ b/packages/nauro-core/tests/test_questions.py
@@ -580,14 +580,25 @@ class TestQuestionIdentifierSeam:
     def test_format_emits_canonical_unpadded_form(self):
         assert format_question_id(17) == "Q17"
 
-    def test_parse_and_format_have_no_identifier_width_limit(self):
-        canonical = "Q1" + "0" * 4999
+    def test_parse_and_format_cap_identifier_width_at_eighteen_digits(self):
+        canonical = "Q1" + "0" * 17
         padded = "Q000" + canonical[1:]
         number = parse_question_id(padded)
         assert format_question_id(number) == canonical
         assert validate_question_id(canonical) == canonical
         with pytest.raises(InvalidQuestionIdentifier):
             validate_question_id(padded)
+        with pytest.raises(InvalidQuestionIdentifier, match="18 digits"):
+            parse_question_id("Q1" + "0" * 18)
+        with pytest.raises(InvalidQuestionIdentifier, match="18 digits"):
+            format_question_id(10**18)
+
+    def test_oversized_id_line_degrades_to_a_non_entry_in_linear_time(self):
+        from nauro_core.questions import OpenQuestionsFile
+
+        text = "# Open Questions\n\n- [Q" + "9" * 200_000 + "] giant\n- [Q7] real\n"
+        parsed = OpenQuestionsFile.parse(text)
+        assert [entry.num for entry in parsed.numbered_entries] == [7]
 
     @pytest.mark.parametrize(
         "value",

--- a/packages/nauro/README.md
+++ b/packages/nauro/README.md
@@ -1,6 +1,6 @@
 # Nauro
 
-What every agent should know
+Decision system for software built with AI
 
 Keep your project's direction in human hands as agents do more of the work.
 

--- a/packages/nauro/src/nauro/sync/merge.py
+++ b/packages/nauro/src/nauro/sync/merge.py
@@ -699,8 +699,9 @@ def _set_union_markdown(local: bytes, remote: bytes) -> bytes:
     Emits the union of the preambles, then per-header body unions in local order with
     remote-only sections appended last; non-blank lines are deduped at document scope.
     """
-    local_text = local.decode("utf-8")
-    remote_text = remote.decode("utf-8")
+    # surrogateescape carries undecodable bytes through the line union unchanged.
+    local_text = local.decode("utf-8", errors="surrogateescape")
+    remote_text = remote.decode("utf-8", errors="surrogateescape")
 
     local_lines = local_text.split("\n")
     remote_lines = remote_text.split("\n")
@@ -746,4 +747,4 @@ def _set_union_markdown(local: bytes, remote: bytes) -> bytes:
     result = "\n".join(deduped)
     if local_trailing_nl or remote_trailing_nl:
         result += "\n"
-    return result.encode("utf-8")
+    return result.encode("utf-8", errors="surrogateescape")

--- a/packages/nauro/src/nauro/sync/remote.py
+++ b/packages/nauro/src/nauro/sync/remote.py
@@ -19,6 +19,8 @@ from nauro.store.config import load_config
 
 _DEFAULT_API_TIMEOUT = 15.0
 _DEFAULT_TRANSFER_TIMEOUT = 60.0
+# Store files are markdown and small JSON; one object past this is refused, not installed.
+MAX_OBJECT_BYTES = 16 * 1024 * 1024
 _CLIENT_LIMITS = httpx.Limits(max_connections=10, max_keepalive_connections=10)
 _TRANSIENT_STATUSES = frozenset({429, 500, 502, 503, 504})
 _EXPIRED_STATUS = 403
@@ -125,6 +127,13 @@ class TransferBoundaryError(PresignError):
             and self.retry is RetryClassification.PERMANENT
             and self.operation in {TransferOperation.MANIFEST, TransferOperation.PRESIGN}
         )
+
+
+class ObjectTooLargeError(PresignError):
+    """A presigned GET body exceeds the per-object cap; refused outright, never retried."""
+
+    def __init__(self, url: str, limit: int) -> None:
+        super().__init__(f"GET refused at {canonical_origin(url)}: object exceeds {limit} bytes")
 
 
 @dataclass(frozen=True)
@@ -530,16 +539,36 @@ def urls_by_path(entries: list[Any], verb: str) -> tuple[dict[str, str], tuple[s
 
 
 def fetch_via_presigned_url(url: str, *, session: TransferSession | None = None) -> FetchedObject:
+    """Stream one object into memory, refusing it once it exceeds ``MAX_OBJECT_BYTES``."""
     with operation_session(session) as active:
-        response = _get(
-            active,
-            url,
-            TransferOperation.GET,
-            timeout=_DEFAULT_TRANSFER_TIMEOUT,
-        )
-    if response.status_code != 200:
-        raise _status_error(active, url, TransferOperation.GET, response.status_code)
-    return FetchedObject(response.content, response.headers.get("ETag", "").strip())
+        active.guard(url, TransferOperation.GET)
+        try:
+            with active.client.stream("GET", url, timeout=_DEFAULT_TRANSFER_TIMEOUT) as response:
+                if response.status_code != 200:
+                    raise _status_error(active, url, TransferOperation.GET, response.status_code)
+                body = _read_bounded_body(response, url)
+                etag = response.headers.get("ETag", "").strip()
+        except (httpx.HTTPError, httpx.InvalidURL, httpx.StreamError) as exc:
+            error = active.boundary_error(url, TransferOperation.GET, exc)
+        else:
+            return FetchedObject(body, etag)
+    raise error from None
+
+
+def _read_bounded_body(response: httpx.Response, url: str) -> bytes:
+    """Read a streamed body up to the cap, refusing early on a larger declared length."""
+    declared = response.headers.get("Content-Length", "")
+    if declared.isascii() and declared.isdigit():
+        if len(declared) > len(str(MAX_OBJECT_BYTES)) or int(declared) > MAX_OBJECT_BYTES:
+            raise ObjectTooLargeError(url, MAX_OBJECT_BYTES)
+    chunks: list[bytes] = []
+    received = 0
+    for chunk in response.iter_bytes():
+        received += len(chunk)
+        if received > MAX_OBJECT_BYTES:
+            raise ObjectTooLargeError(url, MAX_OBJECT_BYTES)
+        chunks.append(chunk)
+    return b"".join(chunks)
 
 
 def put_via_presigned_url(

--- a/packages/nauro/tests/test_distribution_copy.py
+++ b/packages/nauro/tests/test_distribution_copy.py
@@ -13,7 +13,7 @@ except ModuleNotFoundError:
 
 ROOT = Path(__file__).resolve().parents[3]
 
-TAGLINE = "What every agent should know"
+TAGLINE = "Decision system for software built with AI"
 
 SUPPORT_LINE = "Keep your project's direction in human hands as agents do more of the work."
 

--- a/packages/nauro/tests/test_sync/conftest.py
+++ b/packages/nauro/tests/test_sync/conftest.py
@@ -9,6 +9,7 @@ made the import graph say something about the tests that is not true.
 from __future__ import annotations
 
 import json
+from contextlib import contextmanager, nullcontext
 from pathlib import Path
 from unittest.mock import patch
 
@@ -183,11 +184,27 @@ def pull_report(store, entries, *, reporter=None, etags=None):
         return httpx.Response(200, content=bodies[url.split("/GET/", 1)[1]])
 
     with (
-        patch("nauro.sync.remote.httpx.Client.get", side_effect=fake_get),
+        patched_remote_get(fake_get),
         patch("nauro.sync.remote.httpx.Client.post", return_value=presign),
     ):
         report = run_pull(CLOUD_PID, store, reporter)
     return report, reporter
+
+
+@contextmanager
+def patched_remote_get(fake):
+    """Serve one URL-dispatching fake for both buffered (manifest) and streamed (object) GETs.
+    Yields the buffered-GET mock so callers can inspect manifest calls.
+    """
+
+    def stream(_method, url, **kwargs):
+        return nullcontext(fake(url, **kwargs))
+
+    with (
+        patch("nauro.sync.remote.httpx.Client.get", side_effect=fake) as buffered,
+        patch("nauro.sync.remote.httpx.Client.stream", side_effect=stream),
+    ):
+        yield buffered
 
 
 def pull(store, entries, *, reporter=None, etags=None):

--- a/packages/nauro/tests/test_sync/test_hooks.py
+++ b/packages/nauro/tests/test_sync/test_hooks.py
@@ -34,7 +34,7 @@ from nauro.sync.state import (
 )
 from nauro.templates.scaffolds import scaffold_project_store
 from tests.conftest import seed_auth_config
-from tests.test_sync.conftest import CLOUD_PID, _scaffolded_cloud_project
+from tests.test_sync.conftest import CLOUD_PID, _scaffolded_cloud_project, patched_remote_get
 
 
 def _ok(status: int, payload: dict) -> httpx.Response:
@@ -210,7 +210,7 @@ class TestPullBeforeSessionPresign:
             return httpx.Response(200, content=b"# 099\nfresh remote body\n")
 
         with (
-            patch("nauro.sync.remote.httpx.Client.get", side_effect=fake_get),
+            patched_remote_get(fake_get),
             patch("nauro.sync.remote.httpx.Client.post", return_value=presign),
         ):
             result = pull_before_session(CLOUD_PID, cloud_store)

--- a/packages/nauro/tests/test_sync/test_journal_excluded.py
+++ b/packages/nauro/tests/test_sync/test_journal_excluded.py
@@ -16,7 +16,7 @@ import httpx
 from nauro.sync.pull import run_pull
 from nauro.sync.push import push_changed_files
 from tests.conftest import seed_auth_config
-from tests.test_sync.conftest import CLOUD_PID, _scaffolded_cloud_project
+from tests.test_sync.conftest import CLOUD_PID, _scaffolded_cloud_project, patched_remote_get
 
 
 def _ok(status: int, payload: dict) -> httpx.Response:
@@ -79,7 +79,7 @@ def test_pull_skips_remote_journal_path(tmp_path):
         raise AssertionError("journal path must never be fetched")
 
     reporter = _RecordingReporter()
-    with patch("nauro.sync.remote.httpx.Client.get", side_effect=fake_get):
+    with patched_remote_get(fake_get):
         merged = run_pull(CLOUD_PID, store, reporter).merged
 
     assert merged == 0

--- a/packages/nauro/tests/test_sync/test_merge.py
+++ b/packages/nauro/tests/test_sync/test_merge.py
@@ -517,3 +517,13 @@ class TestWriteBackupIsAtomic:
 
         assert first.read_bytes() == b"the first copy\n"
         assert list((tmp_path / CONFLICT_BACKUP_DIR).iterdir()) == [first]
+
+
+def test_set_union_carries_undecodable_bytes_through_unchanged():
+    """A collaborator's non-UTF-8 line must not crash the pull; its bytes survive the union."""
+    local = b"# State History\n\n- local entry\n"
+    remote = b"# State History\n\n- remote \xff\xfe entry\n"
+    merged = _set_union_markdown(local, remote)
+    assert b"- local entry\n" in merged
+    assert b"- remote \xff\xfe entry\n" in merged
+    assert merged.count(b"# State History") == 1

--- a/packages/nauro/tests/test_sync/test_post_restore_sync.py
+++ b/packages/nauro/tests/test_sync/test_post_restore_sync.py
@@ -44,6 +44,7 @@ from tests.test_sync.conftest import (
     _RecordingReporter,
     _seed_token,
     decision_bytes,
+    patched_remote_get,
 )
 
 runner = CliRunner()
@@ -135,7 +136,7 @@ class _Remote:
             return _presign(kwargs["json"]["operations"])
 
         with (
-            patch("nauro.sync.remote.httpx.Client.get", side_effect=get),
+            patched_remote_get(get),
             patch("nauro.sync.remote.httpx.Client.post", side_effect=post),
         ):
             yield

--- a/packages/nauro/tests/test_sync/test_pull.py
+++ b/packages/nauro/tests/test_sync/test_pull.py
@@ -56,6 +56,7 @@ from tests.test_sync.conftest import (
     _seed_token,
     decision_bytes,
     entry_names,
+    patched_remote_get,
     pull,
     pull_report,
     track,
@@ -84,7 +85,7 @@ class TestRunPullCleanPull:
 
         reporter = _RecordingReporter()
         with (
-            patch("nauro.sync.remote.httpx.Client.get", side_effect=fake_get),
+            patched_remote_get(fake_get),
             patch("nauro.sync.remote.httpx.Client.post", return_value=presign),
         ):
             merged = run_pull(CLOUD_PID, cloud_store, reporter).merged
@@ -107,7 +108,7 @@ class TestRunPullCleanPull:
             return httpx.Response(200, content=_STAMPED_DECISION)
 
         with (
-            patch("nauro.sync.remote.httpx.Client.get", side_effect=fake_get),
+            patched_remote_get(fake_get),
             patch("nauro.sync.remote.httpx.Client.post", return_value=presign),
         ):
             merged = run_pull(CLOUD_PID, cloud_store, _RecordingReporter()).merged
@@ -180,7 +181,7 @@ class TestRunPullCleanPull:
 
         reporter = _RecordingReporter()
         with (
-            patch("nauro.sync.remote.httpx.Client.get", side_effect=fake_get),
+            patched_remote_get(fake_get),
             patch("nauro.sync.remote.httpx.Client.post", return_value=presign),
         ):
             merged = run_pull(CLOUD_PID, cloud_store, reporter).merged

--- a/packages/nauro/tests/test_sync/test_pull_admission.py
+++ b/packages/nauro/tests/test_sync/test_pull_admission.py
@@ -45,6 +45,7 @@ from tests.test_sync.conftest import (
     _seed_token,
     decision_bytes,
     entry_names,
+    patched_remote_get,
     pull_report,
     track,
 )
@@ -217,7 +218,7 @@ def _fake_server(entries):
         return httpx.Response(200, content=bodies[url.split("/GET/", 1)[1]])
 
     with (
-        patch("nauro.sync.remote.httpx.Client.get", side_effect=fake_get),
+        patched_remote_get(fake_get),
         patch("nauro.sync.remote.httpx.Client.post", return_value=presigned),
     ):
         yield

--- a/packages/nauro/tests/test_sync/test_sync_command.py
+++ b/packages/nauro/tests/test_sync/test_sync_command.py
@@ -12,7 +12,7 @@ from nauro.sync.pull import PullReport
 from nauro.sync.push import PushReport
 from nauro.templates.scaffolds import scaffold_project_store
 from tests.conftest import seed_auth_config
-from tests.test_sync.conftest import _scaffolded_cloud_project
+from tests.test_sync.conftest import _scaffolded_cloud_project, patched_remote_get
 
 runner = CliRunner()
 
@@ -447,7 +447,7 @@ class TestSyncHonesty:
 
         put_response = httpx.Response(200, headers={"ETag": '"uploaded"'})
         with (
-            patch("nauro.sync.remote.httpx.Client.get", side_effect=fake_get),
+            patched_remote_get(fake_get),
             patch("nauro.sync.remote.httpx.Client.post", side_effect=fake_post) as mock_post,
             patch("nauro.sync.remote.httpx.Client.put", return_value=put_response) as mock_put,
         ):
@@ -525,7 +525,7 @@ class TestSyncPullSurfacesAndMerges:
         put_response.headers = {"ETag": '"e_pushed"'}
 
         with (
-            patch("nauro.sync.remote.httpx.Client.get", side_effect=fake_get),
+            patched_remote_get(fake_get),
             patch("nauro.sync.remote.httpx.Client.post", side_effect=fake_post),
             patch("nauro.sync.remote.httpx.Client.put", return_value=put_response),
         ):

--- a/packages/nauro/tests/test_sync/test_sync_presign.py
+++ b/packages/nauro/tests/test_sync/test_sync_presign.py
@@ -32,7 +32,7 @@ from nauro.sync.state import (
     save_state,
 )
 from tests.conftest import seed_auth_config
-from tests.test_sync.conftest import CLOUD_PID, _scaffolded_cloud_project
+from tests.test_sync.conftest import CLOUD_PID, _scaffolded_cloud_project, patched_remote_get
 
 
 def _ok(status: int, payload: dict) -> httpx.Response:
@@ -181,7 +181,7 @@ class TestPullViaPresign:
         from nauro.sync import remote
 
         with (
-            patch.object(remote.httpx.Client, "get", side_effect=fake_get),
+            patched_remote_get(fake_get),
             patch.object(
                 remote.httpx.Client,
                 "post",
@@ -249,7 +249,7 @@ class TestPullViaPresign:
         from nauro.sync import remote
 
         with (
-            patch.object(remote.httpx.Client, "get", side_effect=fake_get),
+            patched_remote_get(fake_get),
             patch.object(remote.httpx.Client, "post", return_value=presign) as mock_post,
         ):
             from nauro.cli.commands.sync import _pull_from_cloud
@@ -300,7 +300,7 @@ class TestPullViaPresign:
         from nauro.sync import remote
 
         with (
-            patch.object(remote.httpx.Client, "get", side_effect=fake_get),
+            patched_remote_get(fake_get),
             patch.object(remote.httpx.Client, "post", return_value=presign),
         ):
             from nauro.cli.commands.sync import _pull_from_cloud
@@ -338,7 +338,7 @@ class TestPullViaPresign:
         from nauro.sync import remote
 
         with (
-            patch.object(remote.httpx.Client, "get", side_effect=fake_get) as mock_get,
+            patched_remote_get(fake_get) as mock_get,
             patch.object(remote.httpx.Client, "post", side_effect=fake_post) as mock_post,
         ):
             from nauro.cli.commands.sync import _pull_from_cloud
@@ -376,7 +376,7 @@ class TestPullViaPresign:
         from nauro.sync import remote
 
         with (
-            patch.object(remote.httpx.Client, "get", side_effect=fake_get),
+            patched_remote_get(fake_get),
             patch.object(remote.httpx.Client, "post", side_effect=fake_post) as mock_post,
         ):
             from nauro.cli.commands.sync import _pull_from_cloud
@@ -753,9 +753,11 @@ class TestPresignedGetFailures:
     def test_a_transport_fault_never_escapes_as_a_raw_httpx_error(self):
         from nauro.sync.remote import PresignError, TransferBoundaryError, fetch_via_presigned_url
 
-        with patch.object(httpx.Client, "get", side_effect=httpx.ConnectError("no route")):
-            with pytest.raises(TransferBoundaryError) as caught:
-                fetch_via_presigned_url("https://s3/a")
+        def handler(_request):
+            raise httpx.ConnectError("no route")
+
+        with pytest.raises(TransferBoundaryError) as caught:
+            fetch_via_presigned_url("https://s3/a", session=_mock_session(handler))
 
         # The pull core guards its transfers with `except PresignError`; a bare
         # ConnectError past that guard used to crash the whole sync.
@@ -767,9 +769,8 @@ class TestPresignedGetFailures:
         from nauro.sync.remote import TransferBoundaryError, fetch_via_presigned_url
 
         refusal = httpx.Response(403, content=b"<Error>\n  <Code>AccessDenied</Code>\n</Error>")
-        with patch.object(httpx.Client, "get", return_value=refusal):
-            with pytest.raises(TransferBoundaryError) as caught:
-                fetch_via_presigned_url("https://s3/a")
+        with pytest.raises(TransferBoundaryError) as caught:
+            fetch_via_presigned_url("https://s3/a", session=_mock_session(lambda _r: refusal))
 
         assert caught.value.status == 403
         assert caught.value.kind.value == "http-status"
@@ -782,6 +783,56 @@ class TestPresignedGetFailures:
 
         assert caught.value.status is None
         assert caught.value.transport is False
+
+
+def _mock_session(handler):
+    from nauro.sync.remote import TransferSession
+
+    return TransferSession(httpx.Client(transport=httpx.MockTransport(handler)))
+
+
+class TestPresignedGetSizeCap:
+    """One object past the cap is refused as a permanent fault, streamed or declared."""
+
+    def test_body_under_the_cap_is_returned_with_its_etag(self):
+        from nauro.sync.remote import fetch_via_presigned_url
+
+        response = httpx.Response(200, content=b"file body", headers={"ETag": '"abc"'})
+        fetched = fetch_via_presigned_url(
+            "https://s3/a", session=_mock_session(lambda _r: response)
+        )
+        assert fetched.body == b"file body"
+        assert fetched.etag == '"abc"'
+
+    def test_declared_length_over_the_cap_is_refused_before_reading(self, monkeypatch):
+        from nauro.sync import remote
+        from nauro.sync.transfer import TransferFault, classify_fault
+
+        monkeypatch.setattr(remote, "MAX_OBJECT_BYTES", 64)
+        reads: list[int] = []
+
+        def handler(_request):
+            reads.append(1)
+            return httpx.Response(
+                200, stream=httpx.ByteStream(b"x" * 65), headers={"Content-Length": "65"}
+            )
+
+        with pytest.raises(remote.ObjectTooLargeError) as caught:
+            remote.fetch_via_presigned_url("https://s3/a", session=_mock_session(handler))
+        assert classify_fault(caught.value) is TransferFault.PERMANENT
+        assert "exceeds 64 bytes" in str(caught.value)
+
+    def test_undeclared_stream_over_the_cap_is_refused_mid_read(self, monkeypatch):
+        from nauro.sync import remote
+
+        monkeypatch.setattr(remote, "MAX_OBJECT_BYTES", 64)
+        chunks = iter([b"a" * 40, b"b" * 40, b"c" * 40])
+
+        def handler(_request):
+            return httpx.Response(200, stream=httpx.ByteStream(b"".join(chunks)))
+
+        with pytest.raises(remote.ObjectTooLargeError):
+            remote.fetch_via_presigned_url("https://s3/a", session=_mock_session(handler))
 
 
 def _get_status_fault(status: int) -> TransferBoundaryError:

--- a/packages/nauro/tests/test_sync/test_transport_session.py
+++ b/packages/nauro/tests/test_sync/test_transport_session.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import ssl
 import traceback
+from contextlib import nullcontext
 from unittest.mock import MagicMock
 
 import httpx
@@ -19,7 +20,10 @@ def test_operation_session_reuses_and_closes_one_client(monkeypatch):
     from nauro.sync.remote import TransferSession, fetch_via_presigned_url
 
     client = MagicMock(spec=httpx.Client)
-    client.get.side_effect = [_response(content=b"one"), _response(content=b"two")]
+    client.stream.side_effect = [
+        nullcontext(_response(content=b"one")),
+        nullcontext(_response(content=b"two")),
+    ]
     monkeypatch.setattr(httpx, "Client", lambda **_kwargs: client)
 
     with TransferSession() as session:
@@ -28,7 +32,7 @@ def test_operation_session_reuses_and_closes_one_client(monkeypatch):
 
     assert first.body == b"one"
     assert second.body == b"two"
-    assert client.get.call_count == 2
+    assert client.stream.call_count == 2
     client.close.assert_called_once_with()
 
 
@@ -55,10 +59,8 @@ def test_one_session_reuses_the_client_across_api_and_object_calls(monkeypatch):
 
     seed_auth_config(variant="sync")
     client = MagicMock(spec=httpx.Client)
-    client.get.side_effect = [
-        httpx.Response(200, json={"files": [], "next_cursor": None}),
-        _response(content=b"body"),
-    ]
+    client.get.return_value = httpx.Response(200, json={"files": [], "next_cursor": None})
+    client.stream.return_value = nullcontext(_response(content=b"body"))
     client.post.return_value = httpx.Response(
         200,
         json={
@@ -81,7 +83,8 @@ def test_one_session_reuses_the_client_across_api_and_object_calls(monkeypatch):
         fetched = fetch_via_presigned_url(urls[0]["url"], session=session)
 
     assert fetched.body == b"body"
-    assert client.get.call_count == 2
+    assert client.get.call_count == 1
+    assert client.stream.call_count == 1
     assert client.post.call_count == 1
     client.close.assert_called_once_with()
 
@@ -127,7 +130,7 @@ def test_certificate_failure_trips_only_its_origin_and_sanitizes_error(monkeypat
     nested.__cause__ = certificate_error
 
     client = MagicMock(spec=httpx.Client)
-    client.get.side_effect = [nested, _response(content=b"other")]
+    client.stream.side_effect = [nested, nullcontext(_response(content=b"other"))]
     monkeypatch.setattr(httpx, "Client", lambda **_kwargs: client)
     first_url = "https://a.test/object?X-Amz-Signature=secret"
     second_url = "https://a.test/other?X-Amz-Signature=other"
@@ -146,7 +149,7 @@ def test_certificate_failure_trips_only_its_origin_and_sanitizes_error(monkeypat
     assert first.value.__context__ is None
     assert second.value.kind.value == "origin-aborted"
     assert fetched.body == b"other"
-    assert client.get.call_count == 2
+    assert client.stream.call_count == 2
     rendered = f"{first.value!r} {first.value} {second.value!r} {second.value}"
     rendered += "".join(
         traceback.format_exception(type(first.value), first.value, first.value.__traceback__)
@@ -169,10 +172,8 @@ def test_permanent_manifest_http_failure_blocks_same_origin_push_but_not_other_o
     store.mkdir()
     (store / "stack.md").write_bytes(b"local")
     client = MagicMock(spec=httpx.Client)
-    client.get.side_effect = [
-        httpx.Response(403),
-        _response(content=b"other"),
-    ]
+    client.get.return_value = httpx.Response(403)
+    client.stream.return_value = nullcontext(_response(content=b"other"))
     client.post.return_value = httpx.Response(
         200,
         json={
@@ -203,9 +204,9 @@ def test_object_404_does_not_trip_the_origin_for_another_object():
     from nauro.sync.remote import TransferBoundaryError, TransferSession, fetch_via_presigned_url
 
     client = MagicMock(spec=httpx.Client)
-    client.get.side_effect = [
-        httpx.Response(404),
-        _response(content=b"present"),
+    client.stream.side_effect = [
+        nullcontext(httpx.Response(404)),
+        nullcontext(_response(content=b"present")),
     ]
 
     with TransferSession(client=client) as session:
@@ -216,7 +217,7 @@ def test_object_404_does_not_trip_the_origin_for_another_object():
     assert caught.value.status == 404
     assert not caught.value.aborts_origin
     assert fetched.body == b"present"
-    assert client.get.call_count == 2
+    assert client.stream.call_count == 2
 
 
 @pytest.mark.parametrize(

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "ai.nauro/nauro",
   "title": "Nauro",
-  "description": "What every agent should know",
+  "description": "Decision system for software built with AI",
   "websiteUrl": "https://nauro.ai",
   "repository": {
     "url": "https://github.com/Nauro-AI/nauro",


### PR DESCRIPTION
## Why

Store files reach parsers with no size or shape guard, on hosted reads, the local prompt hook, and every sync pull. A collaborator's bytes, or a hostile object in a shared store, could pin a parser for its full timeout, crash a pull, or load a multi-gigabyte object into memory on every session start.

## What changed

- **Decision frontmatter** loads through an alias-free `SafeLoader`, so a YAML anchor/alias or merge-key bomb fails at the first alias instead of expanding at parse or dump time, and a block over 64 KiB is refused before any YAML work. The fast libyaml path is unaffected: its plain grammar never admits an alias. Quoted globs such as `'src/**/*.py'` still parse.
- **Question identifiers** cap at 18 significant digits on parse, format, and the entry model. An oversized `[Q...]` head degrades to a non-entry line, as any unparsable head already does, so one poisoned line no longer makes every read of `open-questions.md` quadratic.
- **Set-union merge** for append-only files decodes and re-encodes with `surrogateescape`, so a collaborator's non-UTF-8 bytes ride through the line union unchanged instead of crashing the pull.
- **Presigned GETs** stream into memory under a 16 MiB per-object cap, refusing early on a larger declared length. The refusal is a permanent transfer fault the pull reports and never retries, mirroring the generation transport.

Sync tests that faked the HTTP client's buffered `get` now serve the same URL-dispatching fake for streamed object reads through one shared helper in the sync conftest.

## Test plan

- New tests: alias bomb refused, quoted asterisks still parse, oversized frontmatter refused; 18-digit cap on parse/format and an oversized id line degrading in linear time; non-UTF-8 bytes surviving the union; body under cap returned with ETag, declared length over cap refused before reading, undeclared stream over cap refused mid-read.
- `packages/nauro-core/tests`: 1925 passed.
- `packages/nauro/tests`: 4965 passed; the 12 failures are pre-existing read-only-directory tests that fail identically on `main` when run as root.
- `ruff check`, `ruff format --check`, `check_ruff_budget.py`, and `check_docstring_budget.py` pass.

## Risk / what to review

The question-id width cap tightens the identifier grammar: `parse_question_id` and `format_question_id` now reject ids beyond 18 significant digits, and `QuestionEntry.num` carries the matching upper bound. Sequential allocation never approaches it, but it is a grammar change worth a deliberate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnF3K3WpeaMt6M44UbGwEy

---
_Generated by [Claude Code](https://claude.ai/code/session_01WnF3K3WpeaMt6M44UbGwEy)_