### PR TITLE
Recover recorded initial generation attachments

### DIFF
--- a/packages/nauro/src/nauro/sync/generation_attachment.py
+++ b/packages/nauro/src/nauro/sync/generation_attachment.py
@@ -18,6 +18,12 @@ from nauro.store.replica_control import _validate_managed_path
 from nauro.store.repo_config import load_repo_config, repo_config_path, save_repo_config
 from nauro.store.resolution import ResolvedProjectBinding
 from nauro.sync.generation_acquisition import acquire_generation_projection
+from nauro.sync.generation_attachment_record import (
+    AttachmentRecord,
+    read_record,
+    save_record,
+    validate_retained_projection,
+)
 from nauro.sync.generation_connection import attachment_connection
 from nauro.sync.generation_credentials import (
     GenerationAuth,
@@ -26,6 +32,7 @@ from nauro.sync.generation_credentials import (
 )
 from nauro.sync.generation_refresh import (
     commit_generation_refresh,
+    prepare_generation_refresh,
     prepare_initial_generation_refresh,
 )
 from nauro.sync.generation_session import GenerationConnectionError, GenerationTransferSession
@@ -136,7 +143,11 @@ def _attach(project: str, repo: Path, present_url: Callable[[str], None]) -> Res
     entry = get_project_entry_v2(project)
     if entry and (entry.mode != "cloud" or entry.server_url != endpoint or entry.has_store_path):
         raise GenerationConnectionError("The registered project conflicts with initial attachment.")
-    _empty_destination(path)
+    retained = read_record(project)
+    if retained is None:
+        _empty_destination(path)
+    else:
+        retained.require_binding(repo, path, connection)
     binding = ResolvedProjectBinding(
         path, project, entry.name if entry else project, "cloud", endpoint
     )
@@ -152,17 +163,35 @@ def _attach(project: str, repo: Path, present_url: Callable[[str], None]) -> Res
         ):
             raise GenerationConnectionError("The project association changed during login.")
         with InitialAttachmentSession(binding, repo, connection, client) as session:
+            if retained is not None and retained.projection.installed_for_user_id != session.actor:
+                raise GenerationConnectionError("Retained attachment belongs to another actor.")
             projection = acquire_generation_projection(
                 binding, active_user_id=session.actor, session=session
             )
             session.require_binding(binding)
