### PR TITLE
Delete dead handlers and stop three failure paths reporting success

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/status.py
+++ b/packages/nauro/src/nauro/cli/commands/status.py
@@ -314,22 +314,13 @@ def _workflow_artifacts(repo_paths: list[Path]) -> _WorkflowArtifacts:
 
 
 def _collect_wiring(repo_paths: list[Path]) -> _WiringSnapshot:
-    try:
-        repo_commands = [json_mcp.recorded_mcp_commands(repo) for repo in repo_paths]
-    except Exception:
-        repo_commands = []
+    repo_commands = [json_mcp.recorded_mcp_commands(repo) for repo in repo_paths]
     try:
         codex_global, codex_command = codex_config.recorded_codex_command()
     except Exception:
         codex_global, codex_command = False, None
-    try:
-        hook_states = tuple(_repo_codex_hook_state(repo) for repo in repo_paths)
-    except Exception:
-        hook_states = ()
-    try:
-        agents_generated = sum(1 for repo in repo_paths if _repo_has_generated_agents_md(repo))
-    except Exception:
-        agents_generated = 0
+    hook_states = tuple(_repo_codex_hook_state(repo) for repo in repo_paths)
+    agents_generated = sum(1 for repo in repo_paths if _repo_has_generated_agents_md(repo))
     try:
         workflow = _workflow_artifacts(repo_paths)
     except Exception:
@@ -374,10 +365,7 @@ def _probe_commands(
 ) -> dict[str, bool] | None:
     if not commands:
         return None
-    try:
-        return _probe_distinct_commands(set(commands), args=args)
-    except Exception:
-        return None
+    return _probe_distinct_commands(set(commands), args=args)
 
 
 def _mcp_status_line(snapshot: _WiringSnapshot, probes: _WiringProbeResults) -> str:
