### PR TITLE
Enforce the nauro dependency ladder with import-linter contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,9 @@ jobs:
       - run: uv sync --locked --package nauro-core --all-extras --python 3.12
       - run: uv run --no-sync --package nauro-core lint-imports
         working-directory: packages/nauro-core
+      - run: uv sync --locked --package nauro --extra dev --python 3.12
+      - run: uv run --no-sync --package nauro lint-imports
+        working-directory: packages/nauro
 
   test-nauro-core:
     runs-on: ubuntu-latest

--- a/packages/nauro/.importlinter
+++ b/packages/nauro/.importlinter
@@ -1,0 +1,45 @@
+[importlinter]
+root_packages =
+    nauro
+    nauro_core
+
+[importlinter:contract:packages]
+name = nauro packages depend downward only
+type = layers
+layers =
+    nauro.cli
+    nauro.mcp
+    nauro.templates
+    nauro.skills | nauro.agents | nauro.graph | nauro.demo
+    nauro.sync
+    nauro.store : nauro.auth
+    nauro.constants | nauro.onboarding
+    nauro_core
+ignore_imports =
+    nauro.sync.merge -> nauro.graph
+    nauro.store.validator -> nauro.mcp.payloads
+    nauro.store.generation_installation -> nauro.sync._path_diagnostics
+    nauro.store.generation_installation -> nauro.sync.generation_acquisition
+    nauro.store.generation_installation -> nauro.sync.generation_session
+    nauro.store.recovery -> nauro.sync._path_diagnostics
+    nauro.store.recovery -> nauro.sync.cloud_projects
+    nauro.store.recovery -> nauro.sync.etag
+    nauro.store.recovery -> nauro.sync.merge
+    nauro.store.recovery -> nauro.sync.remote
+    nauro.store.recovery -> nauro.sync.state
+    nauro.store.recovery -> nauro.sync.transfer
+    nauro.store.post_commit -> nauro.templates.agents_md_regen
+    nauro.store.post_commit -> nauro.sync.push
+    nauro.templates.agents_md -> nauro.mcp.payloads
+    nauro.templates.agents_md -> nauro.cli.integrations.claude_bridge
+    nauro.templates.agents_md -> nauro.cli.integrations.outcomes
+    nauro.templates.agents_md_regen -> nauro.cli.git_hygiene
+    nauro.templates.agents_md_regen -> nauro.cli.integrations.outcomes
+    nauro.templates.agents_md_regen -> nauro.cli.integrations.render
+
+[importlinter:contract:store-foundation]
+name = store foundation modules stay below auth
+type = layers
+layers =
+    nauro.auth
+    nauro.store._atomic : nauro.store.config : nauro.store.decision_lock : nauro.store.filesystem_store : nauro.store.generation_authority : nauro.store.generation_projection : nauro.store.generation_refresh_intent : nauro.store.generation_refresh_state : nauro.store.home : nauro.store.journal : nauro.store.read_authority : nauro.store.reader : nauro.store.registry : nauro.store.replica_control : nauro.store.repo_config : nauro.store.repo_head : nauro.store.resolution : nauro.store.snapshot : nauro.store.store_lock : nauro.store.write_safety

--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -38,6 +38,7 @@ dev = [
     "pytest>=7.0",
     "ruff==0.15.20",
     "mypy==2.1.0",
+    "import-linter==2.12",
 ]
 embeddings = ["nauro-core[embeddings]"]
 

--- a/packages/nauro/src/nauro/onboarding.py
+++ b/packages/nauro/src/nauro/onboarding.py
@@ -1,13 +1,9 @@
-"""Onboarding and empty-state guidance text for the local MCP server.
+"""Guidance text for a missing or empty project store.
 
-These constants are returned when a user has no project store or when a
-project exists but has no decisions/snapshots yet.  They give the LLM
-enough context to guide the user toward a productive first experience.
-
-``NO_DECISIONS_TO_CHECK`` is the shared cross-surface string and lives in
-``nauro_core.constants`` so the same empty-store text reaches users on
-local and cloud transports. The re-export here preserves the import path
-existing callers use.
+Store resolution and the MCP tools return these constants when no store is
+registered or the store holds no decisions yet. ``NO_DECISIONS_TO_CHECK`` is
+re-exported from ``nauro_core.constants`` so local and hosted transports
+render the same empty-store text.
 """
 
 from nauro_core.constants import NO_DECISIONS_TO_CHECK as NO_DECISIONS_TO_CHECK

--- a/uv.lock
+++ b/uv.lock
@@ -952,6 +952,7 @@ dependencies = [
 [package.optional-dependencies]
 dev = [
     { name = "hatchling" },
+    { name = "import-linter" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "ruff" },
@@ -965,6 +966,7 @@ requires-dist = [
     { name = "filelock", specifier = ">=3.29.5" },
     { name = "hatchling", marker = "extra == 'dev'" },
     { name = "httpx", specifier = ">=0.24" },
+    { name = "import-linter", marker = "extra == 'dev'", specifier = "==2.12" },
     { name = "mcp", specifier = ">=1.0,<2" },
     { name = "mypy", marker = "extra == 'dev'", specifier = "==2.1.0" },
     { name = "nauro-core", editable = "packages/nauro-core" },


### PR DESCRIPTION
## Why

The nauro package has a dependency ladder (cli over mcp over templates over the artifact packages over sync over store and auth over the foundations) that nothing enforced, so upward imports kept appearing.

## What changed

- `packages/nauro/.importlinter` gains two layers contracts: one ordering the packages, one keeping the twenty store foundation modules below auth. Package-level layers constrain any store module added later without listing it.
- Twenty ignore lines name the upward edges that only later moves can cut. import-linter fails when an ignore no longer matches, so the list can only shrink.
- import-linter joins the nauro dev extra at the locked 2.12 and the CI job runs the nauro contracts after nauro-core's. The onboarding docstring names its actual consumers.

## Risk / what to review

- The recovery module's edges are spelled out as seven ignores so each must be deleted when fixed. The templates-to-cli ignores disappear with the setup package move; whichever of the two PRs lands second deletes them and adds `nauro.setup` to the ladder.
- The sync writer-credential to sync remote edge is an intra-package cycle a layers contract never sees.

## Test plan

Full pytest for both packages on the rebased branch: 6957 passed, 121 skipped, 12 failed. The 12 are permission-denial tests that fail identically on origin/main under this container's root user. ruff check and format, the ruff and docstring budgets, the single-sourced check and the import-linter contracts all pass. Both new nauro contracts report kept.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U37uJHNuGQ4Nf5aEHLZEr6)_