-            _empty_destination(path)
-            path.mkdir(parents=True, exist_ok=True)
-            installed = install_generation_root(projection, timeout=0)
-            publish_generation_control(installed, timeout=0, session=session)
-            prepared = prepare_initial_generation_refresh(
-                binding, actor=session.actor, session=session
+            record = AttachmentRecord(
+                repo=str(repo.resolve()),
+                store=str(path),
+                connection=connection.binding(),
+                projection=projection.target.identity,
             )
+            if read_record(project) != retained or (retained is not None and retained != record):
+                raise RefreshRequiredError(
+                    "The saved attachment projection changed; evidence retained."
+                )
+            if retained is None:
+                _empty_destination(path)
+            has_refresh = validate_retained_projection(projection)
+            save_record(record)
+            path.mkdir(parents=True, exist_ok=True)
+            if has_refresh:
+                prepared = prepare_generation_refresh(binding, actor=session.actor, session=session)
+            else:
+                installed = install_generation_root(projection, timeout=0)
+                publish_generation_control(installed, timeout=0, session=session)
+                prepared = prepare_initial_generation_refresh(
+                    binding, actor=session.actor, session=session
+                )
             if prepared.projection.target != projection.target:
                 raise RefreshRequiredError("The generation changed during initial attachment.")
             commit_generation_refresh(prepared, session=session)

--- a/packages/nauro/src/nauro/sync/generation_attachment_record.py
+++ b/packages/nauro/src/nauro/sync/generation_attachment_record.py
@@ -1,0 +1,132 @@
+"""Retained identity for one explicit initial attachment."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict
+
+from nauro.store.generation_authority import (
+    RefreshRequiredError,
+    _parse_authorization_view,
+    _parse_pointer,
+)
+from nauro.store.generation_installation import _layout, _validate_carrier, _validate_control_pair
+from nauro.store.generation_projection import (
+    GenerationProjectionIdentity,
+    VerifiedGenerationProjection,
+)
+from nauro.store.generation_refresh_intent import decode_intent
+from nauro.store.generation_refresh_io import (
+    RefreshPaths,
+    durable_replace,
+    read_evidence,
+    refresh_paths,
+    sync_file,
+    sync_parents,
+)
+from nauro.store.home import nauro_home
+from nauro.store.replica_control import _validate_managed_path
+from nauro.sync.generation_credentials import GenerationConnection
+
+
+class AttachmentRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
+
+    version: Literal[1] = 1
+    repo: str
+    store: str
+    connection: str
+    projection: GenerationProjectionIdentity
+
+    def require_binding(self, repo: Path, store: Path, connection: GenerationConnection) -> None:
+        if (self.repo, self.store, self.connection) != (
+            str(repo.resolve()),
+            str(store),
+            connection.binding(),
+        ):
+            raise RefreshRequiredError("Retained attachment belongs to another connection or path.")
+
+
+def record_path(project: str) -> Path:
+    return nauro_home() / f"generation-attachment-{project}.json"
+
+
+def read_record(project: str) -> AttachmentRecord | None:
+    home = nauro_home()
+    raw = read_evidence(RefreshPaths(home, home), record_path(project))
+    if raw is None:
+        return None
+    try:
+        record = AttachmentRecord.model_validate_json(raw)
+    except ValueError:
+        raise RefreshRequiredError("Retained attachment evidence is invalid.") from None
+    if record.projection.project_id != project or record.model_dump_json().encode() != raw:
+        raise RefreshRequiredError("Retained attachment evidence is not exact.")
+    return record
+
+
+def save_record(record: AttachmentRecord) -> None:
+    project = record.projection.project_id
+    prior = read_record(project)
+    if prior is not None and prior != record:
+        raise RefreshRequiredError("Retained attachment cannot be replaced.")
+    home = nauro_home()
+    paths = RefreshPaths(home, home)
+    path = record_path(project)
+    if prior is None:
+        durable_replace(paths, path, record.model_dump_json().encode())
+    sync_file(paths, path)
+    sync_parents(paths, home)
+
+
+def validate_retained_projection(projection: VerifiedGenerationProjection) -> bool:
+    target = projection.target
+    store = target.binding.store_path
+    if not store.exists():
+        return False
+    paths = refresh_paths(target.binding, target.identity.installed_for_user_id)
+    layout = _layout(store, target)
+    files = {
+        store / ".replica-control.lock",
+        paths.marker,
+        paths.pointer,
+        paths.carrier,
+        paths.intent,
+        layout.root_path / "manifest.json",
+        *(layout.root_path / "store" / item.path for item in projection.artifacts),
+    }
+    directories = {layout.staging_dir, layout.root_path / "store"}
+    for file in files:
+        directories.update(parent for parent in file.parents if store in parent.parents)
+    for path in store.rglob("*"):
+        _validate_managed_path(store, path)
+        if not ((path.is_dir() and path in directories) or (path.is_file() and path in files)):
+            raise RefreshRequiredError("Unrecognized attachment evidence is preserved intact.")
+    intent_raw = read_evidence(paths, paths.intent)
+    if intent_raw is not None:
+        intent = decode_intent(intent_raw)
+        for raw in (intent.base_pointer_json, intent.target_pointer_json):
+            pointer = _parse_pointer(raw)
+            if any(
+                getattr(pointer, name) != getattr(target.identity, name)
+                for name in GenerationProjectionIdentity.model_fields
+            ):
+                raise RefreshRequiredError("Retained refresh differs from the initial attachment.")
+        return True
+    marker = read_evidence(paths, paths.marker)
+    carrier_raw = read_evidence(paths, paths.carrier)
+    pointer_raw = read_evidence(paths, paths.pointer)
+    actor = target.identity.installed_for_user_id
+    carrier = _parse_authorization_view(carrier_raw) if carrier_raw is not None else None
+    if carrier is not None and not _validate_carrier(target, actor, marker, carrier):
+        raise RefreshRequiredError("Retained attachment authorization differs.")
+    if pointer_raw is not None and (
+        carrier is None
+        or not _validate_control_pair(target, actor, marker, carrier, _parse_pointer(pointer_raw))
+    ):
+        raise RefreshRequiredError("Retained attachment pointer differs.")
+    if marker is not None and (carrier is None or pointer_raw is None):
+        raise RefreshRequiredError("Retained attachment controls are incomplete.")
+    return False

--- a/packages/nauro/tests/test_generation_attachment.py
+++ b/packages/nauro/tests/test_generation_attachment.py
@@ -146,8 +146,7 @@ def test_initial_attach_and_ordinary_generation_admission(hosted):
     }
     before = {p: p.read_bytes() for p in binding.store_path.rglob("*") if p.is_file()}
     again = _run(repo)
-    assert again.exit_code == 1
-    assert "Existing stores and interrupted replica evidence are preserved" in again.output
+    assert again.exit_code == 0, again.output
     assert {p: p.read_bytes() for p in binding.store_path.rglob("*") if p.is_file()} == before
 
 
@@ -205,9 +204,7 @@ def test_host_refusal_does_not_install(hosted, status):
 
 
 @pytest.mark.parametrize("boundary", ["carrier", "pointer", "marker", "barrier"])
-def test_interrupted_initial_attachment_retains_evidence_and_refuses_repeat(
-    hosted, monkeypatch, boundary
-):
+def test_interrupted_initial_attachment_retains_evidence(hosted, monkeypatch, boundary):
     repo, _, _, _, _ = hosted
     original = installation.atomic_write_bytes
     names = {
@@ -234,9 +231,7 @@ def test_interrupted_initial_attachment_retains_evidence_and_refuses_repeat(
     before = {p: p.read_bytes() for p in root.rglob("*") if p.is_file()}
     assert before
     assert not repo_config_path(repo).exists()
-    again = _run(repo)
-    assert again.exit_code == 1
-    assert {p: p.read_bytes() for p in root.rglob("*") if p.is_file()} == before
+    assert get_project_entry_v2(PROJECT_ID) is None
 
 
 @pytest.mark.parametrize("point", ["carrier", "pointer"])

--- a/packages/nauro/tests/test_generation_attachment_recovery.py
+++ b/packages/nauro/tests/test_generation_attachment_recovery.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from nauro.store import generation_installation as installation
+from nauro.store.registry import get_project_entry_v2, get_store_path_v2
+from nauro.store.repo_config import repo_config_path
+from nauro.sync import generation_attachment as attachment
+from nauro.sync import generation_attachment_record as records
+from nauro.sync import generation_refresh as refresh
+from tests.test_generation_attachment import _run
+from tests.test_generation_attachment import hosted as hosted_fixture
+from tests.test_generation_installation import PROJECT_ID
+
+
+@pytest.fixture
+def hosted(tmp_path, monkeypatch):
+    return hosted_fixture.__wrapped__(tmp_path, monkeypatch)
+
+
+def _files(root):
+    return {str(p.relative_to(root)): p.read_bytes() for p in root.rglob("*") if p.is_file()}
+
+
+def _interrupt(repo, monkeypatch, boundary):
+    with monkeypatch.context() as fault:
+        if boundary in {"root", "registry", "config"}:
+            name = {
+                "root": "install_generation_root",
+                "registry": "bind_project_store_v2",
+                "config": "save_repo_config",
+            }[boundary]
+            original = getattr(attachment, name)
+
+            def interrupt(*args, **kwargs):
+                original(*args, **kwargs)
+                raise KeyboardInterrupt()
+
+            fault.setattr(attachment, name, interrupt)
+        elif boundary == "record":
+            original = records.durable_replace
+
+            def interrupt(*args, **kwargs):
+                original(*args, **kwargs)
+                raise KeyboardInterrupt()
+
+            fault.setattr(records, "durable_replace", interrupt)
+        elif boundary in {"carrier", "pointer", "marker"}:
+            original = installation.atomic_write_bytes
+            selected = {
+                "carrier": "authorization-view.json",
+                "pointer": "pointer.json",
+                "marker": "authority.json",
+            }[boundary]
+
+            def interrupt(path, raw):
+                original(path, raw)
+                if path.name == selected:
+                    raise KeyboardInterrupt()
+
+            fault.setattr(installation, "atomic_write_bytes", interrupt)
+        else:
+            original = refresh.durable_replace
+            selected = {
+                "intent": "refresh-intent.json",
+                "refresh-carrier": "authorization-view.json",
+                "refresh-pointer": "pointer.json",
+            }[boundary]
+
+            def interrupt(paths, path, raw):
+                original(paths, path, raw)
+                if path.name == selected:
+                    raise KeyboardInterrupt()
+
+            fault.setattr(refresh, "durable_replace", interrupt)
+        result = _run(repo)
+        assert result.exit_code == 130, result.output
+
+
+@pytest.mark.parametrize(
+    "boundary",
+    [
+        "record",
+        "root",
+        "carrier",
+        "pointer",
+        "marker",
+        "intent",
+        "refresh-carrier",
+        "refresh-pointer",
+        "registry",
+        "config",
+    ],
+)
+def test_repeat_completes_recorded_attachment(hosted, monkeypatch, boundary):
+    repo, _, _, _, calls = hosted
+    _interrupt(repo, monkeypatch, boundary)
+    saved = records.record_path(PROJECT_ID).read_bytes()
+    result = _run(repo)
+    assert result.exit_code == 0, result.output
+    assert records.record_path(PROJECT_ID).read_bytes() == saved
+    assert get_project_entry_v2(PROJECT_ID).mode == "cloud"
+    assert json.loads(repo_config_path(repo).read_text())["id"] == PROJECT_ID
+    assert {call.url.path for call in calls} <= {
+        "/projects",
+        "/generations/projection",
+        "/generations/presign",
+        "/state",
+    }
+
+
+def test_failed_final_barrier_is_repeated_before_success(hosted, monkeypatch):
+    repo, _, _, _, _ = hosted
+    _interrupt(repo, monkeypatch, "refresh-pointer")
+    before = _files(get_store_path_v2(PROJECT_ID))
+    with monkeypatch.context() as fault:
+        fault.setattr(refresh, "sync_file", lambda *a: (_ for _ in ()).throw(OSError("barrier")))
+        result = _run(repo)
+    assert result.exit_code == 1, result.output
+    assert not repo_config_path(repo).exists()
+    assert _files(get_store_path_v2(PROJECT_ID)) == before
+    assert _run(repo).exit_code == 0
+
+
+@pytest.mark.parametrize("change", ["actor", "revoked", "endpoint", "repo", "generation", "scope"])
+def test_mismatch_refuses_without_changing_retained_evidence(hosted, monkeypatch, change):
+    from nauro.store.config import save_config
+    from nauro.store.generation_projection import GenerationProjectionTarget
+
+    repo, _, credentials, control, _ = hosted
+    _interrupt(repo, monkeypatch, "pointer")
+    before = _files(get_store_path_v2(PROJECT_ID))
+    record = records.record_path(PROJECT_ID).read_bytes()
+    if change == "actor":
+        with credentials.locked():
+            credentials.write(
+                credentials.read().model_copy(update={"user_id": "01K44444444444444444444444"})
+            )
+    elif change == "revoked":
+        control["role"] = "viewer"
+    elif change == "endpoint":
+        save_config({"api_url": "https://other.example"})
+    elif change == "repo":
+        repo = repo.parent / "another"
+        repo.mkdir()
+    else:
+        original = attachment.acquire_generation_projection
+
+        def changed(*args, **kwargs):
+            from dataclasses import replace
+
+            value = original(*args, **kwargs)
+            delta = (
+                {"generation_id": "01K66666666666666666666666"}
+                if change == "generation"
+                else {"projection_scope_id": "b" * 64}
+            )
+            return replace(
+                value,
+                target=GenerationProjectionTarget(
+                    value.target.binding, value.target.identity.model_copy(update=delta)
+                ),
+            )
+
+        monkeypatch.setattr(attachment, "acquire_generation_projection", changed)
+    result = _run(repo)
+    assert result.exit_code == 1, result.output
+    assert not repo_config_path(repo).exists()
+    assert _files(get_store_path_v2(PROJECT_ID)) == before
+    assert records.record_path(PROJECT_ID).read_bytes() == record
+
+
+@pytest.mark.parametrize("change", ["missing", "corrupt", "legacy", "pointer", "root", "symlink"])
+def test_ambiguous_or_corrupt_evidence_refuses_intact(hosted, monkeypatch, change):
+    repo, _, _, _, _ = hosted
+    _interrupt(repo, monkeypatch, "pointer")
+    root = get_store_path_v2(PROJECT_ID)
+    record = records.record_path(PROJECT_ID)
+    if change == "missing":
+        record.unlink()
+    elif change == "corrupt":
+        record.write_bytes(b"{}")
+        record.chmod(0o600)
+    elif change == "legacy":
+        (root / "state.md").write_bytes(b"legacy data")
+    elif change == "symlink":
+        (root / "foreign").symlink_to(repo, target_is_directory=True)
+    else:
+        name = "pointer.json" if change == "pointer" else "state.md"
+        next(root.rglob(name)).write_bytes(b"corrupt")
+    before = _files(root)
+    result = _run(repo)
+    assert result.exit_code == 1, result.output
+    assert _files(root) == before
+    assert not repo_config_path(repo).exists()
+
+
+def test_record_durability_failure_precedes_replica_mutation(hosted, monkeypatch):
+    repo, _, _, _, _ = hosted
+    with monkeypatch.context() as fault:
+        fault.setattr(records, "sync_file", lambda *a: (_ for _ in ()).throw(OSError("barrier")))
+        result = _run(repo)
+    assert result.exit_code == 1, result.output
+    assert not get_store_path_v2(PROJECT_ID).exists()
+    assert records.read_record(PROJECT_ID) is not None
+    assert _run(repo).exit_code == 0
+
+
+def test_partial_staging_is_preserved_without_cleanup(hosted, monkeypatch):
+    repo, _, _, _, _ = hosted
+    _interrupt(repo, monkeypatch, "root")
+    root = get_store_path_v2(PROJECT_ID)
+    staging = next(root.rglob("staging")) / "unfinished"
+    staging.mkdir()
+    (staging / "evidence").write_bytes(b"interrupted")
+    before = _files(root)
+    result = _run(repo)
+    assert result.exit_code == 1, result.output
+    assert _files(root) == before
+    assert not repo_config_path(repo).exists()
+
+
+def test_reauthentication_can_resume_only_the_recorded_actor(hosted, monkeypatch):
+    repo, _, credentials, _, _ = hosted
+    _interrupt(repo, monkeypatch, "marker")
+    with credentials.locked():
+        original = credentials.read()
+        credentials.write(credentials.empty("logged_out"))
+    logins = []
+
+    def login(auth, present_url):
+        logins.append(auth.project)
+        with credentials.locked():
+            credentials.write(original.model_copy(update={"revision": "b" * 64}))
+
+    monkeypatch.setattr(attachment.GenerationAuth, "login", login)
+    result = _run(repo)
+    assert result.exit_code == 0, result.output
+    assert logins == [PROJECT_ID]


### PR DESCRIPTION
## Why

An interrupted `attach --generation` currently leaves replica evidence that prevents another attachment attempt. This change lets the existing command finish a recorded installation after control publication, refresh or local association is interrupted.

## What changed

Save an immutable local attachment record before replica mutation. Repeated attachment verifies its original actor, project, repository, trusted connection and projection, then reuses the existing installer and refresh recovery path. Current authorization and successful durability barriers remain required before completion.

## Test plan

509 installation, refresh and attachment tests passed with 77 existing platform/parameter skips. All 26 focused recovery tests passed. The explicit paired server attachment test passed without skips against the compatible server source. Full lint, formatting, configured and targeted typing, and repository guards passed.

## Risk / what to review

Review identity continuity, partial controls and the final durability barriers. Old interruptions without a record, populated staging directories, unknown evidence and changed generations or scopes still refuse intact. This does not recover every crash point. Startup refresh and ordinary two-machine acceptance remain open. Concurrent-writing delivery is incomplete, and production activation is unchanged.
