### PR TITLE
Refresh generation replicas at stdio startup

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/status.py
+++ b/packages/nauro/src/nauro/cli/commands/status.py
@@ -940,6 +940,10 @@ def status(
             typer.echo(json.dumps(envelope, indent=2))
         raise typer.Exit(exc.exit_code) from exc
 
+    from nauro.cli.generation_reads import status_command
+
+    if status_command(store_path.name, json_output=json_output):
+        return
     facts = _collect_status(project_name, store_path, no_probe=no_probe)
     if json_output:
         typer.echo(json.dumps(_build_status_payload(facts).model_dump(), indent=2))

--- a/packages/nauro/src/nauro/cli/generation_reads.py
+++ b/packages/nauro/src/nauro/cli/generation_reads.py
@@ -64,6 +64,8 @@ def require_legacy_read(name: str, store_path: Path) -> None:
 def status_command(project: str, *, json_output: bool) -> bool:
     try:
         binding = resolve_project_binding(project, None, use_cwd=False)
+        if binding.mode == "local":
+            return False
         if observe_generation_marker(binding) is None:
             return False
         status = replica_status(binding)

--- a/packages/nauro/src/nauro/cli/generation_reads.py
+++ b/packages/nauro/src/nauro/cli/generation_reads.py
@@ -12,8 +12,7 @@ from nauro.mcp.read_dispatch import GENERATION_READS, generation_response
 from nauro.store.generation_authority import GenerationAuthorityError
 from nauro.store.read_authority import observe_generation_marker
 from nauro.store.resolution import resolve_project_binding
-from nauro.sync.generation_refresh import recover_generation_refresh
-from nauro.sync.generation_session import GenerationTransferSession
+from nauro.sync.generation_refresh_status import refresh_replica, replica_status
 from nauro.sync.remote import TransferBoundaryError
 
 
@@ -42,10 +41,8 @@ def refresh_command(project: str, *, push_only: bool) -> bool:
         if push_only:
             typer.echo("Error: Generation replicas cannot push local files.", err=True)
             raise typer.Exit(1)
-        with GenerationTransferSession(binding) as session:
-            store = recover_generation_refresh(binding, actor=session.actor, session=session)
-            session.credentials()
-            typer.echo(f"Refreshed generation {store.target.identity.generation_id}.")
+        store = refresh_replica(binding)
+        typer.echo(f"Refreshed generation {store.target.identity.generation_id}.")
     except (GenerationAuthorityError, TransferBoundaryError, OSError) as exc:
         typer.echo(f"Error: {exc}", err=True)
         raise typer.Exit(1) from exc
@@ -62,3 +59,31 @@ def require_legacy_read(name: str, store_path: Path) -> None:
     except (ValueError, GenerationAuthorityError, OSError) as exc:
         typer.echo("Error: Project read authority changed during the read.", err=True)
         raise typer.Exit(1) from exc
+
+
+def status_command(project: str, *, json_output: bool) -> bool:
+    try:
+        binding = resolve_project_binding(project, None, use_cwd=False)
+        if observe_generation_marker(binding) is None:
+            return False
+        status = replica_status(binding)
+    except (ValueError, OSError):
+        status = {"project_id": project, "error_code": "replica_status_unavailable"}
+    if json_output:
+        typer.echo(json.dumps({"replica_status": status}))
+    else:
+        typer.echo(f"Project: {project}")
+        typer.echo(f"Generation: {status.get('generation_id') or 'unavailable'}")
+        typer.echo(
+            f"Last refresh attempt: {status.get('last_refresh_attempt_at') or 'not recorded'}"
+        )
+        typer.echo(
+            f"Last successful refresh: {status.get('last_refresh_succeeded_at') or 'not recorded'}"
+        )
+        error = status.get("error_code") or status.get("last_refresh_error_code")
+        if error:
+            typer.echo(f"Refresh: {error}. Check 'nauro auth status', then run 'nauro sync'.")
+        typer.echo("Local diagnostic status. Current server authorization was not checked.")
+    if status.get("error_code"):
+        raise typer.Exit(1)
+    return True

--- a/packages/nauro/src/nauro/mcp/read_dispatch.py
+++ b/packages/nauro/src/nauro/mcp/read_dispatch.py
@@ -24,6 +24,7 @@ from nauro.store.resolution import (
     StoreResolutionError,
     resolve_project_binding,
 )
+from nauro.sync.generation_refresh_status import replica_status
 from nauro.sync.generation_session import GenerationTransferSession
 from nauro.sync.history_transport import HttpHistoryTransport
 from nauro.sync.remote import TransferBoundaryError
@@ -33,7 +34,9 @@ logger = logging.getLogger(__name__)
 
 def _prepared(response: generation.GenerationToolResponse) -> CallToolResult:
     return CallToolResult(
-        content=[TextContent(type="text", text=response.text)], isError=response.is_error
+        content=[TextContent(type="text", text=response.text)],
+        isError=response.is_error,
+        structuredContent=response.envelope,
     )
 
 
@@ -95,7 +98,9 @@ def generation_response(
         response: generation.GenerationToolResponse = getattr(generation, name)(
             binding, **arguments, actor=session.actor, session=session
         )
+        status = replica_status(binding)
         session.credentials()
+        response.envelope["replica_status"] = status
         return response
 
 

--- a/packages/nauro/src/nauro/mcp/stdio_server.py
+++ b/packages/nauro/src/nauro/mcp/stdio_server.py
@@ -477,7 +477,16 @@ def _pull_on_startup() -> None:
     try:
         binding = resolve_project_binding(None, Path.cwd())
         if observe_generation_marker(binding) is not None:
-            logger.debug("session-start pull: generation authority, skipping")
+            from nauro.sync.generation_refresh_status import REFRESH_FAILURES, refresh_replica
+
+            try:
+                refresh_replica(binding)
+                logger.info("session-start refresh: completed")
+            except REFRESH_FAILURES:
+                logger.warning(
+                    "session-start refresh: incomplete; run 'nauro status' "
+                    "and check generation login."
+                )
             return
         project_key, store_path = binding.project_id, binding.store_path
 

--- a/packages/nauro/src/nauro/sync/generation_refresh_status.py
+++ b/packages/nauro/src/nauro/sync/generation_refresh_status.py
@@ -1,0 +1,234 @@
+"""Diagnostic refresh attempts for installed generation replicas."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Literal
+
+import httpx
+from nauro_core.provenance import validate_utc_timestamp
+from pydantic import BaseModel, ConfigDict, field_validator, model_validator
+
+from nauro.auth import DEFAULT_AUTH_REDIRECT_URI, PartialAuthConfigError
+from nauro.store.generation_authority import RefreshRequiredError
+from nauro.store.generation_refresh_io import (
+    RefreshPaths,
+    durable_replace,
+    read_evidence,
+    refresh_paths,
+)
+from nauro.store.generation_refresh_state import RefreshControlPair, _pointer
+from nauro.store.generation_store import GenerationSnapshotStore
+from nauro.store.home import nauro_home
+from nauro.store.replica_control import _native_control_lock, _validate_managed_path
+from nauro.store.resolution import ResolvedProjectBinding, resolve_project_binding
+from nauro.sync.generation_connection import connection_for
+from nauro.sync.generation_credentials import AccountRecord, GenerationConnection
+from nauro.sync.generation_refresh import recover_generation_refresh
+from nauro.sync.generation_session import GenerationConnectionError, GenerationTransferSession
+from nauro.sync.remote import TransferBoundaryError
+
+REFRESH_FAILURES = (
+    ValueError,
+    OSError,
+    PartialAuthConfigError,
+    TransferBoundaryError,
+    httpx.HTTPError,
+)
+
+
+class RefreshAttempt(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=True, frozen=True, hide_input_in_errors=True)
+
+    version: Literal[1] = 1
+    project_id: str
+    actor: str
+    connection: str
+    attempted_at: str
+    succeeded_at: str | None
+    error_code: (
+        Literal[
+            "refresh_incomplete",
+            "refresh_failed",
+            "refresh_required",
+            "generation_connection_unavailable",
+        ]
+        | None
+    )
+
+    @field_validator("attempted_at", "succeeded_at")
+    @classmethod
+    def timestamp(cls, value: str | None) -> str | None:
+        return (
+            validate_utc_timestamp(value, field="refresh timestamp") if value is not None else None
+        )
+
+    @model_validator(mode="after")
+    def completed(self) -> RefreshAttempt:
+        if self.error_code is None and (
+            self.succeeded_at is None or self.succeeded_at < self.attempted_at
+        ):
+            raise ValueError("Refresh success needs a completion timestamp")
+        return self
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
+def _account(binding: ResolvedProjectBinding) -> tuple[GenerationConnection, AccountRecord]:
+    try:
+        if resolve_project_binding(binding.project_id, None, use_cwd=False) != binding:
+            raise GenerationConnectionError("The project binding changed.")
+        connection = connection_for(binding, DEFAULT_AUTH_REDIRECT_URI)
+        with connection.store().locked():
+            account = connection.store().read()
+        if account is None or not account.user_id:
+            raise GenerationConnectionError("Generation login required.")
+        return connection, account
+    except (ValueError, OSError, PartialAuthConfigError):
+        raise GenerationConnectionError("Check generation login and project connection.") from None
+
+
+def _attempt_path(
+    binding: ResolvedProjectBinding, connection: GenerationConnection, actor: str
+) -> Path:
+    return (
+        nauro_home()
+        / f"generation-refresh-{binding.project_id}-{actor}-{connection.binding()}.json"
+    )
+
+
+def _read_attempt(
+    binding: ResolvedProjectBinding, connection: GenerationConnection, actor: str
+) -> RefreshAttempt | None:
+    home = nauro_home()
+    raw = read_evidence(RefreshPaths(home, home), _attempt_path(binding, connection, actor))
+    if raw is None:
+        return None
+    try:
+        attempt = RefreshAttempt.model_validate_json(raw)
+    except ValueError:
+        raise RefreshRequiredError("Retained refresh status is invalid.") from None
+    if (attempt.project_id, attempt.actor, attempt.connection) != (
+        binding.project_id,
+        actor,
+        connection.binding(),
+    ) or attempt.model_dump_json().encode() != raw:
+        raise RefreshRequiredError("Refresh status belongs to another binding.")
+    return attempt
+
+
+def refresh_replica(binding: ResolvedProjectBinding) -> GenerationSnapshotStore:
+    connection, account = _account(binding)
+    actor = account.user_id
+    paths = refresh_paths(binding, actor)
+    if not paths.actor.is_dir():
+        raise RefreshRequiredError("An installed actor replica is required.")
+    home = nauro_home()
+    evidence = RefreshPaths(home, home)
+    attempt_path = _attempt_path(binding, connection, actor)
+    lock = attempt_path.with_suffix(".lock")
+    _validate_managed_path(home, lock)
+    with _native_control_lock(home, lock, 0):
+        prior = _read_attempt(binding, connection, actor)
+        attempt = RefreshAttempt(
+            project_id=binding.project_id,
+            actor=actor,
+            connection=connection.binding(),
+            attempted_at=_now(),
+            succeeded_at=prior.succeeded_at if prior else None,
+            error_code="refresh_incomplete",
+        )
+
+        def save(value: RefreshAttempt) -> None:
+            selected, current = _account(binding)
+            if selected != connection or current.user_id != actor:
+                raise GenerationConnectionError("The refresh account changed.")
+            value = RefreshAttempt.model_validate(value.model_dump())
+            durable_replace(evidence, attempt_path, value.model_dump_json().encode())
+
+        save(attempt)
+        try:
+            with GenerationTransferSession(binding) as session:
+                if session.actor != actor or session.connection != connection:
+                    raise GenerationConnectionError("The refresh account changed.")
+                store = recover_generation_refresh(binding, actor=actor, session=session)
+                session.credentials()
+                save(attempt.model_copy(update={"succeeded_at": _now(), "error_code": None}))
+                session.credentials()
+                return store
+        except Exception as exc:
+            code = (
+                "generation_connection_unavailable"
+                if isinstance(exc, GenerationConnectionError)
+                else "refresh_required"
+                if isinstance(exc, RefreshRequiredError)
+                else "refresh_failed"
+            )
+            save(attempt.model_copy(update={"error_code": code}))
+            raise
+
+
+def replica_status(binding: ResolvedProjectBinding) -> dict[str, object]:
+    status: dict[str, object] = {
+        "project_id": binding.project_id,
+        "installed_for_user_id": None,
+        "projection_class": None,
+        "projection_scope_id": None,
+        "store_format_version": None,
+        "generation_id": None,
+        "manifest_digest": None,
+        "committed_at": None,
+        "installed_at": None,
+        "last_refresh_attempt_at": None,
+        "last_refresh_succeeded_at": None,
+        "last_refresh_error_code": None,
+        "offline": None,
+        "api_only_availability": None,
+        "pending_outbox_count": None,
+        "parked_outbox_count": None,
+        "authorization_checked": False,
+    }
+    try:
+        connection, account = _account(binding)
+        actor = account.user_id
+        paths = refresh_paths(binding, actor)
+        status["installed_for_user_id"] = actor
+        with _native_control_lock(paths.store, paths.store / ".replica-control.lock", 0):
+            attempt = _read_attempt(binding, connection, actor)
+            if attempt is not None:
+                status.update(
+                    last_refresh_attempt_at=attempt.attempted_at,
+                    last_refresh_succeeded_at=attempt.succeeded_at,
+                    last_refresh_error_code=attempt.error_code,
+                )
+            raw = read_evidence(paths, paths.pointer)
+            carrier = read_evidence(paths, paths.carrier)
+            if raw is None or carrier is None:
+                raise RefreshRequiredError("Replica controls unavailable.")
+            RefreshControlPair(raw, carrier)
+            pointer = _pointer(raw)
+            if pointer.project_id != binding.project_id or pointer.installed_for_user_id != actor:
+                raise RefreshRequiredError("Replica controls differ from the account.")
+            for name in (
+                "projection_class",
+                "projection_scope_id",
+                "store_format_version",
+                "generation_id",
+                "manifest_digest",
+                "committed_at",
+                "installed_at",
+            ):
+                status[name] = getattr(pointer, name)
+        selected, current = _account(binding)
+        if selected != connection or current != account:
+            raise GenerationConnectionError("The status account changed.")
+        return status
+    except REFRESH_FAILURES:
+        return {
+            "project_id": binding.project_id,
+            "error_code": "replica_status_unavailable",
+            "authorization_checked": False,
+        }

--- a/packages/nauro/tests/test_generation_refresh.py
+++ b/packages/nauro/tests/test_generation_refresh.py
@@ -513,8 +513,8 @@ def test_refresh_executor_has_only_named_runtime_consumers():
                     a.name for a in node.names if a.name == "nauro.sync.generation_refresh"
                 )
     assert sorted(consumers) == [
-        "cli/generation_reads.py",
         "mcp/generation_reads.py",
         "mcp/generation_responses.py",
         "sync/generation_attachment.py",
+        "sync/generation_refresh_status.py",
     ]

--- a/packages/nauro/tests/test_generation_store.py
+++ b/packages/nauro/tests/test_generation_store.py
@@ -142,7 +142,11 @@ def test_store_has_only_dormant_generation_consumers():
                     for alias in node.names
                     if alias.name == "nauro.store.generation_store"
                 )
-    assert sorted(consumers) == ["mcp/generation_reads.py", "sync/generation_refresh.py"]
+    assert sorted(consumers) == [
+        "mcp/generation_reads.py",
+        "sync/generation_refresh.py",
+        "sync/generation_refresh_status.py",
+    ]
 
 
 def test_project_frame_refusal_preserves_bytes_and_gives_quarantine_guidance():

--- a/packages/nauro/tests/test_history_composition.py
+++ b/packages/nauro/tests/test_history_composition.py
@@ -12,6 +12,7 @@ from nauro.mcp import generation_responses as responses
 from nauro.mcp import read_dispatch as dispatch
 from nauro.store import generation_installation as installation
 from nauro.sync import generation_refresh as refresh
+from nauro.sync import generation_refresh_status as refresh_status
 from nauro.sync import history_transport as transport
 from tests.test_generation_installation import USER_ID
 from tests.test_generation_reads import POSIX
@@ -60,7 +61,12 @@ def test_response_and_dispatch_keep_authority_without_private_wire_fields(cloud,
     }
     assert actual.isError is False
     assert actual.content[0].text == result.text
-    assert actual.structuredContent is None
+    assert actual.structuredContent == {
+        **result.envelope,
+        "replica_status": refresh_status.replica_status(binding),
+    }
+    assert USER_ID not in actual.content[0].text
+    assert target.identity.projection_scope_id not in actual.content[0].text
     assert USER_ID not in repr(result)
     assert target.identity.projection_scope_id not in repr(result)
     assert "POISON" not in repr(result)

--- a/packages/nauro/tests/test_normal_generation_reads.py
+++ b/packages/nauro/tests/test_normal_generation_reads.py
@@ -7,7 +7,6 @@ import httpx
 import pytest
 from typer.testing import CliRunner
 
-from nauro.cli import generation_reads as cli
 from nauro.cli.main import app
 from nauro.mcp import read_dispatch, stdio_server
 from nauro.store import generation_installation as installation
@@ -18,7 +17,7 @@ from nauro.store.generation_projection import (
 )
 from nauro.store.registry import register_project_v2
 from nauro.store.resolution import resolve_project_binding
-from nauro.sync import generation_acquisition, generation_refresh
+from nauro.sync import generation_acquisition, generation_refresh, generation_refresh_status
 from nauro.sync.generation_session import GenerationTransferSession
 from tests.generation_account import seed_generation_account
 from tests.test_sync.test_generation_acquisition import PROJECT_ID, USER_ID, FakeServer
@@ -56,7 +55,7 @@ def normal(tmp_path, monkeypatch):
         return GenerationTransferSession(b, server.session.client)
 
     monkeypatch.setattr(read_dispatch, "GenerationTransferSession", factory)
-    monkeypatch.setattr(cli, "GenerationTransferSession", factory)
+    monkeypatch.setattr(generation_refresh_status, "GenerationTransferSession", factory)
     with factory(binding) as session:
         generation_refresh.commit_generation_refresh(
             generation_refresh.prepare_initial_generation_refresh(

--- a/packages/nauro/tests/test_read_dispatch.py
+++ b/packages/nauro/tests/test_read_dispatch.py
@@ -89,10 +89,13 @@ def test_generation_uses_prepared_text_without_legacy_render(cloud, monkeypatch,
     monkeypatch.setattr(dispatch.legacy, f"tool_{name}", forbidden)
     checks.clear()
     actual = getattr(dispatch, name)(project_id=binding.project_id, **kwargs)
+    expected.envelope["replica_status"] = dispatch.replica_status(binding)
     assert actual == CallToolResult(
-        content=[TextContent(type="text", text=expected.text)], isError=False
+        content=[TextContent(type="text", text=expected.text)],
+        isError=False,
+        structuredContent=expected.envelope,
     )
-    assert actual.structuredContent is None
+    assert actual.structuredContent["replica_status"]["last_refresh_attempt_at"] is None
     assert len(checks) == 5
 
 
@@ -174,7 +177,11 @@ def test_generation_failures_never_fall_back(cloud, monkeypatch, defect):
     monkeypatch.setattr(dispatch.legacy, "tool_get_raw_file", forbidden)
     result = dispatch.get_raw_file("state.md", project_id=binding.project_id)
     assert result.isError is True
-    assert result.structuredContent is None
+    if defect in {"missing_intent", "renderer"}:
+        assert set(result.structuredContent) == {"store", "error", "replica_status"}
+        assert result.structuredContent["replica_status"]["authorization_checked"] is False
+    else:
+        assert result.structuredContent is None
     assert len(result.content) == 1
     assert "Verified generation state" not in str(result)
     assert "PRIVATE" not in str(result)
@@ -313,9 +320,9 @@ def test_generation_raw_exclusions_survive_dispatch(cloud, path):
     binding, _, checks = cloud
     checks.clear()
     result = dispatch.get_raw_file(path, project_id=binding.project_id)
-    assert result == dispatch._prepared(
-        generation._error("Invalid or unavailable generation path.", kind="rejected")
-    )
+    expected = generation._error("Invalid or unavailable generation path.", kind="rejected")
+    expected.envelope["replica_status"] = dispatch.replica_status(binding)
+    assert result == dispatch._prepared(expected)
     assert checks == []
 
 

--- a/packages/nauro/tests/test_stdio_startup_authority.py
+++ b/packages/nauro/tests/test_stdio_startup_authority.py
@@ -50,6 +50,21 @@ def marker_bytes(pid: str, version: int = 1) -> bytes:
     ).encode()
 
 
+@pytest.mark.parametrize("json_output", [False, True])
+def test_local_status_does_not_probe_replica_controls(tmp_path, monkeypatch, json_output):
+    from nauro.cli.generation_reads import status_command
+
+    monkeypatch.setenv("NAURO_HOME", str(tmp_path / "home"))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    pid, _ = register_project_v2("Local status", [repo], mode="local")
+    probe = Mock(side_effect=AssertionError("Local status probed replica controls"))
+    monkeypatch.setattr("nauro.cli.generation_reads.observe_generation_marker", probe)
+
+    assert status_command(pid, json_output=json_output) is False
+    probe.assert_not_called()
+
+
 @pytest.mark.parametrize("empty_control", [False, True])
 def test_cloud_legacy_reaches_existing_pull(startup, empty_control):
     pid, store, pull = startup

--- a/packages/nauro/tests/test_stdio_startup_authority.py
+++ b/packages/nauro/tests/test_stdio_startup_authority.py
@@ -1,14 +1,25 @@
 from __future__ import annotations
 
+import base64
 import json
+import time
 from pathlib import Path
 from unittest.mock import Mock
 
+import httpx
 import pytest
+from typer.testing import CliRunner
 
+from nauro.cli.main import app
 from nauro.mcp import stdio_server
 from nauro.store import read_authority
+from nauro.store.generation_refresh_io import refresh_paths
 from nauro.store.registry import register_project_v2
+from nauro.store.resolution import resolve_project_binding
+from nauro.sync import generation_refresh_status as refresh_status
+from tests import test_generation_installation as fixtures
+from tests.test_generation_attachment import _run
+from tests.test_generation_attachment import hosted as attachment_fixture
 
 
 @pytest.fixture
@@ -129,3 +140,241 @@ def test_hardlinked_marker_prevents_pull(startup, tmp_path):
     (control / "authority.json").hardlink_to(target)
     stdio_server._pull_on_startup()
     pull.assert_not_called()
+
+
+def test_valid_marker_selects_refresh_before_legacy_pull(startup, monkeypatch):
+    _, store, pull = startup
+    (store / ".replica").mkdir()
+    (store / ".replica/authority.json").write_bytes(marker_bytes(startup[0]))
+    refresh = Mock()
+    monkeypatch.setattr("nauro.sync.generation_refresh_status.refresh_replica", refresh)
+    stdio_server._pull_on_startup()
+    refresh.assert_called_once()
+    assert refresh.call_args.args[0].store_path == store
+    pull.assert_not_called()
+
+
+@pytest.fixture
+def installed(tmp_path, monkeypatch):
+    repo, connection, credentials, control, calls = attachment_fixture.__wrapped__(
+        tmp_path, monkeypatch
+    )
+    assert _run(repo).exit_code == 0
+    binding = resolve_project_binding(fixtures.PROJECT_ID, None, use_cwd=False)
+    legacy = []
+    monkeypatch.setattr("nauro.sync.hooks.pull_before_session", lambda *a: legacy.append(a))
+    return repo, binding, connection, credentials, control, calls, legacy
+
+
+def _status(binding):
+    result = CliRunner().invoke(
+        app, ["status", "--project", binding.project_id, "--json", "--no-probe"]
+    )
+    assert result.exit_code == 0, result.output
+    return json.loads(result.output)["replica_status"]
+
+
+def test_startup_status_and_rendered_read_bytes(installed):
+    _, binding, _, _, _, _, legacy = installed
+    before = stdio_server.get_raw_file("state.md", project_id=binding.project_id)
+    stdio_server._pull_on_startup()
+    after = stdio_server.get_raw_file("state.md", project_id=binding.project_id)
+    assert before.content == after.content
+    assert after.isError is False
+    status = after.structuredContent["replica_status"]
+    assert status["last_refresh_error_code"] is None
+    assert status["last_refresh_succeeded_at"] is not None
+    assert _status(binding) == status
+    assert status["authorization_checked"] is False
+    assert status["pending_outbox_count"] is None
+    assert legacy == []
+
+
+def test_remote_commit_startup_refresh_then_read(installed, monkeypatch):
+    _, binding, _, _, _, _, legacy = installed
+    monkeypatch.setattr(fixtures, "GENERATION_ID", "01K77777777777777777777777")
+    new = fixtures._projection({"state.md": b"New committed state\n"})
+    client_type = httpx.Client
+
+    def wire(request):
+        if request.url.path == "/generations/projection":
+            return httpx.Response(
+                200,
+                json={
+                    "projection": new.target.identity.model_dump(),
+                    "manifest_base64": base64.b64encode(new.manifest_json).decode(),
+                },
+            )
+        if request.url.path == "/generations/presign":
+            return httpx.Response(
+                200,
+                json={
+                    "projection": new.target.identity.model_dump(),
+                    "urls": [{"path": "state.md", "url": "https://objects.example/state"}],
+                    "expires_at": "2999-12-31T23:59:59Z",
+                },
+            )
+        assert request.url.host == "objects.example"
+        return httpx.Response(200, content=b"New committed state\n")
+
+    # The attachment fixture replaced Client. Use its returned client's concrete type.
+    with client_type(trust_env=False) as old:
+        concrete = type(old)
+    monkeypatch.setattr(
+        httpx, "Client", lambda **kw: concrete(transport=httpx.MockTransport(wire), **kw)
+    )
+    refused = stdio_server.get_raw_file("state.md", project_id=binding.project_id)
+    assert refused.isError is True
+    stdio_server._pull_on_startup()
+    read = stdio_server.get_raw_file("state.md", project_id=binding.project_id)
+    assert read.isError is False
+    assert "New committed state" in read.content[0].text
+    assert read.structuredContent["replica_status"]["generation_id"] == fixtures.GENERATION_ID
+    assert legacy == []
+
+
+@pytest.mark.parametrize("failure", ["expired", "revoked", "network"])
+def test_startup_failure_is_visible_without_fallback(installed, monkeypatch, caplog, failure):
+    _, binding, _, credentials, control, calls, legacy = installed
+    stdio_server._pull_on_startup()
+    previous = _status(binding)
+    pointer = refresh_paths(binding, fixtures.USER_ID).pointer
+    before = pointer.read_bytes()
+    if failure == "expired":
+        with credentials.locked():
+            credentials.write(
+                credentials.read().model_copy(update={"expires_at": int(time.time()) - 1})
+            )
+        calls.clear()
+    elif failure == "revoked":
+        control["status"] = 403
+    else:
+        monkeypatch.setattr(
+            refresh_status,
+            "recover_generation_refresh",
+            lambda *a, **kw: (_ for _ in ()).throw(httpx.ConnectError("PRIVATE")),
+        )
+    stdio_server._pull_on_startup()
+    status = _status(binding)
+    assert status["last_refresh_error_code"] in {
+        "refresh_failed",
+        "generation_connection_unavailable",
+    }
+    assert status["last_refresh_succeeded_at"] == previous["last_refresh_succeeded_at"]
+    assert pointer.read_bytes() == before
+    assert "session-start refresh: incomplete" in caplog.text
+    assert "PRIVATE" not in caplog.text
+    assert legacy == []
+    if failure == "expired":
+        assert calls == []
+
+
+def test_interrupted_attempt_remains_visible(installed, monkeypatch):
+    _, binding, _, _, _, _, _ = installed
+    with monkeypatch.context() as fault:
+        fault.setattr(
+            refresh_status,
+            "recover_generation_refresh",
+            lambda *a, **kw: (_ for _ in ()).throw(KeyboardInterrupt()),
+        )
+        with pytest.raises(KeyboardInterrupt):
+            stdio_server._pull_on_startup()
+    assert _status(binding)["last_refresh_error_code"] == "refresh_incomplete"
+    stdio_server._pull_on_startup()
+    assert _status(binding)["last_refresh_error_code"] is None
+
+
+def test_explicit_sync_uses_same_status(installed):
+    _, binding, _, _, _, _, legacy = installed
+    result = CliRunner().invoke(app, ["sync", "--project", binding.project_id])
+    assert result.exit_code == 0, result.output
+    assert _status(binding)["last_refresh_succeeded_at"] is not None
+    assert legacy == []
+
+
+@pytest.mark.parametrize("change", ["actor", "corrupt", "linked"])
+def test_status_refuses_other_actor_or_invalid_record(installed, change, tmp_path):
+    _, binding, connection, credentials, _, _, _ = installed
+    stdio_server._pull_on_startup()
+    path = refresh_status._attempt_path(binding, connection, fixtures.USER_ID)
+    if change == "actor":
+        with credentials.locked():
+            credentials.write(
+                credentials.read().model_copy(update={"user_id": "01K44444444444444444444444"})
+            )
+    elif change == "corrupt":
+        path.write_bytes(b"PRIVATE INVALID STATUS")
+    else:
+        target = tmp_path / "private"
+        target.write_bytes(path.read_bytes())
+        path.unlink()
+        path.symlink_to(target)
+    result = refresh_status.replica_status(binding)
+    assert result == {
+        "project_id": binding.project_id,
+        "error_code": "replica_status_unavailable",
+        "authorization_checked": False,
+    }
+
+
+@pytest.mark.parametrize("phase", ["start", "success"])
+def test_status_persistence_failure_never_reports_success(installed, monkeypatch, caplog, phase):
+    _, binding, _, _, _, _, _ = installed
+    original = refresh_status.durable_replace
+
+    def failed(paths, path, raw):
+        if phase == "start" or json.loads(raw)["error_code"] is None:
+            raise OSError("PRIVATE PERSISTENCE DETAIL")
+        return original(paths, path, raw)
+
+    monkeypatch.setattr(refresh_status, "durable_replace", failed)
+    stdio_server._pull_on_startup()
+    status = _status(binding)
+    assert status["last_refresh_succeeded_at"] is None
+    assert "session-start refresh: incomplete" in caplog.text
+    assert "PRIVATE" not in caplog.text
+
+
+def test_corrupt_credentials_refuse_sync_without_private_details(installed):
+    _, binding, _, credentials, _, _, _ = installed
+    credentials.path.write_bytes(b'{"private":"PRIVATE CREDENTIAL DETAIL"}')
+    result = CliRunner().invoke(app, ["sync", "--project", binding.project_id])
+    assert result.exit_code == 1
+    assert "Check generation login and project connection" in result.output
+    assert "PRIVATE" not in result.output
+
+
+def test_status_does_not_call_legacy_credentials_or_network(installed, monkeypatch):
+    _, binding, _, _, _, calls, _ = installed
+    monkeypatch.setattr("nauro.auth.load_access_token", lambda: pytest.fail("Legacy credentials"))
+    before = len(calls)
+    assert _status(binding)["generation_id"] == fixtures.GENERATION_ID
+    assert len(calls) == before
+
+
+def test_repeat_attachment_after_startup(installed):
+    repo, binding, _, _, _, _, _ = installed
+    stdio_server._pull_on_startup()
+    before = _status(binding)
+    result = _run(repo)
+    assert result.exit_code == 0, result.output
+    assert _status(binding) == before
+
+
+def test_startup_between_association_writes_preserves_attachment_recovery(tmp_path, monkeypatch):
+    from nauro.store.repo_config import repo_config_path
+    from nauro.sync import generation_attachment as attachment
+
+    repo, _, _, _, _ = attachment_fixture.__wrapped__(tmp_path, monkeypatch)
+    with monkeypatch.context() as fault:
+        fault.setattr(
+            attachment,
+            "save_repo_config",
+            lambda *a, **kw: (_ for _ in ()).throw(KeyboardInterrupt()),
+        )
+        assert _run(repo).exit_code == 130
+    assert not repo_config_path(repo).exists()
+    stdio_server._pull_on_startup()
+    result = _run(repo)
+    assert result.exit_code == 0, result.output
+    assert json.loads(repo_config_path(repo).read_text())["id"] == fixtures.PROJECT_ID

--- a/packages/nauro/tests/test_sync_enablement_messages.py
+++ b/packages/nauro/tests/test_sync_enablement_messages.py
@@ -31,8 +31,8 @@ from nauro.templates.scaffolds import scaffold_project_store
 
 runner = CliRunner()
 
-_CLOUD_PID = "01TESTCLOUDPID000000000001"
-_LOCAL_PID = "01TESTLOCALPID000000000001"
+_CLOUD_PID = "01K11111111111111111111111"
+_LOCAL_PID = "01K22222222222222222222222"
 
 
 def _make_jwt(payload: dict) -> str:


### PR DESCRIPTION
## Why

Stdio startup currently skips installed generation replicas. Another writer can commit while the local client retains its earlier generation, with no recorded startup refresh result.

## What changed

Run the existing authorized refresh coordinator before stdio accepts tool calls. Explicit sync uses the same wrapper. Persist the latest attempt and last successful refresh per project, actor and trusted connection, outside the replica tree so attachment recovery remains intact.

Show diagnostic replica status through the existing status command and structured generation-read metadata. Rendered context stays unchanged. Expired credentials do not launch an interactive login, and failures do not fall back to legacy pulls.

## Test plan

The full client suite passed 5,045 tests with 110 skips, using the CI test selection. The explicit paired-server attachment test passed without skips. Tests cover remote generation advancement, startup failures, interruption, credential expiry, status persistence and repeat attachment after startup. Full lint, formatting, configured and targeted typing, and repository guards passed.

## Risk / what to review

Review actor and connection changes, failed status persistence, and attachment recovery interactions. Status is diagnostic and does not grant access. Unmeasured network, API-only and outbox fields remain null. This does not drain an outbox or refresh automatically on ordinary stale reads. Live startup, credential longevity and ordinary two-machine acceptance remain unproven. Concurrent-writing delivery is incomplete; production activation is unchanged.