@@ -435,8 +423,6 @@ def _codex_hooks_status_line(snapshot: _WiringSnapshot, probes: _WiringProbeResu
         return f"  Codex hooks   configured ({detail}; {untrusted})"
     if probes.skipped:
         return f"  Codex hooks   configured ({detail}; liveness not probed)"
-    if probes.hooks is None:
-        return f"  Codex hooks   configured ({detail}; liveness unknown)"
     return f"  Codex hooks   configured ({detail}; command healthy)"
 
 
@@ -542,12 +528,9 @@ def _count_shared_names(project_name: str, project_id: str) -> int:
 
 
 def _repo_paths(project_id: str) -> list[Path]:
-    try:
-        from nauro.store.registry import get_repo_paths
+    from nauro.store.registry import get_repo_paths
 
-        return [Path(path) for path in get_repo_paths(project_id)]
-    except Exception:
-        return []
+    return [Path(path) for path in get_repo_paths(project_id)]
 
 
 @dataclass(frozen=True)

--- a/packages/nauro/src/nauro/cli/integrations/claude_hooks.py
+++ b/packages/nauro/src/nauro/cli/integrations/claude_hooks.py
@@ -269,20 +269,16 @@ class _SharedStrip(Enum):
 
 def _strip_hook_from_file(settings_path: Path) -> _SharedStrip | SharedStripFailed:
     """Strip the nauro hook entry from one shared settings file.
-    A file that is absent, unreadable, or off-shape is UNMANAGED and left untouched: Nauro does
-    not own that layer. A write that fails after the entry was found is reported, never hidden.
+    An absent file or one that is not a JSON object is UNMANAGED and left untouched: Nauro does
+    not own that layer. One that cannot be read, parsed or rewritten is reported, never hidden.
     """
     if not settings_path.exists():
         return _SharedStrip.UNMANAGED
     try:
-        text = settings_path.read_text(encoding="utf-8")
-    except UnicodeDecodeError:
-        return _SharedStrip.UNMANAGED
+        raw = json.loads(settings_path.read_text(encoding="utf-8"))
     except OSError as exc:
         return SharedStripFailed(detail=f"could not check it for a nauro hook: {exc}")
-    try:
-        raw = json.loads(text)
-    except json.JSONDecodeError as exc:
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
         return SharedStripFailed(detail=f"could not parse it for a nauro hook: {exc}")
     if not isinstance(raw, dict):
         return _SharedStrip.UNMANAGED

--- a/packages/nauro/src/nauro/cli/integrations/claude_hooks.py
+++ b/packages/nauro/src/nauro/cli/integrations/claude_hooks.py
@@ -15,7 +15,7 @@ from nauro.cli.git_hygiene import (
     wiring_path_is_tracked,
 )
 from nauro.cli.integrations._json_config import write_json_config
-from nauro.cli.integrations.outcomes import ClaudeHookKind, ClaudeHookOutcome
+from nauro.cli.integrations.outcomes import ClaudeHookKind, ClaudeHookOutcome, SharedStripFailed
 from nauro.cli.nauro_command import _find_nauro_command
 from nauro.store.write_safety import find_symlink
 
@@ -188,12 +188,13 @@ def _add_hook_entry(settings_path: Path, raw: dict, repo: Path) -> ClaudeHookOut
     # depend on a content change (a repo wired by an older run can be
     # byte-identical yet still unignored).
     if _has_nauro_hook(settings):
-        legacy_cleaned = _strip_hook_from_file(_settings_shared_path(repo)) is True
+        shared = _strip_hook_from_file(_settings_shared_path(repo))
         return ClaudeHookOutcome(
             ClaudeHookKind.ALREADY_PRESENT,
             repo,
             gitignore=ensure_wiring_ignored(repo, SETTINGS_LOCAL_REL),
-            legacy_cleaned=legacy_cleaned,
+            legacy_cleaned=shared is _SharedStrip.REMOVED,
+            shared_strip=_shared_strip_failure(shared),
         )
 
     # The parse guarantees hooks is absent or an object and UserPromptSubmit is
@@ -204,7 +205,7 @@ def _add_hook_entry(settings_path: Path, raw: dict, repo: Path) -> ClaudeHookOut
     write_json_config(settings_path, raw)
     # Strip the stale shared-layer entry only after the replacement is durably
     # on disk, so an interrupted run can never leave the repo with no hook.
-    legacy_cleaned = _strip_hook_from_file(_settings_shared_path(repo)) is True
+    shared = _strip_hook_from_file(_settings_shared_path(repo))
     ignore_result = ensure_wiring_ignored(repo, SETTINGS_LOCAL_REL)
     git_warnings = tuple(public_surface_git_warnings(repo, SETTINGS_LOCAL_REL))
     return ClaudeHookOutcome(
@@ -212,7 +213,8 @@ def _add_hook_entry(settings_path: Path, raw: dict, repo: Path) -> ClaudeHookOut
         repo,
         git_warnings=git_warnings,
         gitignore=ignore_result,
-        legacy_cleaned=legacy_cleaned,
+        legacy_cleaned=shared is _SharedStrip.REMOVED,
+        shared_strip=_shared_strip_failure(shared),
     )
 
 
@@ -234,9 +236,18 @@ def _remove_hook_entries(repo: Path, settings_path: Path) -> ClaudeHookOutcome:
     else:
         local_removed = False
 
-    legacy_removed = _strip_hook_from_file(_settings_shared_path(repo)) is True
+    shared = _strip_hook_from_file(_settings_shared_path(repo))
     ignore_result = remove_wiring_ignore_entry(repo, SETTINGS_LOCAL_REL)
 
+    if isinstance(shared, SharedStripFailed):
+        return ClaudeHookOutcome(
+            ClaudeHookKind.SHARED_STRIP_FAILED,
+            repo,
+            gitignore=ignore_result,
+            local_cleaned=local_removed,
+            shared_strip=shared,
+        )
+    legacy_removed = shared is _SharedStrip.REMOVED
     if not local_removed and not legacy_removed:
         return ClaudeHookOutcome(ClaudeHookKind.NOTHING_TO_REMOVE, repo, gitignore=ignore_result)
     return ClaudeHookOutcome(
@@ -244,35 +255,51 @@ def _remove_hook_entries(repo: Path, settings_path: Path) -> ClaudeHookOutcome:
         repo,
         gitignore=ignore_result,
         legacy_cleaned=legacy_removed,
+        local_cleaned=local_removed,
     )
 
 
-def _strip_hook_from_file(settings_path: Path) -> bool | None:
-    """Best-effort strip of the nauro hook entry from one settings file.
-    True when an entry was removed, False when none was present, and ``None`` when the file was
-    absent, unreadable, or off-shape and left untouched: Nauro does not own that layer.
+class _SharedStrip(Enum):
+    """What stripping the nauro hook from the shared settings layer found."""
+
+    REMOVED = auto()
+    NOT_PRESENT = auto()
+    UNMANAGED = auto()
+
+
+def _strip_hook_from_file(settings_path: Path) -> _SharedStrip | SharedStripFailed:
+    """Strip the nauro hook entry from one shared settings file.
+    A file that is absent, unreadable, or off-shape is UNMANAGED and left untouched: Nauro does
+    not own that layer. A write that fails after the entry was found is reported, never hidden.
     """
     if not settings_path.exists():
-        return None
+        return _SharedStrip.UNMANAGED
     try:
-        raw = json.loads(settings_path.read_text(encoding="utf-8"))
-    except (UnicodeDecodeError, json.JSONDecodeError, OSError):
-        return None
+        text = settings_path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        return _SharedStrip.UNMANAGED
+    except OSError as exc:
+        return SharedStripFailed(detail=f"could not check it for a nauro hook: {exc}")
+    try:
+        raw = json.loads(text)
+    except json.JSONDecodeError as exc:
+        return SharedStripFailed(detail=f"could not parse it for a nauro hook: {exc}")
     if not isinstance(raw, dict):
-        return None
+        return _SharedStrip.UNMANAGED
     if not _strip_hook_entries(raw):
-        return False
-    # Best-effort covers the write side too: an unwritable shared file must
-    # not abort the surface whose own hook already landed, and the atomic
-    # write's failure leaves the original bytes intact.
+        return _SharedStrip.NOT_PRESENT
     try:
         if raw:
             write_json_config(settings_path, raw)
         else:
             settings_path.unlink()
-    except OSError:
-        return None
-    return True
+    except OSError as exc:
+        return SharedStripFailed(detail=f"the nauro hook is still wired there: {exc}")
+    return _SharedStrip.REMOVED
+
+
+def _shared_strip_failure(shared: _SharedStrip | SharedStripFailed) -> SharedStripFailed | None:
+    return shared if isinstance(shared, SharedStripFailed) else None
 
 
 def _strip_hook_entries(raw: dict) -> bool:

--- a/packages/nauro/src/nauro/cli/integrations/orchestrator.py
+++ b/packages/nauro/src/nauro/cli/integrations/orchestrator.py
@@ -222,14 +222,9 @@ def _all_claude_code_lines(
         except Exception as exc:
             outcomes.append(HandlerErrorOutcome(f"Claude Code MCP ({repo}): error - {exc}"))
     if not remove and _every_repo_mcp_wired(outcomes):
-        try:
-            pruned = _prune_redundant_user_scope_mcp()
-            if pruned:
-                outcomes.append(pruned)
-        except Exception as exc:  # never let cleanup break wiring
-            outcomes.append(
-                HandlerErrorOutcome(f"Claude Code MCP (user-scope cleanup): error - {exc}")
-            )
+        pruned = _prune_redundant_user_scope_mcp()
+        if pruned:
+            outcomes.append(pruned)
     try:
         outcomes.extend(
             materialize_skills_claude_code(

--- a/packages/nauro/src/nauro/cli/integrations/outcomes.py
+++ b/packages/nauro/src/nauro/cli/integrations/outcomes.py
@@ -65,6 +65,15 @@ class ClaudeHookKind(Enum):
     WROTE = auto()
     REMOVED = auto()
     NOTHING_TO_REMOVE = auto()
+    SHARED_STRIP_FAILED = auto()
+
+
+@dataclass(frozen=True)
+class SharedStripFailed:
+    """The shared settings layer could not be cleared of a nauro hook: it was unreadable,
+    unparseable, or unwritable, so the hook may still be wired there."""
+
+    detail: str
 
 
 @dataclass(frozen=True)
@@ -80,6 +89,8 @@ class ClaudeHookOutcome:
     # True when this run also stripped a stale Nauro entry from the shared
     # .claude/settings.json (the hook now lives in .claude/settings.local.json).
     legacy_cleaned: bool = False
+    local_cleaned: bool = False
+    shared_strip: SharedStripFailed | None = None
 
 
 class ClaudeUserConfigKind(Enum):

--- a/packages/nauro/src/nauro/cli/integrations/render.py
+++ b/packages/nauro/src/nauro/cli/integrations/render.py
@@ -146,6 +146,9 @@ def _render_claude_hook(o: ClaudeHookOutcome) -> list[str]:
         if o.legacy_cleaned
         else []
     )
+    shared_strip_failed_add = (
+        [f"    .claude/settings.json - {o.shared_strip.detail}"] if o.shared_strip else []
+    )
     match o.kind:
         case ClaudeHookKind.REFUSED_SYMLINK:
             return [f"  {o.repo}: {o.refusal.message}"]
@@ -166,24 +169,40 @@ def _render_claude_hook(o: ClaudeHookOutcome) -> list[str]:
                 f"  {o.repo}: nauro hook already present in .claude/settings.local.json",
                 *_render_gitignore(o.gitignore),
                 *legacy_cleanup_add,
+                *shared_strip_failed_add,
             ]
         case ClaudeHookKind.WROTE:
             return [
                 f"  {o.repo}: wrote nauro hook to .claude/settings.local.json",
                 *_render_gitignore(o.gitignore),
                 *legacy_cleanup_add,
+                *shared_strip_failed_add,
                 *o.git_warnings,
             ]
         case ClaudeHookKind.NOTHING_TO_REMOVE:
             return [f"  {o.repo}: no nauro hook to remove", *_render_gitignore(o.gitignore)]
-        case ClaudeHookKind.REMOVED:
-            removed_from = (
-                ".claude/settings.local.json and .claude/settings.json"
-                if o.legacy_cleaned
-                else ".claude/settings.local.json"
+        case ClaudeHookKind.SHARED_STRIP_FAILED:
+            local_removed = (
+                [f"  {o.repo}: removed nauro hook from .claude/settings.local.json"]
+                if o.local_cleaned
+                else []
             )
             return [
-                f"  {o.repo}: removed nauro hook from {removed_from}",
+                *local_removed,
+                f"  {o.repo}: .claude/settings.json - {o.shared_strip.detail}",
+                *_render_gitignore(o.gitignore),
+            ]
+        case ClaudeHookKind.REMOVED:
+            layers = [
+                layer
+                for layer, cleaned in (
+                    (".claude/settings.local.json", o.local_cleaned),
+                    (".claude/settings.json", o.legacy_cleaned),
+                )
+                if cleaned
+            ]
+            return [
+                f"  {o.repo}: removed nauro hook from {' and '.join(layers)}",
                 *_render_gitignore(o.gitignore),
             ]
         case _:

--- a/packages/nauro/src/nauro/cli/utils.py
+++ b/packages/nauro/src/nauro/cli/utils.py
@@ -65,19 +65,9 @@ class DisconnectedProjectExit(ProjectResolutionExit):
         super().__init__(RESOLUTION_DISCONNECTED_PROJECT, guidance)
 
 
-def cli_origin() -> OriginDescriptor | None:
-    """Return the origin descriptor stamped on every write-path event from the CLI surface.
-    Total by construction: origin is provenance, never load-bearing for the write, so any
-    failure yields ``None`` rather than raising.
-    """
-    try:
-        return OriginDescriptor(
-            transport="cli",
-            client_name="nauro-cli",
-            client_version=__version__,
-        )
-    except Exception:
-        return None
+def cli_origin() -> OriginDescriptor:
+    """Return the origin descriptor stamped on every write-path event from the CLI surface."""
+    return OriginDescriptor(transport="cli", client_name="nauro-cli", client_version=__version__)
 
 
 def refuse_global_config_collision(repo_root: Path) -> None:

--- a/packages/nauro/src/nauro/mcp/tools.py
+++ b/packages/nauro/src/nauro/mcp/tools.py
@@ -609,7 +609,7 @@ def tool_flag_question(
                     f"decision-{top['number']:03d}: {top['title']}."
                 )
         except Exception:
-            pass
+            logger.debug("similar-decision hint skipped for %s", store_path.name, exc_info=True)
 
     text = question
     if question and context:

--- a/packages/nauro/src/nauro/store/filesystem_store.py
+++ b/packages/nauro/src/nauro/store/filesystem_store.py
@@ -74,13 +74,10 @@ class FilesystemStore:
             atomic_write_text(target, content)
 
     def delete_file(self, path: str) -> None:
-        try:
-            target = self._resolve_within(path)
-        except ValueError:
-            return
-        if not target.exists():
-            return
-        target.unlink()
+        """Remove ``path`` if present; an out-of-store path is an error, as for ``write_file``."""
+        target = self._resolve_within(path)
+        if target.exists():
+            target.unlink()
 
     def list_decisions(self) -> list[str]:
         decisions_dir = self._store_path / DECISIONS_DIR

--- a/packages/nauro/tests/test_cli_status.py
+++ b/packages/nauro/tests/test_cli_status.py
@@ -384,22 +384,6 @@ def test_status_codex_hooks_broken_when_command_is_dead(tmp_path, monkeypatch):
     assert "recorded command won't run" in result.output
 
 
-def test_status_codex_hooks_does_not_claim_health_when_probe_fails(tmp_path, monkeypatch):
-    _setup_project(tmp_path, monkeypatch)
-    _wire_codex_hooks(tmp_path)
-
-    def fail_probe(_commands, _hook_commands):
-        raise OSError("probe unavailable")
-
-    monkeypatch.setattr(status_mod, "_probe_distinct_commands", fail_probe)
-
-    result = runner.invoke(app, ["status"])
-
-    assert result.exit_code == 0
-    assert "Codex hooks   configured (wired in 1/1 repos; liveness unknown)" in result.output
-    assert "command healthy" not in result.output
-
-
 def test_status_codex_hooks_broken_when_event_is_missing(tmp_path, monkeypatch):
     _setup_project(tmp_path, monkeypatch)
     _wire_codex_hooks(tmp_path, events=("SessionStart",))

--- a/packages/nauro/tests/test_flag_question_hint.py
+++ b/packages/nauro/tests/test_flag_question_hint.py
@@ -6,6 +6,7 @@ similarity). These tests pin the threshold behavior and the named constants
 that replaced the previously-inlined literals.
 """
 
+import logging
 from pathlib import Path
 from unittest.mock import patch
 
@@ -62,6 +63,20 @@ def test_hint_absent_below_threshold(store):
         result = tool_flag_question(store, question="Should we cache hot reads?")
 
     assert "hint" not in result
+
+
+def test_hint_failure_is_logged_and_flag_still_lands(store, caplog):
+    """A hint lookup that fails is logged at debug and the question is still flagged."""
+    caplog.set_level(logging.DEBUG, logger="nauro.mcp.tools")
+    with (
+        patch("nauro.store.reader._list_decisions", side_effect=RuntimeError("index gone")),
+        patch("nauro.mcp.tools._try_push"),
+    ):
+        result = tool_flag_question(store, question="Should we cache hot reads?")
+
+    assert "hint" not in result
+    assert result["store"] == "local"
+    assert any("similar-decision hint skipped" in record.message for record in caplog.records)
 
 
 def test_pointer_flag_prefixes_constant():

--- a/packages/nauro/tests/test_integration_outcomes.py
+++ b/packages/nauro/tests/test_integration_outcomes.py
@@ -33,6 +33,7 @@ from nauro.cli.integrations.outcomes import (
     LegacyKind,
     LegacyOutcome,
     RawLine,
+    SharedStripFailed,
     SkillKind,
     SkillOutcome,
 )
@@ -296,11 +297,68 @@ RENDER_CASES = [
         [f"  {REPO}: no nauro hook to remove"],
     ),
     (
-        ClaudeHookOutcome(ClaudeHookKind.REMOVED, REPO),
+        ClaudeHookOutcome(
+            ClaudeHookKind.SHARED_STRIP_FAILED,
+            REPO,
+            shared_strip=SharedStripFailed(
+                "the nauro hook is still wired there: read-only file system"
+            ),
+        ),
+        [
+            f"  {REPO}: .claude/settings.json - the nauro hook is still wired there: "
+            "read-only file system"
+        ],
+    ),
+    (
+        ClaudeHookOutcome(
+            ClaudeHookKind.SHARED_STRIP_FAILED,
+            REPO,
+            shared_strip=SharedStripFailed(
+                "the nauro hook is still wired there: read-only file system"
+            ),
+            local_cleaned=True,
+        ),
+        [
+            f"  {REPO}: removed nauro hook from .claude/settings.local.json",
+            f"  {REPO}: .claude/settings.json - the nauro hook is still wired there: "
+            "read-only file system",
+        ],
+    ),
+    (
+        ClaudeHookOutcome(
+            ClaudeHookKind.WROTE,
+            REPO,
+            shared_strip=SharedStripFailed("could not check it for a nauro hook: EACCES"),
+        ),
+        [
+            f"  {REPO}: wrote nauro hook to .claude/settings.local.json",
+            "    .claude/settings.json - could not check it for a nauro hook: EACCES",
+        ],
+    ),
+    (
+        ClaudeHookOutcome(
+            ClaudeHookKind.ALREADY_PRESENT,
+            REPO,
+            shared_strip=SharedStripFailed(
+                "the nauro hook is still wired there: read-only file system"
+            ),
+        ),
+        [
+            f"  {REPO}: nauro hook already present in .claude/settings.local.json",
+            "    .claude/settings.json - the nauro hook is still wired there: "
+            "read-only file system",
+        ],
+    ),
+    (
+        ClaudeHookOutcome(ClaudeHookKind.REMOVED, REPO, local_cleaned=True),
         [f"  {REPO}: removed nauro hook from .claude/settings.local.json"],
     ),
     (
         ClaudeHookOutcome(ClaudeHookKind.REMOVED, REPO, legacy_cleaned=True),
+        [f"  {REPO}: removed nauro hook from .claude/settings.json"],
+    ),
+    (
+        ClaudeHookOutcome(ClaudeHookKind.REMOVED, REPO, local_cleaned=True, legacy_cleaned=True),
         [
             f"  {REPO}: removed nauro hook from .claude/settings.local.json "
             "and .claude/settings.json"

--- a/packages/nauro/tests/test_setup_atomic_writes.py
+++ b/packages/nauro/tests/test_setup_atomic_writes.py
@@ -297,10 +297,10 @@ def test_interrupted_write_leaves_target_and_no_temps(driver, tmp_path: Path, mo
     assert _tmp_siblings(target) == []
 
 
-def test_interrupted_legacy_strip_soft_fails(tmp_path: Path, monkeypatch):
-    """The shared-layer legacy strip is best-effort on the write side too: an
-    interrupted rewrite leaves the original bytes, no temps, and no exception —
-    the surface reports its own outcome instead of aborting."""
+def test_interrupted_legacy_strip_reports_failure(tmp_path: Path, monkeypatch):
+    """An interrupted shared-layer rewrite leaves the original bytes and no temps,
+    and the surface reports the failed removal instead of aborting or claiming
+    there was nothing to remove."""
     from nauro.cli.integrations.outcomes import ClaudeHookKind
 
     target = _seed_file(
@@ -316,7 +316,9 @@ def test_interrupted_legacy_strip_soft_fails(tmp_path: Path, monkeypatch):
 
     outcome = materialize_hooks_claude_code(tmp_path / "repo", remove=True)
 
-    assert outcome.kind is ClaudeHookKind.NOTHING_TO_REMOVE
+    assert outcome.kind is ClaudeHookKind.SHARED_STRIP_FAILED
+    assert outcome.shared_strip is not None
+    assert outcome.shared_strip.detail == "the nauro hook is still wired there: replace failed"
     assert outcome.legacy_cleaned is False
     assert target.read_bytes() == before
     assert _tmp_siblings(target) == []

--- a/packages/nauro/tests/test_setup_hooks.py
+++ b/packages/nauro/tests/test_setup_hooks.py
@@ -866,10 +866,79 @@ def test_add_survives_unwritable_shared_settings(tmp_path: Path, monkeypatch):
 
     assert line.kind is ClaudeHookKind.WROTE
     assert line.legacy_cleaned is False
+    assert line.shared_strip is not None
+    assert line.shared_strip.detail == "the nauro hook is still wired there: read-only file system"
     assert line.gitignore is not None
     assert line.gitignore.kind is GitIgnoreKind.ADDED
     assert len(_nauro_entries(json.loads(_settings(repo).read_text()))) == 1
     assert shared.read_text(encoding="utf-8") == before
+
+
+def test_remove_reports_unwritable_shared_settings(tmp_path: Path, monkeypatch):
+    """A shared file that still holds the nauro hook but cannot be rewritten is
+    reported as a failed removal, never as nothing to remove."""
+    import nauro.cli.integrations.claude_hooks as claude_hooks_mod
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    shared = _legacy_shared_with_nauro_hook(repo, extra={"model": "claude-opus"})
+    before = shared.read_text(encoding="utf-8")
+    real_write = claude_hooks_mod.write_json_config
+
+    def failing_shared_write(path: Path, raw: dict) -> None:
+        if path.name == "settings.json":
+            raise OSError("read-only file system")
+        real_write(path, raw)
+
+    monkeypatch.setattr(claude_hooks_mod, "write_json_config", failing_shared_write)
+
+    line = materialize_hooks_claude_code(repo, remove=True)
+
+    assert line.kind is ClaudeHookKind.SHARED_STRIP_FAILED
+    assert line.shared_strip is not None
+    assert line.shared_strip.detail == "the nauro hook is still wired there: read-only file system"
+    assert line.legacy_cleaned is False
+    assert line.local_cleaned is False
+    assert shared.read_text(encoding="utf-8") == before
+    assert len(_nauro_entries(json.loads(before))) == 1
+
+
+def test_remove_reports_unreadable_shared_settings(tmp_path: Path):
+    """A shared settings path that exists but cannot be read is reported as a
+    failed removal, never as nothing to remove: the hook may still be wired."""
+    repo = tmp_path / "repo"
+    (repo / ".claude" / "settings.json").mkdir(parents=True)
+
+    line = materialize_hooks_claude_code(repo, remove=True)
+
+    assert line.kind is ClaudeHookKind.SHARED_STRIP_FAILED
+    assert line.shared_strip is not None
+    assert line.shared_strip.detail.startswith("could not check it for a nauro hook: ")
+
+
+def test_remove_keeps_the_local_removal_when_the_shared_strip_fails(tmp_path: Path, monkeypatch):
+    """The local hook removal is reported alongside the shared-layer failure."""
+    import nauro.cli.integrations.claude_hooks as claude_hooks_mod
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    materialize_hooks_claude_code(repo, remove=False)
+    assert len(_nauro_entries(json.loads(_settings(repo).read_text()))) == 1
+    # A stale shared-layer copy that the add never saw, and that cannot be rewritten.
+    _legacy_shared_with_nauro_hook(repo, extra={"model": "claude-opus"})
+
+    def failing_shared_write(path: Path, raw: dict) -> None:
+        if path.name == "settings.json":
+            raise OSError("read-only file system")
+        raise AssertionError(f"unexpected write to {path}")
+
+    monkeypatch.setattr(claude_hooks_mod, "write_json_config", failing_shared_write)
+
+    line = materialize_hooks_claude_code(repo, remove=True)
+
+    assert line.kind is ClaudeHookKind.SHARED_STRIP_FAILED
+    assert line.local_cleaned is True
+    assert not _settings(repo).exists()
 
 
 def test_strip_leaves_null_hooks_matcher_untouched(tmp_path: Path):

--- a/packages/nauro/tests/test_setup_hooks.py
+++ b/packages/nauro/tests/test_setup_hooks.py
@@ -916,6 +916,22 @@ def test_remove_reports_unreadable_shared_settings(tmp_path: Path):
     assert line.shared_strip.detail.startswith("could not check it for a nauro hook: ")
 
 
+def test_remove_reports_undecodable_shared_settings(tmp_path: Path):
+    """A shared settings file that is not UTF-8 text may still hold the hook, so it is reported
+    like any other file Nauro cannot parse, and its bytes are left untouched."""
+    repo = tmp_path / "repo"
+    shared = repo / ".claude" / "settings.json"
+    shared.parent.mkdir(parents=True)
+    shared.write_bytes(b'\xff\xfe{"hooks": {}}')
+
+    line = materialize_hooks_claude_code(repo, remove=True)
+
+    assert line.kind is ClaudeHookKind.SHARED_STRIP_FAILED
+    assert line.shared_strip is not None
+    assert line.shared_strip.detail.startswith("could not parse it for a nauro hook: ")
+    assert shared.read_bytes() == b'\xff\xfe{"hooks": {}}'
+
+
 def test_remove_keeps_the_local_removal_when_the_shared_strip_fails(tmp_path: Path, monkeypatch):
     """The local hook removal is reported alongside the shared-layer failure."""
     import nauro.cli.integrations.claude_hooks as claude_hooks_mod

--- a/packages/nauro/tests/test_store.py
+++ b/packages/nauro/tests/test_store.py
@@ -895,15 +895,23 @@ def test_filesystem_store_write_file_rejects_traversal(tmp_path):
     assert not outside.exists()
 
 
-def test_filesystem_store_delete_file_ignores_traversal(tmp_path):
-    """delete_file never reaches outside the store; a traversal path is a no-op
-    that leaves the sibling file intact."""
+def test_filesystem_store_delete_file_rejects_traversal(tmp_path):
+    """delete_file fails loud on a traversal path, as write_file does, and never
+    reaches the sibling file outside the store."""
     store_root = tmp_path / "store"
     store_root.mkdir()
     victim = tmp_path / "victim.md"
     victim.write_text("keep me")
-    FilesystemStore(store_root).delete_file("../victim.md")
+    with pytest.raises(ValueError):
+        FilesystemStore(store_root).delete_file("../victim.md")
     assert victim.read_text() == "keep me"
+
+
+def test_filesystem_store_delete_file_absent_is_noop(tmp_path):
+    """Deleting a path inside the store that does not exist is a silent no-op."""
+    store_root = tmp_path / "store"
+    store_root.mkdir()
+    FilesystemStore(store_root).delete_file("missing.md")
 
 
 def test_filesystem_store_read_file_returns_none_on_traversal(tmp_path):

--- a/scripts/ruff_budget_baseline.jsonl
+++ b/scripts/ruff_budget_baseline.jsonl
@@ -71,8 +71,8 @@
 {"path":"packages/nauro/src/nauro/cli/commands/link.py","rule":"PLR0915","count":1}
 {"path":"packages/nauro/src/nauro/cli/commands/repair.py","rule":"PERF401","count":2}
 {"path":"packages/nauro/src/nauro/cli/commands/serve.py","rule":"B008","count":1}
-{"path":"packages/nauro/src/nauro/cli/commands/status.py","rule":"BLE001","count":14}
-{"path":"packages/nauro/src/nauro/cli/commands/status.py","rule":"PLR0911","count":2}
+{"path":"packages/nauro/src/nauro/cli/commands/status.py","rule":"BLE001","count":9}
+{"path":"packages/nauro/src/nauro/cli/commands/status.py","rule":"PLR0911","count":1}
 {"path":"packages/nauro/src/nauro/cli/commands/status.py","rule":"S112","count":1}
 {"path":"packages/nauro/src/nauro/cli/commands/status.py","rule":"TRY300","count":1}
 {"path":"packages/nauro/src/nauro/cli/commands/sync.py","rule":"B905","count":1}
@@ -84,6 +84,7 @@
 {"path":"packages/nauro/src/nauro/cli/git_hygiene.py","rule":"PLR0912","count":1}
 {"path":"packages/nauro/src/nauro/cli/integrations/claude_bridge.py","rule":"PLR0911","count":2}
 {"path":"packages/nauro/src/nauro/cli/integrations/claude_hooks.py","rule":"C901","count":1}
+{"path":"packages/nauro/src/nauro/cli/integrations/claude_hooks.py","rule":"PLR0911","count":1}
 {"path":"packages/nauro/src/nauro/cli/integrations/claude_hooks.py","rule":"PLR0912","count":1}
 {"path":"packages/nauro/src/nauro/cli/integrations/claude_hooks.py","rule":"PLW2901","count":1}
 {"path":"packages/nauro/src/nauro/cli/integrations/claude_user_config.py","rule":"PLR0911","count":1}
@@ -100,12 +101,10 @@
 {"path":"packages/nauro/src/nauro/cli/integrations/json_mcp.py","rule":"S112","count":1}
 {"path":"packages/nauro/src/nauro/cli/integrations/legacy.py","rule":"RET505","count":1}
 {"path":"packages/nauro/src/nauro/cli/integrations/orchestrator.py","rule":"B905","count":2}
-{"path":"packages/nauro/src/nauro/cli/integrations/orchestrator.py","rule":"BLE001","count":17}
+{"path":"packages/nauro/src/nauro/cli/integrations/orchestrator.py","rule":"BLE001","count":16}
 {"path":"packages/nauro/src/nauro/cli/integrations/orchestrator.py","rule":"C901","count":2}
-{"path":"packages/nauro/src/nauro/cli/integrations/orchestrator.py","rule":"PLR0912","count":1}
 {"path":"packages/nauro/src/nauro/cli/integrations/render.py","rule":"PLR0911","count":9}
 {"path":"packages/nauro/src/nauro/cli/nauro_command.py","rule":"SIM103","count":1}
-{"path":"packages/nauro/src/nauro/cli/utils.py","rule":"BLE001","count":1}
 {"path":"packages/nauro/src/nauro/cli/utils.py","rule":"PLR0912","count":1}
 {"path":"packages/nauro/src/nauro/graph/html_render.py","rule":"C901","count":1}
 {"path":"packages/nauro/src/nauro/graph/html_render.py","rule":"PERF401","count":1}
@@ -122,7 +121,6 @@
 {"path":"packages/nauro/src/nauro/mcp/tools.py","rule":"C901","count":2}
 {"path":"packages/nauro/src/nauro/mcp/tools.py","rule":"PLR0911","count":1}
 {"path":"packages/nauro/src/nauro/mcp/tools.py","rule":"PLR0912","count":1}
-{"path":"packages/nauro/src/nauro/mcp/tools.py","rule":"S110","count":1}
 {"path":"packages/nauro/src/nauro/store/generation_authority.py","rule":"TRY300","count":1}
 {"path":"packages/nauro/src/nauro/store/generation_authority.py","rule":"TRY301","count":1}
 {"path":"packages/nauro/src/nauro/store/generation_installation.py","rule":"BLE001","count":3}


### PR DESCRIPTION
## Why

Seven handlers caught exceptions their callees cannot raise, and three failure paths reported success: a Claude Code hook whose shared settings file could not be read or rewritten rendered as "no nauro hook to remove", `delete_file` swallowed the traversal guard that `write_file` fails loud on, and the flag_question similar-decision hint swallowed every failure silently.

## What changed

- The four status inspectors, the liveness probe handler, the user-scope prune handler and the CLI origin handler are deleted; the Codex hooks row loses a liveness-unknown branch nothing could reach, and the one test that fabricated the impossible raise goes with it.
- The shared-layer hook strip returns a typed result carried on the outcome. Removal surfaces a shared-strip failure that keeps the local removal visible, the add path renders it as a warning, and the REMOVED line names only the layers a hook was actually removed from. A shared file Nauro cannot decode is reported like one it cannot parse.
- `FilesystemStore.delete_file` raises the same ValueError as `write_file` on traversal. The similar-decision hint logs at debug like the other degraded steps.
- The ruff budget baseline drops nine findings.

## Deferred

An unreadable registry cannot be reported from the status lookup: the cloud-mode read crashes first and corrupt JSON is swallowed inside the registry loader. That belongs with a typed read result at the registry boundary.

## Test plan

Full pytest for both packages on the rebased branch: 6967 passed, 121 skipped, 12 failed. The 12 are permission-denial tests that fail identically on origin/main under this container's root user. ruff check and format, the ruff and docstring budgets, the single-sourced check and the import-linter contracts all pass.