### PR TITLE
Add explicit initial generation attachment

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/attach.py
+++ b/packages/nauro/src/nauro/cli/commands/attach.py
@@ -86,6 +86,9 @@ def _refuse_attach_collision(repo_path: Path, project_id: str) -> None:
 def attach(
     project_id: str = typer.Argument(..., help="Cloud project_id (ULID)."),
     repo_path: Path | None = _Opt_repo_path,
+    generation: bool = typer.Option(
+        False, "--generation", help="Install an initial generation replica."
+    ),
 ) -> None:
     """Attach the current repo to an existing cloud project."""
     repo_path = repo_path if repo_path is not None else Path.cwd()
@@ -97,6 +100,25 @@ def attach(
     refuse_global_config_collision(repo_path)
     refuse_repo_config_symlink(repo_path)
     _refuse_attach_collision(repo_path, project_id)
+    if generation is True:
+        from filelock import Timeout
+
+        from nauro.auth import PartialAuthConfigError
+        from nauro.store.generation_authority import GenerationAuthorityError
+        from nauro.sync.generation_attachment import attach_generation
+        from nauro.sync.reference_auth import AUTH_ERRORS
+
+        try:
+            binding = attach_generation(
+                project_id,
+                repo_path,
+                lambda url: typer.echo(f"Sign in to attach this generation project:\n{url}"),
+            )
+        except (*AUTH_ERRORS, GenerationAuthorityError, PartialAuthConfigError, Timeout) as exc:
+            typer.echo(f"Attachment incomplete: {exc}", err=True)
+            raise typer.Exit(code=1) from exc
+        typer.echo(f"Attached generation project '{binding.display_name}' to {repo_path.resolve()}")
+        return
     try:
         name = require_cloud_membership(project_id)
         entry = get_project_entry_v2(project_id)

--- a/packages/nauro/src/nauro/store/generation_installation.py
+++ b/packages/nauro/src/nauro/store/generation_installation.py
@@ -9,10 +9,15 @@ import secrets
 import shutil
 import stat
 import time
+from collections.abc import Callable
 from contextlib import suppress
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from nauro.sync.generation_session import GenerationTransferSession
 
 from nauro.auth import ActiveUserReadError, read_active_user_id
 from nauro.store._atomic import atomic_write_bytes, is_tmp_sibling
@@ -971,6 +976,7 @@ def _write_carrier(
     active_actor: str,
     prior: bytes | None,
     intended: bytes,
+    require_actor: Callable[[], str],
 ) -> InstalledAuthorizationView:
     _reprove_publication_paths(installed, store_path, layout, lock_path)
     if _read_control_file(store_path, carrier_path) != prior:
@@ -978,7 +984,7 @@ def _write_carrier(
     if _read_control_file(store_path, marker_path) is not None:
         raise _publication_failure()
     _require_published_carrier(installed.target, active_actor, intended, intended)
-    _require_active_actor(active_actor)
+    require_actor()
     failure: Exception | None = None
     try:
         atomic_write_bytes(carrier_path, intended)
@@ -989,7 +995,7 @@ def _write_carrier(
         raise _publication_failure() from None
     carrier = _require_published_carrier(installed.target, active_actor, observed, intended)
     if failure is not None:
-        _require_active_actor(active_actor)
+        require_actor()
     return carrier
 
 
@@ -1005,6 +1011,7 @@ def _write_pointer(
     carrier_bytes: bytes,
     prior: bytes | None,
     intended: bytes,
+    require_actor: Callable[[], str],
 ) -> InstalledGenerationPointer:
     _reprove_publication_paths(installed, store_path, layout, lock_path)
     observed_carrier = _read_control_file(store_path, carrier_path)
@@ -1019,7 +1026,7 @@ def _write_pointer(
         raise _publication_failure()
     intended_pointer = _parse_exact_pointer(intended)
     _require_published_pair(installed.target, active_actor, carrier, intended_pointer)
-    _require_active_actor(active_actor)
+    require_actor()
     failure: Exception | None = None
     try:
         atomic_write_bytes(pointer_path, intended)
@@ -1035,15 +1042,15 @@ def _write_pointer(
     pointer = _parse_exact_pointer(observed_pointer)
     _require_published_pair(installed.target, active_actor, carrier, pointer)
     if failure is not None:
-        _require_active_actor(active_actor)
+        require_actor()
     return pointer
 
 
 def _publish_generation_control(
-    installed: InstalledGenerationRoot, timeout: float
+    installed: InstalledGenerationRoot, timeout: float, require_actor: Callable[[], str]
 ) -> GenerationProjectAuthority:
     rebuilt = _rebuild_installed_root(installed)
-    active_actor = _require_active_actor(rebuilt.target.identity.installed_for_user_id)
+    active_actor = require_actor()
     initial, store_path, layout = _derive_publication(installed)
     if initial != rebuilt:
         raise _publication_failure()
@@ -1118,6 +1125,7 @@ def _publish_generation_control(
                     active_actor,
                     carrier_json,
                     intended_carrier,
+                    require_actor,
                 )
                 carrier_json = intended_carrier
                 pointer = None
@@ -1148,6 +1156,7 @@ def _publish_generation_control(
                     carrier_json,
                     pointer_json,
                     pointer_bytes,
+                    require_actor,
                 )
             else:
                 pointer_bytes = pointer.canonical_bytes()
@@ -1166,7 +1175,7 @@ def _publish_generation_control(
             _audit_installed_root(store_path, layout, locked)
             if _read_control_file(store_path, marker_path) is not None:
                 raise _publication_failure()
-            _require_active_actor(active_actor)
+            require_actor()
             try:
                 atomic_write_bytes(marker_path, marker_bytes)
             except Exception:
@@ -1184,15 +1193,34 @@ def _publish_generation_control(
             if final_carrier != carrier_json or final_pointer != pointer_bytes:
                 raise _publication_failure() from None
             _audit_installed_root(store_path, layout, locked)
-    _require_active_actor(active_actor)
+    require_actor()
     return verified
 
 
 def publish_generation_control(
-    installed: InstalledGenerationRoot, *, timeout: float = -1
+    installed: InstalledGenerationRoot,
+    *,
+    timeout: float = -1,
+    session: GenerationTransferSession | None = None,
 ) -> GenerationProjectAuthority:
+    def require_actor() -> str:
+        actor = installed.target.identity.installed_for_user_id
+        if session is None:
+            return _require_active_actor(actor)
+        from nauro.sync.generation_acquisition import check_generation_projection
+
+        session.require_binding(installed.target.binding)
+        session.require_actor(actor)
+        current = check_generation_projection(
+            installed.target.binding, active_user_id=actor, session=session
+        )
+        session.require_actor(actor)
+        if current != installed.target:
+            raise RefreshRequiredError("The authorized generation changed during installation.")
+        return actor
+
     try:
-        return _publish_generation_control(installed, timeout)
+        return _publish_generation_control(installed, timeout, require_actor)
     except GenerationAuthorityError as exc:
         raise type(exc)(str(exc)) from None
 

--- a/packages/nauro/src/nauro/sync/generation_attachment.py
+++ b/packages/nauro/src/nauro/sync/generation_attachment.py
@@ -1,0 +1,187 @@
+"""Explicit initial attachment through generation authority and credentials."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+import httpx
+from filelock import FileLock
+from nauro_core.identifiers import IdentifierKind, validate_identifier
+
+from nauro.auth import DEFAULT_AUTH_REDIRECT_URI, ActiveCredentials
+from nauro.store.generation_authority import RefreshRequiredError
+from nauro.store.generation_installation import install_generation_root, publish_generation_control
+from nauro.store.home import ensure_nauro_home, nauro_home
+from nauro.store.registry import bind_project_store_v2, get_project_entry_v2, get_store_path_v2
+from nauro.store.replica_control import _validate_managed_path
+from nauro.store.repo_config import load_repo_config, repo_config_path, save_repo_config
+from nauro.store.resolution import ResolvedProjectBinding
+from nauro.sync.generation_acquisition import acquire_generation_projection
+from nauro.sync.generation_connection import attachment_connection
+from nauro.sync.generation_credentials import (
+    GenerationAuth,
+    GenerationConnection,
+    generation_credentials,
+)
+from nauro.sync.generation_refresh import (
+    commit_generation_refresh,
+    prepare_initial_generation_refresh,
+)
+from nauro.sync.generation_session import GenerationConnectionError, GenerationTransferSession
+from nauro.sync.reference_oauth import response_json
+from nauro.sync.remote import TransferSession
+
+
+class InitialAttachmentSession(GenerationTransferSession):
+    def __init__(
+        self,
+        binding: ResolvedProjectBinding,
+        repo: Path,
+        connection: GenerationConnection,
+        client: httpx.Client,
+    ) -> None:
+        self.binding, self.connection, self.repo = binding, connection, repo
+        self.entry = get_project_entry_v2(binding.project_id)
+        self.repo_config = self._repo_config()
+        if self.repo_config is not None:
+            config = load_repo_config(repo)
+            if (
+                config.get("id") != binding.project_id
+                or config.get("server_url") != binding.server_url
+            ):
+                raise GenerationConnectionError("Repository association conflicts with attachment.")
+        store = connection.store()
+        with store.locked():
+            record = store.read()
+            if record is None:
+                raise GenerationConnectionError("Generation login required.")
+            self.actor = record.user_id
+            self.revision = record.revision
+        self.credentials()
+        TransferSession.__init__(self, client)
+
+    def _repo_config(self) -> bytes | None:
+        path = repo_config_path(self.repo)
+        _validate_managed_path(self.repo, path)
+        return path.read_bytes() if path.exists() else None
+
+    def require_binding(self, binding: ResolvedProjectBinding) -> None:
+        super().require_binding(binding)
+        response = response_json(
+            self.client,
+            "GET",
+            self.api_url + "/projects?project_id=" + binding.project_id,
+            headers={"Authorization": "Bearer " + self.credentials().access_token},
+        )
+        self.credentials()
+        projects = response.get("projects")
+        if (
+            response.get("authority") != "generation_owner"
+            or not isinstance(projects, list)
+            or not any(
+                isinstance(item, dict)
+                and item.get("project_id") == binding.project_id
+                and item.get("role") == "owner"
+                for item in projects
+            )
+        ):
+            raise GenerationConnectionError("Initial attachment requires current owner access.")
+
+    def credentials(self) -> ActiveCredentials:
+        if (
+            attachment_connection(DEFAULT_AUTH_REDIRECT_URI) != self.connection
+            or get_project_entry_v2(self.binding.project_id) != self.entry
+            or self._repo_config() != self.repo_config
+        ):
+            raise GenerationConnectionError("The attachment connection changed.")
+        try:
+            credentials = generation_credentials(self.connection, self.actor)
+            store = self.connection.store()
+            with store.locked():
+                record = store.read()
+                if record is None or record.revision != self.revision:
+                    raise ValueError("The captured credentials changed")
+            return credentials
+        except (ValueError, OSError) as exc:
+            raise GenerationConnectionError("Generation login or renewal required.") from exc
+
+
+def _empty_destination(path: Path) -> None:
+    _validate_managed_path(nauro_home(), path)
+    if path.exists() and (not path.is_dir() or any(path.iterdir())):
+        raise RefreshRequiredError(
+            "Initial attachment requires an empty destination. Existing stores and interrupted "
+            "replica evidence are preserved. Use explicit sync for an installed replica; "
+            "incomplete attachment requires recovery before another attach."
+        )
+
+
+def attach_generation(
+    project: str, repo: Path, present_url: Callable[[str], None]
+) -> ResolvedProjectBinding:
+    validate_identifier(IdentifierKind.ulid, project, field="project")
+    _validate_managed_path(repo, repo_config_path(repo))
+    ensure_nauro_home()
+    lock = nauro_home() / f"generation-attachment-{project}.lock"
+    _validate_managed_path(nauro_home(), lock)
+    with FileLock(lock, timeout=0):
+        return _attach(project, repo, present_url)
+
+
+def _attach(project: str, repo: Path, present_url: Callable[[str], None]) -> ResolvedProjectBinding:
+    connection = attachment_connection(DEFAULT_AUTH_REDIRECT_URI)
+    endpoint = connection.endpoint.removesuffix("/mcp")
+    path = get_store_path_v2(project)
+    entry = get_project_entry_v2(project)
+    if entry and (entry.mode != "cloud" or entry.server_url != endpoint or entry.has_store_path):
+        raise GenerationConnectionError("The registered project conflicts with initial attachment.")
+    _empty_destination(path)
+    binding = ResolvedProjectBinding(
+        path, project, entry.name if entry else project, "cloud", endpoint
+    )
+    config_path = repo_config_path(repo)
+    prior_config = config_path.read_bytes() if config_path.exists() else None
+    with httpx.Client(trust_env=False) as client:
+        auth = GenerationAuth(connection, project, client)
+        if auth.status() != "active":
+            auth.login(present_url)
+        if (
+            get_project_entry_v2(project) != entry
+            or (config_path.read_bytes() if config_path.exists() else None) != prior_config
+        ):
+            raise GenerationConnectionError("The project association changed during login.")
+        with InitialAttachmentSession(binding, repo, connection, client) as session:
+            projection = acquire_generation_projection(
+                binding, active_user_id=session.actor, session=session
+            )
+            session.require_binding(binding)
+            _empty_destination(path)
+            path.mkdir(parents=True, exist_ok=True)
+            installed = install_generation_root(projection, timeout=0)
+            publish_generation_control(installed, timeout=0, session=session)
+            prepared = prepare_initial_generation_refresh(
+                binding, actor=session.actor, session=session
+            )
+            if prepared.projection.target != projection.target:
+                raise RefreshRequiredError("The generation changed during initial attachment.")
+            commit_generation_refresh(prepared, session=session)
+            session.require_binding(binding)
+            bind_project_store_v2(
+                project_id=project,
+                name=binding.display_name,
+                mode="cloud",
+                repo_path=repo,
+                store_path=path,
+                server_url=endpoint,
+            )
+            save_repo_config(
+                repo,
+                {
+                    "mode": "cloud",
+                    "id": project,
+                    "name": binding.display_name,
+                    "server_url": endpoint,
+                },
+            )
+    return binding

--- a/packages/nauro/src/nauro/sync/generation_connection.py
+++ b/packages/nauro/src/nauro/sync/generation_connection.py
@@ -49,9 +49,16 @@ def selected_connection(
 def connection_for(binding: ResolvedProjectBinding, redirect_uri: str) -> GenerationConnection:
     if observe_generation_marker(binding) is None:
         raise ValueError("Generation authority required")
-    domain, client, api, audience = resolve_auth_config(os.environ, load_config())
-    if binding.server_url is None or _origin(binding.server_url) != _origin(api):
+    connection = attachment_connection(redirect_uri)
+    if binding.server_url is None or _origin(
+        binding.server_url
+    ) != connection.endpoint.removesuffix("/mcp"):
         raise ValueError("Project and trusted authentication endpoints differ")
+    return connection
+
+
+def attachment_connection(redirect_uri: str) -> GenerationConnection:
+    domain, client, api, audience = resolve_auth_config(os.environ, load_config())
     return GenerationConnection(
         endpoint=_origin(api) + "/mcp",
         issuer=f"https://{domain}/",

--- a/packages/nauro/tests/snapshots/public_contract_v1.json
+++ b/packages/nauro/tests/snapshots/public_contract_v1.json
@@ -130,6 +130,17 @@
         "name": "attach",
         "params": [
           {
+            "default": false,
+            "flags": [
+              "--generation"
+            ],
+            "is_flag": true,
+            "kind": "option",
+            "name": "generation",
+            "required": false,
+            "type": "boolean"
+          },
+          {
             "kind": "argument",
             "name": "project_id",
             "required": true,

--- a/packages/nauro/tests/test_generation_attachment.py
+++ b/packages/nauro/tests/test_generation_attachment.py
@@ -1,0 +1,353 @@
+from __future__ import annotations
+
+import base64
+import json
+import socket
+import time
+
+import httpx
+import pytest
+from typer.testing import CliRunner
+
+from nauro.auth import DEFAULT_AUTH_REDIRECT_URI
+from nauro.cli.main import app
+from nauro.mcp import stdio_server
+from nauro.store import generation_installation as installation
+from nauro.store.config import load_config, save_config
+from nauro.store.registry import get_project_entry_v2, get_store_path_v2
+from nauro.store.repo_config import repo_config_path
+from nauro.store.resolution import resolve_project_binding
+from nauro.sync import generation_attachment as attachment
+from nauro.sync.generation_connection import attachment_connection, connection_for
+from nauro.sync.generation_credentials import AccountRecord
+from nauro.sync.generation_refresh import admit_generation_store
+from nauro.sync.generation_session import GenerationTransferSession
+from tests.test_generation_installation import PROJECT_ID, USER_ID, _projection
+
+
+@pytest.fixture
+def hosted(tmp_path, monkeypatch):
+    monkeypatch.setattr(socket.socket, "connect", lambda *a: pytest.fail("External network"))
+    for key in (
+        "NAURO_AUTH0_DOMAIN",
+        "NAURO_AUTH0_CLIENT_ID",
+        "NAURO_API_URL",
+        "NAURO_AUTH0_AUDIENCE",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    save_config(
+        {
+            "auth0_domain": "issuer.example",
+            "auth0_client_id": "client",
+            "api_url": "https://mcp.nauro.ai",
+            "auth0_audience": "https://mcp.nauro.ai/mcp",
+            "auth": {"user_id": "01K44444444444444444444444", "access_token": "wrong-account"},
+        }
+    )
+    connection = attachment_connection(DEFAULT_AUTH_REDIRECT_URI)
+    credentials = connection.store()
+    with credentials.locked():
+        credentials.write(
+            AccountRecord(
+                revision="a" * 64,
+                binding=connection.binding(),
+                state="active",
+                user_id=USER_ID,
+                subject="owner",
+                access_token="generation-token",
+                refresh_token="refresh",
+                expires_at=int(time.time()) + 600,
+            )
+        )
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.chdir(repo)
+    projection = _projection({"state.md": b"Committed generation state\n"})
+    calls = []
+    control = {"status": 200, "role": "owner", "after_download": lambda: None}
+
+    def wire(request):
+        calls.append(request)
+        if request.url.host == "objects.example":
+            control["after_download"]()
+            return httpx.Response(200, content=b"Committed generation state\n")
+        assert request.headers["Authorization"] == "Bearer generation-token"
+        if request.url.path == "/projects":
+            return httpx.Response(
+                200,
+                json={
+                    "authority": "generation_owner",
+                    "projects": [
+                        {
+                            "project_id": PROJECT_ID,
+                            "name": "Synthetic",
+                            "role": control["role"],
+                        }
+                    ],
+                },
+            )
+        if request.url.path == "/generations/projection":
+            return httpx.Response(
+                control["status"],
+                json={
+                    "projection": projection.target.identity.model_dump(),
+                    "manifest_base64": base64.b64encode(projection.manifest_json).decode(),
+                },
+            )
+        assert request.url.path == "/generations/presign"
+        return httpx.Response(
+            200,
+            json={
+                "projection": projection.target.identity.model_dump(),
+                "urls": [{"path": "state.md", "url": "https://objects.example/state"}],
+                "expires_at": "2999-12-31T23:59:59Z",
+            },
+        )
+
+    client_type = httpx.Client
+    monkeypatch.setattr(
+        attachment.httpx,
+        "Client",
+        lambda **kw: client_type(transport=httpx.MockTransport(wire), **kw),
+    )
+    monkeypatch.setattr(installation, "read_active_user_id", lambda: pytest.fail("Legacy account"))
+    return repo, connection, credentials, control, calls
+
+
+def _run(repo):
+    return CliRunner().invoke(app, ["attach", PROJECT_ID, "--generation", "--repo", str(repo)])
+
+
+def test_initial_attach_and_ordinary_generation_admission(hosted):
+    repo, connection, _, _, calls = hosted
+    config_before = load_config()
+    result = _run(repo)
+    assert result.exit_code == 0, result.output
+    assert load_config() == config_before
+    binding = resolve_project_binding(PROJECT_ID, None, use_cwd=False)
+    assert connection_for(binding, DEFAULT_AUTH_REDIRECT_URI) == connection
+    with GenerationTransferSession(binding) as session:
+        store = admit_generation_store(binding, actor=USER_ID, session=session)
+        assert store.read_file("state.md") == "Committed generation state\n"
+    read = CliRunner().invoke(app, ["get-raw-file", "state.md", "--project", PROJECT_ID])
+    assert read.exit_code == 0, read.output
+    assert (
+        json.loads(read.stdout)["read_authority"]["generation_id"] == "01K11111111111111111111111"
+    )
+    response = stdio_server.get_raw_file("state.md", project_id=PROJECT_ID)
+    assert response.isError is False
+    assert "Committed generation state" in response.content[0].text
+    assert json.loads(repo_config_path(repo).read_text())["id"] == PROJECT_ID
+    assert {r.url.path for r in calls} == {
+        "/projects",
+        "/generations/projection",
+        "/generations/presign",
+        "/state",
+    }
+    before = {p: p.read_bytes() for p in binding.store_path.rglob("*") if p.is_file()}
+    again = _run(repo)
+    assert again.exit_code == 1
+    assert "Existing stores and interrupted replica evidence are preserved" in again.output
+    assert {p: p.read_bytes() for p in binding.store_path.rglob("*") if p.is_file()} == before
+
+
+@pytest.mark.parametrize("entry", ["legacy.md", ".replica/authority.json"])
+def test_existing_evidence_refuses_before_network(hosted, entry):
+    repo, _, _, _, calls = hosted
+    evidence = get_store_path_v2(PROJECT_ID) / entry
+    evidence.parent.mkdir(parents=True)
+    evidence.write_bytes(b"retained evidence")
+    result = _run(repo)
+    assert result.exit_code == 1
+    assert calls == []
+    assert evidence.read_bytes() == b"retained evidence"
+    assert not repo_config_path(repo).exists()
+
+
+@pytest.mark.parametrize("change", ["expired", "logout", "actor", "endpoint", "revoked"])
+def test_credentials_and_authority_rechecked_after_download(hosted, change):
+    repo, _, credentials, control, _ = hosted
+
+    def alter():
+        if change == "endpoint":
+            save_config({"api_url": "https://other.example"})
+        elif change == "revoked":
+            control["role"] = "viewer"
+        else:
+            with credentials.locked():
+                record = credentials.read()
+                if change == "logout":
+                    credentials.write(credentials.empty("logged_out"))
+                else:
+                    delta = (
+                        {"expires_at": 1}
+                        if change == "expired"
+                        else {"user_id": "01K44444444444444444444444"}
+                    )
+                    credentials.write(record.model_copy(update=delta))
+
+    control["after_download"] = alter
+    result = _run(repo)
+    assert result.exit_code == 1
+    assert not (get_store_path_v2(PROJECT_ID) / ".replica/authority.json").exists()
+    assert get_project_entry_v2(PROJECT_ID) is None
+    assert not repo_config_path(repo).exists()
+
+
+@pytest.mark.parametrize("status", [401, 403, 409])
+def test_host_refusal_does_not_install(hosted, status):
+    repo, _, _, control, _ = hosted
+    control["status"] = status
+    result = _run(repo)
+    assert result.exit_code == 1
+    assert not get_store_path_v2(PROJECT_ID).exists()
+    assert not repo_config_path(repo).exists()
+
+
+@pytest.mark.parametrize("boundary", ["carrier", "pointer", "marker", "barrier"])
+def test_interrupted_initial_attachment_retains_evidence_and_refuses_repeat(
+    hosted, monkeypatch, boundary
+):
+    repo, _, _, _, _ = hosted
+    original = installation.atomic_write_bytes
+    names = {
+        "carrier": "authorization-view.json",
+        "pointer": "pointer.json",
+        "marker": "authority.json",
+    }
+
+    def write(path, raw):
+        original(path, raw)
+        if path.name == names.get(boundary):
+            raise KeyboardInterrupt()
+
+    monkeypatch.setattr(installation, "atomic_write_bytes", write)
+    if boundary == "barrier":
+        from nauro.sync import generation_refresh
+
+        monkeypatch.setattr(
+            generation_refresh, "sync_file", lambda *a: (_ for _ in ()).throw(OSError("barrier"))
+        )
+    result = _run(repo)
+    assert result.exit_code == (1 if boundary == "barrier" else 130), result.output
+    root = get_store_path_v2(PROJECT_ID)
+    before = {p: p.read_bytes() for p in root.rglob("*") if p.is_file()}
+    assert before
+    assert not repo_config_path(repo).exists()
+    again = _run(repo)
+    assert again.exit_code == 1
+    assert {p: p.read_bytes() for p in root.rglob("*") if p.is_file()} == before
+
+
+@pytest.mark.parametrize("point", ["carrier", "pointer"])
+def test_owner_revocation_during_control_publication_stops_marker(hosted, monkeypatch, point):
+    repo, _, _, control, _ = hosted
+    original = installation.atomic_write_bytes
+
+    def write(path, raw):
+        original(path, raw)
+        if path.name == {"carrier": "authorization-view.json", "pointer": "pointer.json"}[point]:
+            control["role"] = "viewer"
+
+    monkeypatch.setattr(installation, "atomic_write_bytes", write)
+    result = _run(repo)
+    assert result.exit_code == 1
+    assert not (get_store_path_v2(PROJECT_ID) / ".replica/authority.json").exists()
+    assert not repo_config_path(repo).exists()
+
+
+def test_reauthentication_before_marker_uses_generation_login(hosted, monkeypatch):
+    repo, connection, credentials, _, _ = hosted
+    with credentials.locked():
+        record = credentials.read()
+        credentials.write(credentials.empty("logged_out"))
+    logins = []
+
+    def login(auth, present_url):
+        assert auth.connection == connection
+        assert not get_store_path_v2(PROJECT_ID).exists()
+        logins.append(auth.project)
+        present_url("https://issuer.example/authorize")
+        with credentials.locked():
+            credentials.write(record)
+
+    monkeypatch.setattr(attachment.GenerationAuth, "login", login)
+    result = _run(repo)
+    assert result.exit_code == 0, result.output
+    assert logins == [PROJECT_ID]
+
+
+def test_generation_change_before_marker_refuses(hosted, monkeypatch):
+    from nauro.sync import generation_acquisition
+
+    repo, _, _, _, _ = hosted
+    original = generation_acquisition.check_generation_projection
+
+    def changed(*args, **kwargs):
+        target = original(*args, **kwargs)
+        from nauro.store.generation_projection import GenerationProjectionTarget
+
+        return GenerationProjectionTarget(
+            target.binding,
+            target.identity.model_copy(
+                update={
+                    "generation_id": "01K66666666666666666666666",
+                }
+            ),
+        )
+
+    monkeypatch.setattr(generation_acquisition, "check_generation_projection", changed)
+    result = _run(repo)
+    assert result.exit_code == 1
+    assert not (get_store_path_v2(PROJECT_ID) / ".replica/authority.json").exists()
+    assert not repo_config_path(repo).exists()
+
+
+@pytest.mark.parametrize("change", ["scope", "revision"])
+def test_same_actor_context_change_stops_completion(hosted, monkeypatch, change):
+    from nauro.store.generation_projection import GenerationProjectionTarget
+    from nauro.sync import generation_acquisition
+
+    repo, _, credentials, control, _ = hosted
+    if change == "revision":
+
+        def renewed():
+            with credentials.locked():
+                credentials.write(credentials.read().model_copy(update={"revision": "b" * 64}))
+
+        control["after_download"] = renewed
+    else:
+        original = generation_acquisition.check_generation_projection
+
+        def changed(*args, **kwargs):
+            target = original(*args, **kwargs)
+            return GenerationProjectionTarget(
+                target.binding,
+                target.identity.model_copy(
+                    update={
+                        "projection_scope_id": "b" * 64,
+                    }
+                ),
+            )
+
+        monkeypatch.setattr(generation_acquisition, "check_generation_projection", changed)
+    result = _run(repo)
+    assert result.exit_code == 1
+    assert not (get_store_path_v2(PROJECT_ID) / ".replica/authority.json").exists()
+    assert not repo_config_path(repo).exists()
+
+
+def test_old_listing_is_not_owner_authorization(hosted, monkeypatch):
+    repo, _, _, _, _ = hosted
+    original = attachment.response_json
+
+    def legacy(*args, **kwargs):
+        response = original(*args, **kwargs)
+        response.pop("authority", None)
+        return response
+
+    monkeypatch.setattr(attachment, "response_json", legacy)
+    result = _run(repo)
+    assert result.exit_code == 1
+    assert not get_store_path_v2(PROJECT_ID).exists()
+    assert not repo_config_path(repo).exists()

--- a/packages/nauro/tests/test_generation_installation.py
+++ b/packages/nauro/tests/test_generation_installation.py
@@ -1003,15 +1003,19 @@ def test_installed_root_coexists_with_legacy_surfaces(tmp_path: Path) -> None:
         assert snapshot.authority == authority
 
 
-def test_installer_is_dormant_and_private(store: Path, monkeypatch) -> None:
+def test_installer_has_only_explicit_attachment_consumer(store: Path, monkeypatch) -> None:
     assert list(signature(install_generation_root).parameters) == ["projection", "timeout"]
     assert [item.name for item in fields(InstalledGenerationRoot)] == (
         "target root_key root_path audit reused".split()
     )
-    assert list(signature(publish_generation_control).parameters) == ["installed", "timeout"]
+    assert list(signature(publish_generation_control).parameters) == [
+        "installed",
+        "timeout",
+        "session",
+    ]
     assert "locked_replica_control_snapshot" not in Path(installation.__file__).read_text()
     for path in Path(installation.__file__).parents[2].rglob("*.py"):
-        if path != Path(installation.__file__):
+        if path != Path(installation.__file__) and path.name != "generation_attachment.py":
             assert "publish_generation_control(" not in path.read_text(encoding="utf-8")
     monkeypatch.setattr("nauro.sync.state.save_state", lambda *_a, **_k: pytest.fail("state"))
     installed = install_generation_root(_projection())

--- a/packages/nauro/tests/test_generation_refresh.py
+++ b/packages/nauro/tests/test_generation_refresh.py
@@ -516,4 +516,5 @@ def test_refresh_executor_has_only_named_runtime_consumers():
         "cli/generation_reads.py",
         "mcp/generation_reads.py",
         "mcp/generation_responses.py",
+        "sync/generation_attachment.py",
     ]


### PR DESCRIPTION
## Why

A second machine has no command that installs its first generation replica. Credential selection normally requires the marker that installation has not yet created.

## What changed

Add explicit `nauro attach PROJECT --generation`. It captures generation credentials, requires current owner authorization from a project-specific server response, verifies downloaded bytes and completes existing installation and refresh barriers before binding the repository. Legacy attach remains unchanged.

## Test plan

All 17 CI checks passed. The full local client suite passed 5,000 tests with 110 skips. All 21 environment-gated cross-repository cases passed when rerun with the server selected. The new cross-repository attachment check also passed without a skip. CI typing, formatting, lint and repository guards passed.

## Risk / what to review

Review credential changes and interruption boundaries during control publication. Older servers cannot satisfy the explicit owner-authority acknowledgement. Nonempty stores and interrupted attachment evidence refuse intact; initial-attachment reconciliation and startup refresh remain deferred. Concurrent-writing delivery remains incomplete, and production activation is unchanged.
