### PR TITLE
Extract the judgment commit contract into its own kernel module

### DIFF
--- a/packages/nauro-core/src/nauro_core/operations/_commit_contract.py
+++ b/packages/nauro-core/src/nauro_core/operations/_commit_contract.py
@@ -1,0 +1,1065 @@
+"""Contract types and helpers shared by the hosted judgment commit phases."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from typing import Annotated, Literal, TypeAlias
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    StrictInt,
+    StrictStr,
+    TypeAdapter,
+    ValidationError,
+    computed_field,
+    field_validator,
+    model_validator,
+)
+
+from nauro_core.constants import MAX_RATIONALE_LENGTH, MAX_TITLE_LENGTH
+from nauro_core.decision_model import (
+    Decision,
+    parse_decision,
+)
+from nauro_core.identifiers import IdentifierKind, validate_identifier
+from nauro_core.operations._decision_transitions import (
+    DecisionProvenance,
+)
+from nauro_core.operations.results import ErrorPayload, ProposeDecisionResult, RelatedDecision
+from nauro_core.protected_generation_membership import (
+    is_hosted_snapshot_content_member,
+    validate_protected_generation_path,
+)
+from nauro_core.provenance import validate_commit_sha, validate_utc_timestamp
+from nauro_core.snapshot import serialize_snapshot
+from nauro_core.snapshot_references import snapshot_descriptor
+from nauro_core.validation import compute_hash, normalize_title
+
+_SHA256_HEX_LENGTH = 64
+
+
+class JudgmentCommitError(ValueError):
+    """Base class for deterministic judgment-commit planning failures."""
+
+
+class CanonicalPayloadRejected(JudgmentCommitError):
+    """Approved payload bytes are invalid or noncanonical."""
+
+
+class ApprovalAttestationRejected(JudgmentCommitError):
+    """Approval attestation conflicts with the approved payload."""
+
+
+class ApprovedPayloadDigestMismatch(JudgmentCommitError):
+    """The checked expected digest does not match the approved bytes."""
+
+
+class ApprovedBaseStale(JudgmentCommitError):
+    """The approved base is not the observed committed generation."""
+
+
+class CommittedGenerationCorrupt(JudgmentCommitError):
+    """The committed artifact corpus violates generation invariants."""
+
+
+class ProposalRejected(JudgmentCommitError):
+    """Proposal evaluation produced the existing rejected result shape."""
+
+    def __init__(self, result: ProposeDecisionResult) -> None:
+        self.result = result
+        super().__init__(result.assessment)
+
+
+class ClaimObservationError(JudgmentCommitError):
+    """Claim observations cannot finalize the prepared plan."""
+
+
+class MissingClaimObservation(ClaimObservationError):
+    pass
+
+
+class UnexpectedClaimObservation(ClaimObservationError):
+    pass
+
+
+class DuplicateClaimObservation(ClaimObservationError):
+    pass
+
+
+class MalformedClaimObservation(ClaimObservationError):
+    pass
+
+
+class MismatchedClaimObservation(ClaimObservationError):
+    pass
+
+
+class ClaimUnavailable(ClaimObservationError):
+    pass
+
+
+class TitleClaimConflict(ClaimObservationError):
+    pass
+
+
+class ContentClaimConflict(ClaimObservationError):
+    pass
+
+
+def sha256_hex(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def validate_sha256(value: object, *, field: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{field} must be a lowercase SHA-256 digest.")
+    if len(value) != _SHA256_HEX_LENGTH or any(char not in "0123456789abcdef" for char in value):
+        raise ValueError(f"{field} must be a lowercase SHA-256 digest.")
+    return value
+
+
+class _FrozenModel(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+
+class _ImmutableResultList(list):
+    def _reject_mutation(self, *args: object, **kwargs: object) -> None:
+        raise TypeError("immutable result sequence")
+
+    __delitem__ = _reject_mutation
+    __iadd__ = _reject_mutation
+    __imul__ = _reject_mutation
+    __setitem__ = _reject_mutation
+    append = _reject_mutation
+    clear = _reject_mutation
+    extend = _reject_mutation
+    insert = _reject_mutation
+    pop = _reject_mutation
+    remove = _reject_mutation
+    reverse = _reject_mutation
+    sort = _reject_mutation
+
+
+class _CommittedResultProjection(_FrozenModel):
+    status: Literal["confirmed", "rejected"]
+    tier: StrictInt
+    operation: Literal["add", "update", "supersede", "reject"]
+    similar_decisions: tuple[RelatedDecision, ...]
+    assessment: StrictStr
+    decision_id: StrictStr | None
+    touched_decisions: tuple[StrictStr, ...]
+    resolved_questions: tuple[StrictStr, ...]
+    relocated_ids: tuple[StrictStr, ...] | None
+    skipped_prose_ids: tuple[StrictStr, ...] | None
+    error: ErrorPayload | None
+
+    @classmethod
+    def from_result(cls, result: ProposeDecisionResult) -> _CommittedResultProjection:
+        return cls.model_validate(result.model_dump())
+
+    def materialize(self) -> ProposeDecisionResult:
+        return ProposeDecisionResult.model_construct(
+            status=self.status,
+            tier=self.tier,
+            operation=self.operation,
+            similar_decisions=_ImmutableResultList(self.similar_decisions),
+            assessment=self.assessment,
+            decision_id=self.decision_id,
+            touched_decisions=_ImmutableResultList(self.touched_decisions),
+            resolved_questions=_ImmutableResultList(self.resolved_questions),
+            relocated_ids=self.relocated_ids,
+            skipped_prose_ids=self.skipped_prose_ids,
+            error=self.error,
+        )
+
+
+class RejectedSelection(_FrozenModel):
+    alternative: StrictStr
+    reason: StrictStr
+
+    @field_validator("alternative", "reason")
+    @classmethod
+    def _nonempty(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("rejected alternative and reason must be non-empty.")
+        return value
+
+
+class JudgmentContent(_FrozenModel):
+    operation: Literal["add", "update", "supersede"]
+    affected_decision_id: StrictStr | None
+    title: StrictStr | None
+    rationale: StrictStr
+    rejected: tuple[RejectedSelection, ...]
+    confidence: Literal["high", "medium", "low"] | None
+    decision_type: (
+        Literal["architecture", "api_design", "infrastructure", "pattern", "refactor", "data_model"]
+        | None
+    )
+    reversibility: Literal["easy", "moderate", "hard"] | None
+    files_affected: tuple[StrictStr, ...]
+    resolves_questions: tuple[StrictStr, ...]
+
+    @model_validator(mode="after")
+    def _validate_operation_fields(self) -> JudgmentContent:
+        if len(self.rationale) > MAX_RATIONALE_LENGTH:
+            raise ValueError(f"rationale exceeds {MAX_RATIONALE_LENGTH} characters.")
+        if len(set(self.resolves_questions)) != len(self.resolves_questions):
+            raise ValueError("resolves_questions contains duplicate ids.")
+        if any(not value for value in self.files_affected):
+            raise ValueError("files_affected values must be non-empty strings.")
+        if self.operation == "add":
+            if self.affected_decision_id is not None:
+                raise ValueError("add requires affected_decision_id to be null.")
+        elif not self.affected_decision_id:
+            raise ValueError(f"{self.operation} requires affected_decision_id.")
+        if self.operation == "update":
+            return self
+        if self.title is not None and len(self.title) > MAX_TITLE_LENGTH:
+            raise ValueError(f"title exceeds {MAX_TITLE_LENGTH} characters.")
+        if self.confidence is None:
+            raise ValueError(f"{self.operation} requires an effective confidence value.")
+        return self
+
+
+class HostedPreTeamApprovalPayloadV1(_FrozenModel):
+    payload_schema: Literal["nauro.judgment_commit.pre_team.v1"]
+    approval_mode: Literal["pre_team_session"]
+    base_generation_id: StrictStr
+    base_decision_counter: StrictInt = Field(ge=0)
+    proposed_base_commit: None
+    content: JudgmentContent
+
+    @field_validator("base_generation_id")
+    @classmethod
+    def _generation_id(cls, value: str) -> str:
+        return validate_identifier(IdentifierKind.ulid, value, field="base_generation_id")
+
+
+class TeamProposalPayloadV1(_FrozenModel):
+    payload_schema: Literal["nauro.judgment_commit.team_proposal.v1"]
+    approval_mode: Literal["team_ratification"]
+    proposal_id: StrictStr
+    proposal_revision: StrictInt = Field(ge=1)
+    proposed_by: StrictStr
+    contributor_operation_id: StrictStr
+    base_generation_id: StrictStr
+    base_decision_counter: StrictInt = Field(ge=0)
+    proposed_base_commit: StrictStr | None
+    content: JudgmentContent
+
+    @field_validator("proposal_id", "proposed_by", "base_generation_id")
+    @classmethod
+    def _ulids(cls, value: str, info) -> str:
+        return validate_identifier(IdentifierKind.ulid, value, field=info.field_name)
+
+    @field_validator("contributor_operation_id")
+    @classmethod
+    def _operation_id(cls, value: str) -> str:
+        return validate_identifier(
+            IdentifierKind.operation_id, value, field="contributor_operation_id"
+        )
+
+    @field_validator("proposed_base_commit")
+    @classmethod
+    def _base_commit(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return validate_commit_sha(value, field="proposed_base_commit")
+
+
+ApprovedPayload: TypeAlias = Annotated[
+    HostedPreTeamApprovalPayloadV1 | TeamProposalPayloadV1,
+    Field(discriminator="payload_schema"),
+]
+_PAYLOAD_ADAPTER = TypeAdapter(ApprovedPayload)
+
+
+class PreTeamApprovalAttestation(_FrozenModel):
+    actor_id: StrictStr
+    operation_id: StrictStr
+    request_received_at: StrictStr
+
+    @field_validator("actor_id")
+    @classmethod
+    def _actor_id(cls, value: str) -> str:
+        return validate_identifier(IdentifierKind.ulid, value, field="actor_id")
+
+    @field_validator("operation_id")
+    @classmethod
+    def _operation_id(cls, value: str) -> str:
+        return validate_identifier(IdentifierKind.operation_id, value, field="operation_id")
+
+    @field_validator("request_received_at")
+    @classmethod
+    def _timestamp(cls, value: str) -> str:
+        return validate_utc_timestamp(value, field="request_received_at")
+
+
+class TeamRatificationAttestation(_FrozenModel):
+    approved_by: StrictStr
+    approved_at: StrictStr
+    ratification_action_id: StrictStr
+
+    @field_validator("approved_by", "ratification_action_id")
+    @classmethod
+    def _ulids(cls, value: str, info) -> str:
+        return validate_identifier(IdentifierKind.ulid, value, field=info.field_name)
+
+    @field_validator("approved_at")
+    @classmethod
+    def _timestamp(cls, value: str) -> str:
+        return validate_utc_timestamp(value, field="approved_at")
+
+
+ApprovalAttestation: TypeAlias = PreTeamApprovalAttestation | TeamRatificationAttestation
+
+
+class CommittedArtifact(_FrozenModel):
+    path: StrictStr
+    content: bytes
+    manifest_artifact_digest: StrictStr
+
+    @model_validator(mode="after")
+    def _validate_artifact(self) -> CommittedArtifact:
+        validate_protected_generation_path(self.path)
+        validate_sha256(self.manifest_artifact_digest, field="manifest_artifact_digest")
+        if sha256_hex(self.content) != self.manifest_artifact_digest:
+            raise ValueError(f"artifact digest mismatch for {self.path!r}.")
+        return self
+
+
+class CommittedGeneration(_FrozenModel):
+    generation_id: StrictStr
+    decision_counter: StrictInt = Field(ge=0)
+    observed_manifest_digest: StrictStr
+    artifacts: tuple[CommittedArtifact, ...]
+
+    @field_validator("generation_id")
+    @classmethod
+    def _generation_id(cls, value: str) -> str:
+        return validate_identifier(IdentifierKind.ulid, value, field="generation_id")
+
+    @field_validator("observed_manifest_digest")
+    @classmethod
+    def _manifest_digest(cls, value: str) -> str:
+        return validate_sha256(value, field="observed_manifest_digest")
+
+    @model_validator(mode="after")
+    def _unique_paths(self) -> CommittedGeneration:
+        paths = [artifact.path for artifact in self.artifacts]
+        if len(set(paths)) != len(paths):
+            raise ValueError("committed generation contains duplicate artifact paths.")
+        return self
+
+
+class PreparedBase(_FrozenModel):
+    generation_id: StrictStr
+    decision_counter: StrictInt = Field(ge=0)
+    observed_manifest_digest: StrictStr
+
+    @field_validator("generation_id")
+    @classmethod
+    def _generation_id(cls, value: str) -> str:
+        return validate_identifier(IdentifierKind.ulid, value, field="generation_id")
+
+    @field_validator("observed_manifest_digest")
+    @classmethod
+    def _manifest_digest(cls, value: str) -> str:
+        return validate_sha256(value, field="observed_manifest_digest")
+
+
+class PlannedArtifact(_FrozenModel):
+    path: StrictStr
+    content: bytes
+
+    @field_validator("path")
+    @classmethod
+    def _path(cls, value: str) -> str:
+        return validate_protected_generation_path(value)
+
+    @computed_field
+    @property
+    def sha256(self) -> str:
+        return sha256_hex(self.content)
+
+    @computed_field
+    @property
+    def length(self) -> int:
+        return len(self.content)
+
+
+class PlannedSnapshot(_FrozenModel):
+    content: bytes
+
+    @computed_field
+    @property
+    def sha256(self) -> str:
+        return sha256_hex(self.content)
+
+    @computed_field
+    @property
+    def length(self) -> int:
+        return len(self.content)
+
+
+class PrimaryDecision(_FrozenModel):
+    decision_id: StrictStr
+    path: StrictStr
+    sha256: StrictStr
+
+    @field_validator("sha256")
+    @classmethod
+    def _digest(cls, value: str) -> str:
+        return validate_sha256(value, field="primary_decision.sha256")
+
+    @model_validator(mode="after")
+    def _path_matches_id(self) -> PrimaryDecision:
+        if self.path != f"decisions/{self.decision_id}.md":
+            raise ValueError("primary decision path must derive from decision_id.")
+        return self
+
+
+def _validate_normalized_title(value: str) -> str:
+    if not value or normalize_title(value) != value:
+        raise ValueError("normalized_title must be non-empty canonical normalized title text.")
+    return value
+
+
+class AbsentTitleClaimProbe(_FrozenModel):
+    kind: Literal["absent_title"] = "absent_title"
+    normalized_title: StrictStr
+
+    _normalized = field_validator("normalized_title")(_validate_normalized_title)
+
+
+class OwnedTitleClaimProbe(_FrozenModel):
+    kind: Literal["owned_title"] = "owned_title"
+    normalized_title: StrictStr
+    expected_owner_decision_number: StrictInt = Field(gt=0)
+
+    _normalized = field_validator("normalized_title")(_validate_normalized_title)
+
+
+class AbsentContentClaimProbe(_FrozenModel):
+    kind: Literal["absent_content"] = "absent_content"
+    content_hash: StrictStr
+
+    @field_validator("content_hash")
+    @classmethod
+    def _content_hash(cls, value: str) -> str:
+        return validate_sha256(value, field="content_hash")
+
+
+ClaimProbe: TypeAlias = Annotated[
+    AbsentTitleClaimProbe | OwnedTitleClaimProbe | AbsentContentClaimProbe,
+    Field(discriminator="kind"),
+]
+
+
+class AbsentTitleClaimObservation(_FrozenModel):
+    kind: Literal["absent_title"] = "absent_title"
+    normalized_title: StrictStr
+
+    _normalized = field_validator("normalized_title")(_validate_normalized_title)
+
+
+class CommittedTitleClaimObservation(_FrozenModel):
+    kind: Literal["committed_title"] = "committed_title"
+    normalized_title: StrictStr
+    owner_decision_number: StrictInt = Field(gt=0)
+
+    _normalized = field_validator("normalized_title")(_validate_normalized_title)
+
+
+class UnavailableTitleClaimObservation(_FrozenModel):
+    kind: Literal["unavailable_title"] = "unavailable_title"
+    normalized_title: StrictStr
+    reason: Literal["reserved", "recovery_required"]
+
+    _normalized = field_validator("normalized_title")(_validate_normalized_title)
+
+
+class AbsentContentClaimObservation(_FrozenModel):
+    kind: Literal["absent_content"] = "absent_content"
+    content_hash: StrictStr
+
+    @field_validator("content_hash")
+    @classmethod
+    def _content_hash(cls, value: str) -> str:
+        return validate_sha256(value, field="content_hash")
+
+
+class CommittedContentClaimObservation(_FrozenModel):
+    kind: Literal["committed_content"] = "committed_content"
+    content_hash: StrictStr
+
+    @field_validator("content_hash")
+    @classmethod
+    def _content_hash(cls, value: str) -> str:
+        return validate_sha256(value, field="content_hash")
+
+
+class UnavailableContentClaimObservation(_FrozenModel):
+    kind: Literal["unavailable_content"] = "unavailable_content"
+    content_hash: StrictStr
+    reason: Literal["reserved", "recovery_required"]
+
+    @field_validator("content_hash")
+    @classmethod
+    def _content_hash(cls, value: str) -> str:
+        return validate_sha256(value, field="content_hash")
+
+
+ClaimObservation: TypeAlias = Annotated[
+    AbsentTitleClaimObservation
+    | CommittedTitleClaimObservation
+    | UnavailableTitleClaimObservation
+    | AbsentContentClaimObservation
+    | CommittedContentClaimObservation
+    | UnavailableContentClaimObservation,
+    Field(discriminator="kind"),
+]
+OBSERVATION_ADAPTER = TypeAdapter(ClaimObservation)
+
+
+class ClaimIntent(_FrozenModel):
+    kind: Literal[
+        "acquire_new_title",
+        "hold_owned_title",
+        "acquire_title_transfer",
+        "acquire_new_content_hash",
+        "commit_title_owner",
+        "retain_title_owner",
+        "release_title_owner",
+        "transfer_title_owner",
+        "commit_content_hash",
+    ]
+    normalized_title: StrictStr | None = None
+    content_hash: StrictStr | None = None
+    owner_decision_number: StrictInt | None = Field(default=None, gt=0)
+    from_owner_decision_number: StrictInt | None = Field(default=None, gt=0)
+    to_owner_decision_number: StrictInt | None = Field(default=None, gt=0)
+
+
+class ClaimIntents(_FrozenModel):
+    entry: tuple[ClaimIntent, ...]
+    publication: tuple[ClaimIntent, ...]
+
+
+class FinalizedClaimPlan(_FrozenModel):
+    entry: tuple[ClaimIntent, ...]
+    publication: tuple[ClaimIntent, ...]
+
+
+class PreparedJudgmentCommit(_FrozenModel):
+    schema_version: Literal[1] = 1
+    transformation_version: Literal[1] = 1
+    payload_bytes: bytes
+    payload_digest: StrictStr
+    payload: ApprovedPayload
+    approval_attestation: ApprovalAttestation
+    base: PreparedBase
+    effective_at: StrictStr
+    decision_provenance: DecisionProvenance | None
+    assigned_decision_number: StrictInt | None = Field(default=None, gt=0)
+    new_decision_counter: StrictInt = Field(ge=0)
+    planned_artifacts: tuple[PlannedArtifact, ...]
+    snapshot: PlannedSnapshot
+    snapshot_format: Literal["serialized", "references"] = "serialized"
+    primary_decision: PrimaryDecision
+    claim_probes: tuple[ClaimProbe, ...]
+    claim_intents: ClaimIntents
+    result_projection: _CommittedResultProjection
+
+    @property
+    def committed_result(self) -> ProposeDecisionResult:
+        return self.result_projection.materialize()
+
+    @model_validator(mode="after")
+    def _cross_validate(self) -> PreparedJudgmentCommit:
+        if sha256_hex(self.payload_bytes) != self.payload_digest:
+            raise ValueError("payload digest does not derive from payload bytes.")
+        if parse_payload(self.payload_bytes) != self.payload:
+            raise ValueError("parsed payload does not derive from payload bytes.")
+        if (
+            self.payload.base_generation_id != self.base.generation_id
+            or self.payload.base_decision_counter != self.base.decision_counter
+        ):
+            raise ValueError("prepared base does not match the approved payload.")
+        effective_at, provenance = derive_provenance(self.payload, self.approval_attestation)
+        if effective_at != self.effective_at or provenance != self.decision_provenance:
+            raise ValueError("approval attestation does not match effective provenance.")
+        paths = [artifact.path for artifact in self.planned_artifacts]
+        if paths != sorted(paths) or len(paths) != len(set(paths)):
+            raise ValueError("planned artifacts must be unique and path-sorted.")
+        primary = next(
+            (
+                artifact
+                for artifact in self.planned_artifacts
+                if artifact.path == self.primary_decision.path
+            ),
+            None,
+        )
+        if primary is None or primary.sha256 != self.primary_decision.sha256:
+            raise ValueError("primary decision does not match planned artifact bytes.")
+        primary_model = parse_decision(
+            primary.content.decode("utf-8"),
+            self.primary_decision.path.removeprefix("decisions/"),
+        )
+        target_model = None
+        if self.payload.content.affected_decision_id is not None:
+            target_path = f"decisions/{self.payload.content.affected_decision_id}.md"
+            target_artifact = next(
+                (artifact for artifact in self.planned_artifacts if artifact.path == target_path),
+                None,
+            )
+            if target_artifact is None:
+                raise ValueError("affected decision is absent from planned artifacts.")
+            target_model = parse_decision(
+                target_artifact.content.decode("utf-8"),
+                target_path.removeprefix("decisions/"),
+            )
+        probes, intents = build_claim_contract(
+            self.payload.content.operation,
+            target_model,
+            primary_model,
+        )
+        if probes != self.claim_probes or intents != self.claim_intents:
+            raise ValueError("claim probes and intents do not derive from planned artifacts.")
+        if (
+            derive_snapshot_bytes(
+                self.planned_artifacts,
+                payload=self.payload,
+                effective_at=self.effective_at,
+                snapshot_format=self.snapshot_format,
+            )
+            != self.snapshot.content
+        ):
+            raise ValueError("snapshot bytes do not derive from planned artifacts.")
+        expected_counter = self.base.decision_counter + (
+            1 if self.payload.content.operation in ("add", "supersede") else 0
+        )
+        if self.new_decision_counter != expected_counter:
+            raise ValueError("new decision counter does not match the operation.")
+        if self.payload.content.operation in ("add", "supersede"):
+            if self.assigned_decision_number != expected_counter:
+                raise ValueError("assigned number must equal counter plus one.")
+        elif self.assigned_decision_number is not None:
+            raise ValueError("update must not assign a decision number.")
+        expected_touched = [self.primary_decision.decision_id]
+        if self.payload.content.operation == "supersede":
+            assert self.payload.content.affected_decision_id is not None
+            expected_touched.append(self.payload.content.affected_decision_id)
+        if (
+            self.committed_result.status != "confirmed"
+            or self.committed_result.tier != 2
+            or self.committed_result.operation != self.payload.content.operation
+            or self.committed_result.decision_id != self.primary_decision.decision_id
+            or self.committed_result.touched_decisions != expected_touched
+            or self.committed_result.error is not None
+        ):
+            raise ValueError("committed result does not match the planned transition.")
+        return self
+
+
+class JudgmentCommitPlan(_FrozenModel):
+    schema_version: Literal[1] = 1
+    prepared: PreparedJudgmentCommit
+    validated_claim_observations: tuple[ClaimObservation, ...]
+    claim_plan: FinalizedClaimPlan
+    plan_record_bytes: bytes
+
+    @computed_field
+    @property
+    def plan_record_digest(self) -> str:
+        return sha256_hex(self.plan_record_bytes)
+
+    @property
+    def committed_result(self) -> ProposeDecisionResult:
+        return self.prepared.committed_result
+
+    @model_validator(mode="after")
+    def _verify_record(self) -> JudgmentCommitPlan:
+        if tuple(observation_key(value) for value in self.validated_claim_observations) != tuple(
+            probe_key(value) for value in self.prepared.claim_probes
+        ):
+            raise ValueError("validated observations do not match prepared probe order.")
+        for probe, observation in zip(
+            self.prepared.claim_probes,
+            self.validated_claim_observations,
+            strict=True,
+        ):
+            validate_observation(probe, observation)
+        if self.claim_plan.entry != self.prepared.claim_intents.entry or (
+            self.claim_plan.publication != self.prepared.claim_intents.publication
+        ):
+            raise ValueError("finalized claim plan does not derive from prepared intents.")
+        if self.plan_record_bytes != build_plan_record(
+            self.prepared, self.validated_claim_observations
+        ):
+            raise ValueError("plan record bytes do not derive from the prepared plan.")
+        return self
+
+
+def canonical_judgment_payload_bytes(payload: Mapping[str, object]) -> bytes:
+    """Serialize the only accepted approved payload byte representation."""
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise CanonicalPayloadRejected(f"approved payload contains duplicate key {key!r}.")
+        result[key] = value
+    return result
+
+
+def parse_payload(payload_bytes: bytes) -> ApprovedPayload:
+    try:
+        text = payload_bytes.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise CanonicalPayloadRejected("approved payload must be valid UTF-8.") from exc
+    try:
+        raw = json.loads(
+            text,
+            object_pairs_hook=_reject_duplicate_keys,
+            parse_constant=lambda value: (_ for _ in ()).throw(
+                CanonicalPayloadRejected(f"approved payload contains invalid number {value}.")
+            ),
+        )
+    except CanonicalPayloadRejected:
+        raise
+    except (json.JSONDecodeError, TypeError) as exc:
+        raise CanonicalPayloadRejected("approved payload must be valid JSON.") from exc
+    try:
+        payload = _PAYLOAD_ADAPTER.validate_python(raw)
+    except ValidationError as exc:
+        raise CanonicalPayloadRejected(f"approved payload is invalid: {exc}") from exc
+    try:
+        canonical = canonical_judgment_payload_bytes(payload.model_dump(mode="json"))
+    except UnicodeEncodeError as exc:
+        raise CanonicalPayloadRejected(
+            "approved payload cannot be serialized as canonical UTF-8 JSON."
+        ) from exc
+    if canonical != payload_bytes:
+        raise CanonicalPayloadRejected("approved payload bytes are not canonical JSON.")
+    return payload
+
+
+def derive_provenance(
+    payload: ApprovedPayload,
+    attestation: ApprovalAttestation,
+) -> tuple[str, DecisionProvenance | None]:
+    if isinstance(payload, HostedPreTeamApprovalPayloadV1):
+        if not isinstance(attestation, PreTeamApprovalAttestation):
+            raise ApprovalAttestationRejected(
+                "pre-team payload requires pre-team approval attestation."
+            )
+        return attestation.request_received_at, None
+    if not isinstance(attestation, TeamRatificationAttestation):
+        raise ApprovalAttestationRejected("team payload requires team ratification attestation.")
+    if payload.contributor_operation_id == attestation.ratification_action_id:
+        raise ApprovalAttestationRejected(
+            "team contributor_operation_id and ratification_action_id must be distinct."
+        )
+    return (
+        attestation.approved_at,
+        DecisionProvenance(
+            proposed_by=payload.proposed_by,
+            approved_by=attestation.approved_by,
+            approved_at=attestation.approved_at,
+            proposal_id=payload.proposal_id,
+            proposed_base_commit=payload.proposed_base_commit,
+        ),
+    )
+
+
+def derive_snapshot_bytes(
+    artifacts: tuple[PlannedArtifact, ...],
+    *,
+    payload: ApprovedPayload,
+    effective_at: str,
+    snapshot_format: Literal["serialized", "references"] = "serialized",
+) -> bytes:
+    if snapshot_format not in {"serialized", "references"}:
+        raise ValueError("unsupported snapshot format")
+    snapshot_files = {
+        artifact.path: artifact.content.decode("utf-8")
+        for artifact in artifacts
+        if is_hosted_snapshot_content_member(artifact.path)
+    }
+    title = payload.content.title or ""
+    trigger = {
+        "add": f"decision: {title}",
+        "update": "update: ",
+        "supersede": f"supersede: {title}",
+    }[payload.content.operation]
+    if snapshot_format == "references":
+        return snapshot_descriptor(
+            {a.path: a.content for a in artifacts}, timestamp=effective_at, trigger=trigger
+        )
+    snapshot = serialize_snapshot(
+        timestamp=effective_at,
+        trigger=trigger,
+        files=dict(sorted(snapshot_files.items())),
+    )
+    return json.dumps(
+        snapshot,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def build_claim_contract(
+    operation: str,
+    target: Decision | None,
+    primary: Decision,
+) -> tuple[tuple[ClaimProbe, ...], ClaimIntents]:
+    new_number = primary.num
+    new_title = normalize_title(primary.title)
+    content_hash = compute_hash(primary.title, primary.rationale)
+    content_probe = AbsentContentClaimProbe(content_hash=content_hash)
+    acquire_content = ClaimIntent(kind="acquire_new_content_hash", content_hash=content_hash)
+    commit_content = ClaimIntent(kind="commit_content_hash", content_hash=content_hash)
+    if operation == "add":
+        probes: tuple[ClaimProbe, ...] = (
+            AbsentTitleClaimProbe(normalized_title=new_title),
+            content_probe,
+        )
+        intents = ClaimIntents(
+            entry=(
+                ClaimIntent(
+                    kind="acquire_new_title",
+                    normalized_title=new_title,
+                    owner_decision_number=new_number,
+                ),
+                acquire_content,
+            ),
+            publication=(
+                ClaimIntent(
+                    kind="commit_title_owner",
+                    normalized_title=new_title,
+                    owner_decision_number=new_number,
+                ),
+                commit_content,
+            ),
+        )
+        return probes, intents
+    assert target is not None
+    old_title = normalize_title(target.title)
+    if operation == "update":
+        probes = (
+            OwnedTitleClaimProbe(
+                normalized_title=old_title,
+                expected_owner_decision_number=target.num,
+            ),
+            content_probe,
+        )
+        intents = ClaimIntents(
+            entry=(
+                ClaimIntent(
+                    kind="hold_owned_title",
+                    normalized_title=old_title,
+                    owner_decision_number=target.num,
+                ),
+                acquire_content,
+            ),
+            publication=(
+                ClaimIntent(
+                    kind="retain_title_owner",
+                    normalized_title=old_title,
+                    owner_decision_number=target.num,
+                ),
+                commit_content,
+            ),
+        )
+        return probes, intents
+    if new_title == old_title:
+        probes = (
+            OwnedTitleClaimProbe(
+                normalized_title=old_title,
+                expected_owner_decision_number=target.num,
+            ),
+            content_probe,
+        )
+        intents = ClaimIntents(
+            entry=(
+                ClaimIntent(
+                    kind="acquire_title_transfer",
+                    normalized_title=old_title,
+                    from_owner_decision_number=target.num,
+                    to_owner_decision_number=new_number,
+                ),
+                acquire_content,
+            ),
+            publication=(
+                ClaimIntent(
+                    kind="transfer_title_owner",
+                    normalized_title=old_title,
+                    from_owner_decision_number=target.num,
+                    to_owner_decision_number=new_number,
+                ),
+                commit_content,
+            ),
+        )
+        return probes, intents
+    probes = (
+        OwnedTitleClaimProbe(
+            normalized_title=old_title,
+            expected_owner_decision_number=target.num,
+        ),
+        AbsentTitleClaimProbe(normalized_title=new_title),
+        content_probe,
+    )
+    intents = ClaimIntents(
+        entry=(
+            ClaimIntent(
+                kind="hold_owned_title",
+                normalized_title=old_title,
+                owner_decision_number=target.num,
+            ),
+            ClaimIntent(
+                kind="acquire_new_title",
+                normalized_title=new_title,
+                owner_decision_number=new_number,
+            ),
+            acquire_content,
+        ),
+        publication=(
+            ClaimIntent(
+                kind="release_title_owner",
+                normalized_title=old_title,
+                owner_decision_number=target.num,
+            ),
+            ClaimIntent(
+                kind="commit_title_owner",
+                normalized_title=new_title,
+                owner_decision_number=new_number,
+            ),
+            commit_content,
+        ),
+    )
+    return probes, intents
+
+
+def probe_key(probe: ClaimProbe) -> tuple[str, str]:
+    if isinstance(probe, AbsentContentClaimProbe):
+        return ("content", probe.content_hash)
+    return ("title", probe.normalized_title)
+
+
+def observation_key(observation: ClaimObservation) -> tuple[str, str]:
+    if isinstance(
+        observation,
+        (
+            AbsentContentClaimObservation,
+            CommittedContentClaimObservation,
+            UnavailableContentClaimObservation,
+        ),
+    ):
+        return ("content", observation.content_hash)
+    return ("title", observation.normalized_title)
+
+
+def validate_observation(probe: ClaimProbe, observation: ClaimObservation) -> None:
+    if isinstance(
+        observation,
+        (UnavailableTitleClaimObservation, UnavailableContentClaimObservation),
+    ):
+        raise ClaimUnavailable(f"claim {observation_key(observation)!r} is {observation.reason}.")
+    if isinstance(probe, AbsentTitleClaimProbe):
+        if isinstance(observation, AbsentTitleClaimObservation):
+            return
+        if isinstance(observation, CommittedTitleClaimObservation):
+            raise TitleClaimConflict(
+                "normalized title is already owned by decision "
+                f"{observation.owner_decision_number}."
+            )
+    elif isinstance(probe, OwnedTitleClaimProbe):
+        if isinstance(observation, CommittedTitleClaimObservation) and (
+            observation.owner_decision_number == probe.expected_owner_decision_number
+        ):
+            return
+        raise MismatchedClaimObservation(
+            "owned title claim does not match the expected committed owner."
+        )
+    elif isinstance(observation, AbsentContentClaimObservation):
+        return
+    elif isinstance(observation, CommittedContentClaimObservation):
+        raise ContentClaimConflict("content hash is already present in decision history.")
+    raise MismatchedClaimObservation("claim observation does not match its prepared probe.")
+
+
+def _artifact_inventory(prepared: PreparedJudgmentCommit) -> dict[str, object]:
+    descriptors = [
+        {"length": artifact.length, "path": artifact.path, "sha256": artifact.sha256}
+        for artifact in prepared.planned_artifacts
+    ]
+    inventory = {"artifacts": descriptors, "schema": "nauro.artifact_inventory.v1"}
+    inventory_bytes = canonical_judgment_payload_bytes(inventory)
+    return {
+        "artifact_count": len(descriptors),
+        "digest": sha256_hex(inventory_bytes),
+        "schema": "nauro.artifact_inventory.v1",
+        "total_byte_count": sum(descriptor["length"] for descriptor in descriptors),
+    }
+
+
+def build_plan_record(
+    prepared: PreparedJudgmentCommit,
+    observations: tuple[ClaimObservation, ...],
+) -> bytes:
+    content = prepared.payload.content
+    provenance = (
+        {
+            "approved_at": prepared.decision_provenance.approved_at,
+            "approved_by": prepared.decision_provenance.approved_by,
+            "proposal_id": prepared.decision_provenance.proposal_id,
+            "proposed_base_commit": prepared.decision_provenance.proposed_base_commit,
+            "proposed_by": prepared.decision_provenance.proposed_by,
+        }
+        if prepared.decision_provenance is not None
+        else None
+    )
+    record = {
+        "affected_decision_id": content.affected_decision_id,
+        "approval_mode": prepared.payload.approval_mode,
+        "approval": prepared.approval_attestation.model_dump(mode="json"),
+        "artifact_inventory": _artifact_inventory(prepared),
+        "base": prepared.base.model_dump(mode="json"),
+        "claim_plan": {
+            "entry": [value.model_dump(mode="json") for value in prepared.claim_intents.entry],
+            "observations": [value.model_dump(mode="json") for value in observations],
+            "probes": [value.model_dump(mode="json") for value in prepared.claim_probes],
+            "publication": [
+                value.model_dump(mode="json") for value in prepared.claim_intents.publication
+            ],
+        },
+        "committed_result": prepared.committed_result.model_dump(mode="json"),
+        "decision_provenance": provenance,
+        "new_decision_counter": prepared.new_decision_counter,
+        "operation": content.operation,
+        "payload_digest": prepared.payload_digest,
+        "payload_schema": prepared.payload.payload_schema,
+        "primary_decision": prepared.primary_decision.model_dump(mode="json"),
+        "record_schema": "nauro.judgment_commit.plan_record.v1",
+        "snapshot": {
+            "length": prepared.snapshot.length,
+            "sha256": prepared.snapshot.sha256,
+        },
+        "transform_version": prepared.transformation_version,
+    }
+    return canonical_judgment_payload_bytes(record)

--- a/packages/nauro-core/src/nauro_core/operations/_commit_finalize.py
+++ b/packages/nauro-core/src/nauro_core/operations/_commit_finalize.py
@@ -2,164 +2,60 @@
 
 from __future__ import annotations
 
-from . import commit_plan as contract
+from collections.abc import Mapping, Sequence
+
+from pydantic import ValidationError
+
+from nauro_core.operations._commit_contract import (
+    OBSERVATION_ADAPTER,
+    ClaimObservation,
+    DuplicateClaimObservation,
+    FinalizedClaimPlan,
+    JudgmentCommitPlan,
+    MalformedClaimObservation,
+    MissingClaimObservation,
+    PreparedJudgmentCommit,
+    UnexpectedClaimObservation,
+    build_plan_record,
+    observation_key,
+    probe_key,
+    validate_observation,
+)
 
 
-def _probe_key_impl(probe: contract.ClaimProbe) -> tuple[str, str]:
-    if isinstance(probe, contract.AbsentContentClaimProbe):
-        return ("content", probe.content_hash)
-    return ("title", probe.normalized_title)
-
-
-def _observation_key_impl(observation: contract.ClaimObservation) -> tuple[str, str]:
-    if isinstance(
-        observation,
-        (
-            contract.AbsentContentClaimObservation,
-            contract.CommittedContentClaimObservation,
-            contract.UnavailableContentClaimObservation,
-        ),
-    ):
-        return ("content", observation.content_hash)
-    return ("title", observation.normalized_title)
-
-
-def _validate_observation_impl(
-    probe: contract.ClaimProbe, observation: contract.ClaimObservation
-) -> None:
-    if isinstance(
-        observation,
-        (contract.UnavailableTitleClaimObservation, contract.UnavailableContentClaimObservation),
-    ):
-        raise contract.ClaimUnavailable(
-            f"claim {contract._observation_key(observation)!r} is {observation.reason}."
-        )
-    if isinstance(probe, contract.AbsentTitleClaimProbe):
-        if isinstance(observation, contract.AbsentTitleClaimObservation):
-            return
-        if isinstance(observation, contract.CommittedTitleClaimObservation):
-            raise contract.TitleClaimConflict(
-                "normalized title is already owned by decision "
-                f"{observation.owner_decision_number}."
-            )
-    elif isinstance(probe, contract.OwnedTitleClaimProbe):
-        if isinstance(observation, contract.CommittedTitleClaimObservation) and (
-            observation.owner_decision_number == probe.expected_owner_decision_number
-        ):
-            return
-        raise contract.MismatchedClaimObservation(
-            "owned title claim does not match the expected committed owner."
-        )
-    elif isinstance(observation, contract.AbsentContentClaimObservation):
-        return
-    elif isinstance(observation, contract.CommittedContentClaimObservation):
-        raise contract.ContentClaimConflict("content hash is already present in decision history.")
-    raise contract.MismatchedClaimObservation(
-        "claim observation does not match its prepared probe."
-    )
-
-
-def _artifact_inventory_impl(prepared: contract.PreparedJudgmentCommit) -> dict[str, object]:
-    descriptors = [
-        {"length": artifact.length, "path": artifact.path, "sha256": artifact.sha256}
-        for artifact in prepared.planned_artifacts
-    ]
-    inventory = {"artifacts": descriptors, "schema": "nauro.artifact_inventory.v1"}
-    inventory_bytes = contract.canonical_judgment_payload_bytes(inventory)
-    return {
-        "artifact_count": len(descriptors),
-        "digest": contract._sha256(inventory_bytes),
-        "schema": "nauro.artifact_inventory.v1",
-        "total_byte_count": sum(descriptor["length"] for descriptor in descriptors),
-    }
-
-
-def _plan_record_impl(
-    prepared: contract.PreparedJudgmentCommit,
-    observations: tuple[contract.ClaimObservation, ...],
-) -> bytes:
-    content = prepared.payload.content
-    provenance = (
-        {
-            "approved_at": prepared.decision_provenance.approved_at,
-            "approved_by": prepared.decision_provenance.approved_by,
-            "proposal_id": prepared.decision_provenance.proposal_id,
-            "proposed_base_commit": prepared.decision_provenance.proposed_base_commit,
-            "proposed_by": prepared.decision_provenance.proposed_by,
-        }
-        if prepared.decision_provenance is not None
-        else None
-    )
-    record = {
-        "affected_decision_id": content.affected_decision_id,
-        "approval_mode": prepared.payload.approval_mode,
-        "approval": prepared.approval_attestation.model_dump(mode="json"),
-        "artifact_inventory": contract._artifact_inventory(prepared),
-        "base": prepared.base.model_dump(mode="json"),
-        "claim_plan": {
-            "entry": [value.model_dump(mode="json") for value in prepared.claim_intents.entry],
-            "observations": [value.model_dump(mode="json") for value in observations],
-            "probes": [value.model_dump(mode="json") for value in prepared.claim_probes],
-            "publication": [
-                value.model_dump(mode="json") for value in prepared.claim_intents.publication
-            ],
-        },
-        "committed_result": prepared.committed_result.model_dump(mode="json"),
-        "decision_provenance": provenance,
-        "new_decision_counter": prepared.new_decision_counter,
-        "operation": content.operation,
-        "payload_digest": prepared.payload_digest,
-        "payload_schema": prepared.payload.payload_schema,
-        "primary_decision": prepared.primary_decision.model_dump(mode="json"),
-        "record_schema": "nauro.judgment_commit.plan_record.v1",
-        "snapshot": {
-            "length": prepared.snapshot.length,
-            "sha256": prepared.snapshot.sha256,
-        },
-        "transform_version": prepared.transformation_version,
-    }
-    return contract.canonical_judgment_payload_bytes(record)
-
-
-def finalize_judgment_commit_impl(
-    prepared: contract.PreparedJudgmentCommit,
-    claim_observations: contract.Sequence[
-        contract.ClaimObservation | contract.Mapping[str, object]
-    ],
-) -> contract.JudgmentCommitPlan:
+def finalize_judgment_commit(
+    prepared: PreparedJudgmentCommit,
+    claim_observations: Sequence[ClaimObservation | Mapping[str, object]],
+) -> JudgmentCommitPlan:
     """Validate claim observations and finalize the storage-neutral plan."""
-    parsed: list[contract.ClaimObservation] = []
+    parsed: list[ClaimObservation] = []
     for raw in claim_observations:
         try:
-            parsed.append(contract._OBSERVATION_ADAPTER.validate_python(raw))
-        except contract.ValidationError as exc:
-            raise contract.MalformedClaimObservation("claim observation is malformed.") from exc
-    observed_by_key: dict[tuple[str, str], contract.ClaimObservation] = {}
+            parsed.append(OBSERVATION_ADAPTER.validate_python(raw))
+        except ValidationError as exc:
+            raise MalformedClaimObservation("claim observation is malformed.") from exc
+    observed_by_key: dict[tuple[str, str], ClaimObservation] = {}
     for observation in parsed:
-        key = contract._observation_key(observation)
+        key = observation_key(observation)
         if key in observed_by_key:
-            raise contract.DuplicateClaimObservation(f"duplicate claim observation for {key!r}.")
+            raise DuplicateClaimObservation(f"duplicate claim observation for {key!r}.")
         observed_by_key[key] = observation
-    probe_keys = {contract._probe_key(probe) for probe in prepared.claim_probes}
+    probe_keys = {probe_key(probe) for probe in prepared.claim_probes}
     extra = set(observed_by_key) - probe_keys
     if extra:
-        raise contract.UnexpectedClaimObservation(
-            f"unexpected claim observation(s): {sorted(extra)!r}."
-        )
+        raise UnexpectedClaimObservation(f"unexpected claim observation(s): {sorted(extra)!r}.")
     missing = probe_keys - set(observed_by_key)
     if missing:
-        raise contract.MissingClaimObservation(
-            f"missing claim observation(s): {sorted(missing)!r}."
-        )
-    ordered = tuple(observed_by_key[contract._probe_key(probe)] for probe in prepared.claim_probes)
+        raise MissingClaimObservation(f"missing claim observation(s): {sorted(missing)!r}.")
+    ordered = tuple(observed_by_key[probe_key(probe)] for probe in prepared.claim_probes)
     for probe, observation in zip(prepared.claim_probes, ordered, strict=True):
-        contract._validate_observation(probe, observation)
-    claim_plan = contract.FinalizedClaimPlan(
+        validate_observation(probe, observation)
+    claim_plan = FinalizedClaimPlan(
         entry=prepared.claim_intents.entry,
         publication=prepared.claim_intents.publication,
     )
-    record_bytes = contract._plan_record(prepared, ordered)
-    return contract.JudgmentCommitPlan(
+    record_bytes = build_plan_record(prepared, ordered)
+    return JudgmentCommitPlan(
         prepared=prepared,
         validated_claim_observations=ordered,
         claim_plan=claim_plan,

--- a/packages/nauro-core/src/nauro_core/operations/_commit_prepare.py
+++ b/packages/nauro-core/src/nauro_core/operations/_commit_prepare.py
@@ -2,68 +2,75 @@
 
 from __future__ import annotations
 
+from datetime import date
 from typing import Literal
 
-from . import commit_plan as contract
+from nauro_core.decision_model import (
+    Decision,
+    DecisionConfidence,
+    DecisionSource,
+    DecisionType,
+    RejectedAlternative,
+    Reversibility,
+    format_decision,
+    parse_decision,
+)
+from nauro_core.operations._commit_contract import (
+    ApprovalAttestation,
+    ApprovedBaseStale,
+    ApprovedPayload,
+    ApprovedPayloadDigestMismatch,
+    CommittedGeneration,
+    CommittedGenerationCorrupt,
+    JudgmentContent,
+    PlannedArtifact,
+    PlannedSnapshot,
+    PreparedBase,
+    PreparedJudgmentCommit,
+    PrimaryDecision,
+    ProposalRejected,
+    _CommittedResultProjection,
+    build_claim_contract,
+    derive_provenance,
+    derive_snapshot_bytes,
+    parse_payload,
+    sha256_hex,
+    validate_sha256,
+)
+from nauro_core.operations._decision_transitions import (
+    DecisionProvenance,
+    append_decision_update,
+    attach_supersedes,
+    build_new_decision,
+    mark_superseded,
+    resolve_questions_content,
+    slugify_decision_title,
+)
+from nauro_core.operations._proposal_evaluation import (
+    ProposalEvaluation,
+    evaluate_parsed_proposal,
+    validate_proposal_request,
+)
+from nauro_core.operations.results import ProposeDecisionResult
+from nauro_core.parsing import _decision_number_prefix
+from nauro_core.protected_generation_membership import (
+    validate_protected_generation_path,
+)
+from nauro_core.questions import OpenQuestionsFile
 
 
-def _reject_duplicate_keys_impl(pairs: list[tuple[str, object]]) -> dict[str, object]:
-    result: dict[str, object] = {}
-    for key, value in pairs:
-        if key in result:
-            raise contract.CanonicalPayloadRejected(
-                f"approved payload contains duplicate key {key!r}."
-            )
-        result[key] = value
-    return result
-
-
-def _parse_payload_impl(payload_bytes: bytes) -> contract.ApprovedPayload:
-    try:
-        text = payload_bytes.decode("utf-8")
-    except UnicodeDecodeError as exc:
-        raise contract.CanonicalPayloadRejected("approved payload must be valid UTF-8.") from exc
-    try:
-        raw = contract.json.loads(
-            text,
-            object_pairs_hook=contract._reject_duplicate_keys,
-            parse_constant=lambda value: (_ for _ in ()).throw(
-                contract.CanonicalPayloadRejected(
-                    f"approved payload contains invalid number {value}."
-                )
-            ),
-        )
-    except contract.CanonicalPayloadRejected:
-        raise
-    except (contract.json.JSONDecodeError, TypeError) as exc:
-        raise contract.CanonicalPayloadRejected("approved payload must be valid JSON.") from exc
-    try:
-        payload = contract._PAYLOAD_ADAPTER.validate_python(raw)
-    except contract.ValidationError as exc:
-        raise contract.CanonicalPayloadRejected(f"approved payload is invalid: {exc}") from exc
-    try:
-        canonical = contract.canonical_judgment_payload_bytes(payload.model_dump(mode="json"))
-    except UnicodeEncodeError as exc:
-        raise contract.CanonicalPayloadRejected(
-            "approved payload cannot be serialized as canonical UTF-8 JSON."
-        ) from exc
-    if canonical != payload_bytes:
-        raise contract.CanonicalPayloadRejected("approved payload bytes are not canonical JSON.")
-    return payload
-
-
-def _parse_committed_generation_impl(
-    generation: contract.CommittedGeneration,
-) -> tuple[dict[str, bytes], list[contract.Decision], dict[int, str]]:
+def _parse_committed_generation(
+    generation: CommittedGeneration,
+) -> tuple[dict[str, bytes], list[Decision], dict[int, str]]:
     artifact_bytes: dict[str, bytes] = {}
-    decisions: list[contract.Decision] = []
+    decisions: list[Decision] = []
     stems_by_number: dict[int, str] = {}
     for artifact in sorted(generation.artifacts, key=lambda value: value.path):
-        contract.validate_protected_generation_path(artifact.path)
+        validate_protected_generation_path(artifact.path)
         try:
             text = artifact.content.decode("utf-8")
         except UnicodeDecodeError as exc:
-            raise contract.CommittedGenerationCorrupt(
+            raise CommittedGenerationCorrupt(
                 f"committed artifact {artifact.path!r} is not valid UTF-8."
             ) from exc
         artifact_bytes[artifact.path] = bytes(artifact.content)
@@ -71,37 +78,37 @@ def _parse_committed_generation_impl(
             continue
         filename = artifact.path[len("decisions/") :]
         try:
-            decision = contract.parse_decision(text, filename)
+            decision = parse_decision(text, filename)
         except Exception as exc:
-            raise contract.CommittedGenerationCorrupt(
+            raise CommittedGenerationCorrupt(
                 f"committed decision {artifact.path!r} does not parse."
             ) from exc
         if decision.num <= 0:
-            raise contract.CommittedGenerationCorrupt(
+            raise CommittedGenerationCorrupt(
                 f"committed decision {artifact.path!r} has no positive number."
             )
         if decision.num in stems_by_number:
-            raise contract.CommittedGenerationCorrupt(
+            raise CommittedGenerationCorrupt(
                 f"committed generation contains duplicate decision number {decision.num}."
             )
         decisions.append(decision)
         stems_by_number[decision.num] = filename.removesuffix(".md")
     maximum = max(stems_by_number, default=0)
     if maximum > generation.decision_counter:
-        raise contract.CommittedGenerationCorrupt(
+        raise CommittedGenerationCorrupt(
             f"published decision number {maximum} exceeds counter {generation.decision_counter}."
         )
     return artifact_bytes, decisions, stems_by_number
 
 
-def _rejected_result_impl(
+def _rejected_result(
     tier: int,
-    operation: str,
+    operation: Literal["add", "update", "supersede"],
     assessment: str,
-) -> contract.ProposalRejected:
+) -> ProposalRejected:
     result_operation = "reject" if tier == 1 else operation
-    return contract.ProposalRejected(
-        contract.ProposeDecisionResult(
+    return ProposalRejected(
+        ProposeDecisionResult(
             status="rejected",
             tier=tier,
             operation=result_operation,
@@ -110,11 +117,11 @@ def _rejected_result_impl(
     )
 
 
-def _target_impl(
-    content: contract.JudgmentContent,
-    decisions: list[contract.Decision],
+def _target(
+    content: JudgmentContent,
+    decisions: list[Decision],
     stems_by_number: dict[int, str],
-) -> tuple[contract.Decision | None, str | None]:
+) -> tuple[Decision | None, str | None]:
     if content.operation == "add":
         return None, None
     target_stem = content.affected_decision_id
@@ -124,7 +131,7 @@ def _target_impl(
         None,
     )
     if target is None:
-        raise contract._rejected_result(
+        raise _rejected_result(
             1,
             content.operation,
             f"{content.operation} target {target_stem!r} not found in committed generation.",
@@ -132,97 +139,28 @@ def _target_impl(
     return target, target_stem
 
 
-def _provenance_impl(
-    payload: contract.ApprovedPayload,
-    attestation: contract.ApprovalAttestation,
-) -> tuple[str, contract.DecisionProvenance | None]:
-    if isinstance(payload, contract.HostedPreTeamApprovalPayloadV1):
-        if not isinstance(attestation, contract.PreTeamApprovalAttestation):
-            raise contract.ApprovalAttestationRejected(
-                "pre-team payload requires pre-team approval attestation."
-            )
-        return attestation.request_received_at, None
-    if not isinstance(attestation, contract.TeamRatificationAttestation):
-        raise contract.ApprovalAttestationRejected(
-            "team payload requires team ratification attestation."
-        )
-    if payload.contributor_operation_id == attestation.ratification_action_id:
-        raise contract.ApprovalAttestationRejected(
-            "team contributor_operation_id and ratification_action_id must be distinct."
-        )
-    return (
-        attestation.approved_at,
-        contract.DecisionProvenance(
-            proposed_by=payload.proposed_by,
-            approved_by=attestation.approved_by,
-            approved_at=attestation.approved_at,
-            proposal_id=payload.proposal_id,
-            proposed_base_commit=payload.proposed_base_commit,
-        ),
-    )
-
-
-def _derive_snapshot_bytes_impl(
-    artifacts: tuple[contract.PlannedArtifact, ...],
+def _build_artifacts(
     *,
-    payload: contract.ApprovedPayload,
+    payload: ApprovedPayload,
+    provenance: DecisionProvenance | None,
     effective_at: str,
-    snapshot_format: Literal["serialized", "references"] = "serialized",
-) -> bytes:
-    if snapshot_format not in {"serialized", "references"}:
-        raise ValueError("unsupported snapshot format")
-    snapshot_files = {
-        artifact.path: artifact.content.decode("utf-8")
-        for artifact in artifacts
-        if contract.is_hosted_snapshot_content_member(artifact.path)
-    }
-    title = payload.content.title or ""
-    trigger = {
-        "add": f"decision: {title}",
-        "update": "update: ",
-        "supersede": f"supersede: {title}",
-    }[payload.content.operation]
-    if snapshot_format == "references":
-        from nauro_core.snapshot_references import snapshot_descriptor
-
-        return snapshot_descriptor(
-            {a.path: a.content for a in artifacts}, timestamp=effective_at, trigger=trigger
-        )
-    snapshot = contract.serialize_snapshot(
-        timestamp=effective_at,
-        trigger=trigger,
-        files=dict(sorted(snapshot_files.items())),
-    )
-    return contract.json.dumps(
-        snapshot,
-        separators=(",", ":"),
-        ensure_ascii=False,
-        allow_nan=False,
-    ).encode("utf-8")
-
-
-def _build_artifacts_impl(
-    *,
-    payload: contract.ApprovedPayload,
-    provenance: contract.DecisionProvenance | None,
-    effective_at: str,
-    generation: contract.CommittedGeneration,
+    generation: CommittedGeneration,
     current: dict[str, bytes],
-    evaluation: contract.ProposalEvaluation,
-    target: contract.Decision | None,
+    evaluation: ProposalEvaluation,
+    target: Decision | None,
     target_stem: str | None,
     snapshot_format: Literal["serialized", "references"] = "serialized",
 ) -> tuple[
-    tuple[contract.PlannedArtifact, ...],
-    contract.PlannedSnapshot,
-    contract.PrimaryDecision,
-    contract.ProposeDecisionResult,
+    tuple[PlannedArtifact, ...],
+    PlannedSnapshot,
+    PrimaryDecision,
+    ProposeDecisionResult,
     int | None,
     int,
-    contract.Decision,
+    Decision,
 ]:
     content = payload.content
-    decision_date = contract.date.fromisoformat(effective_at[:10])
+    decision_date = date.fromisoformat(effective_at[:10])
     assigned = (
         generation.decision_counter + 1 if content.operation in ("add", "supersede") else None
     )
@@ -230,12 +168,11 @@ def _build_artifacts_impl(
     planned = dict(current)
 
     rejected = tuple(
-        contract.RejectedAlternative(name=item.alternative, reason=item.reason)
-        for item in content.rejected
+        RejectedAlternative(name=item.alternative, reason=item.reason) for item in content.rejected
     )
     if content.operation == "update":
         assert target is not None and target_stem is not None
-        primary_model = contract.append_decision_update(
+        primary_model = append_decision_update(
             target,
             additional_rationale=content.rationale,
             update_date=decision_date,
@@ -243,48 +180,39 @@ def _build_artifacts_impl(
         )
         primary_stem = target_stem
         primary_path = f"decisions/{primary_stem}.md"
-        planned[primary_path] = contract.format_decision(primary_model).encode("utf-8")
+        planned[primary_path] = format_decision(primary_model).encode("utf-8")
         touched = [primary_stem]
     else:
         assert assigned is not None and content.title is not None and content.confidence is not None
-        primary_model = contract.build_new_decision(
+        primary_model = build_new_decision(
             number=assigned,
             decision_date=decision_date,
             title=content.title,
             rationale=content.rationale,
-            confidence=contract.DecisionConfidence(content.confidence),
-            decision_type=contract.DecisionType(content.decision_type)
-            if content.decision_type
-            else None,
-            reversibility=contract.Reversibility(content.reversibility)
-            if content.reversibility
-            else None,
-            source=contract.DecisionSource.mcp,
+            confidence=DecisionConfidence(content.confidence),
+            decision_type=DecisionType(content.decision_type) if content.decision_type else None,
+            reversibility=Reversibility(content.reversibility) if content.reversibility else None,
+            source=DecisionSource.mcp,
             files_affected=content.files_affected,
             rejected=rejected,
             provenance=provenance,
         )
         if content.operation == "supersede":
             assert target is not None and target_stem is not None
-            primary_model = contract.attach_supersedes(primary_model, target.num)
-        primary_stem = (
-            f"{contract._decision_number_prefix(assigned)}"
-            f"{contract.slugify_decision_title(content.title)}"
-        )
+            primary_model = attach_supersedes(primary_model, target.num)
+        primary_stem = f"{_decision_number_prefix(assigned)}{slugify_decision_title(content.title)}"
         primary_path = f"decisions/{primary_stem}.md"
-        planned[primary_path] = contract.format_decision(primary_model).encode("utf-8")
+        planned[primary_path] = format_decision(primary_model).encode("utf-8")
         touched = [primary_stem]
         if content.operation == "supersede":
             assert target is not None and target_stem is not None
             old_path = f"decisions/{target_stem}.md"
-            planned[old_path] = contract.format_decision(
-                contract.mark_superseded(target, assigned)
-            ).encode("utf-8")
+            planned[old_path] = format_decision(mark_superseded(target, assigned)).encode("utf-8")
             touched.append(target_stem)
 
     questions_path = "open-questions.md"
     questions_body = planned.get(questions_path, b"").decode("utf-8")
-    resolution = contract.resolve_questions_content(
+    resolution = resolve_questions_content(
         questions_body,
         question_ids=content.resolves_questions,
         decision_number=primary_model.num,
@@ -293,7 +221,7 @@ def _build_artifacts_impl(
     if content.resolves_questions:
         planned[questions_path] = resolution.content.encode("utf-8")
 
-    result = contract.ProposeDecisionResult(
+    result = ProposeDecisionResult(
         status="confirmed",
         tier=2,
         operation=content.operation,
@@ -306,183 +234,49 @@ def _build_artifacts_impl(
         skipped_prose_ids=resolution.skipped_prose_ids or None,
     )
     artifacts = tuple(
-        contract.PlannedArtifact(path=path, content=body) for path, body in sorted(planned.items())
+        PlannedArtifact(path=path, content=body) for path, body in sorted(planned.items())
     )
-    snapshot = contract.PlannedSnapshot(
-        content=contract._derive_snapshot_bytes(
+    snapshot = PlannedSnapshot(
+        content=derive_snapshot_bytes(
             artifacts, payload=payload, effective_at=effective_at, snapshot_format=snapshot_format
         )
     )
     primary_bytes = planned[primary_path]
-    primary = contract.PrimaryDecision(
+    primary = PrimaryDecision(
         decision_id=primary_stem,
         path=primary_path,
-        sha256=contract._sha256(primary_bytes),
+        sha256=sha256_hex(primary_bytes),
     )
     return artifacts, snapshot, primary, result, assigned, new_counter, primary_model
 
 
-def _claim_contract_impl(
-    operation: str,
-    target: contract.Decision | None,
-    primary: contract.Decision,
-) -> tuple[tuple[contract.ClaimProbe, ...], contract.ClaimIntents]:
-    new_number = primary.num
-    new_title = contract.normalize_title(primary.title)
-    content_hash = contract.compute_hash(primary.title, primary.rationale)
-    content_probe = contract.AbsentContentClaimProbe(content_hash=content_hash)
-    acquire_content = contract.ClaimIntent(
-        kind="acquire_new_content_hash", content_hash=content_hash
-    )
-    commit_content = contract.ClaimIntent(kind="commit_content_hash", content_hash=content_hash)
-    if operation == "add":
-        probes: tuple[contract.ClaimProbe, ...] = (
-            contract.AbsentTitleClaimProbe(normalized_title=new_title),
-            content_probe,
-        )
-        intents = contract.ClaimIntents(
-            entry=(
-                contract.ClaimIntent(
-                    kind="acquire_new_title",
-                    normalized_title=new_title,
-                    owner_decision_number=new_number,
-                ),
-                acquire_content,
-            ),
-            publication=(
-                contract.ClaimIntent(
-                    kind="commit_title_owner",
-                    normalized_title=new_title,
-                    owner_decision_number=new_number,
-                ),
-                commit_content,
-            ),
-        )
-        return probes, intents
-    assert target is not None
-    old_title = contract.normalize_title(target.title)
-    if operation == "update":
-        probes = (
-            contract.OwnedTitleClaimProbe(
-                normalized_title=old_title,
-                expected_owner_decision_number=target.num,
-            ),
-            content_probe,
-        )
-        intents = contract.ClaimIntents(
-            entry=(
-                contract.ClaimIntent(
-                    kind="hold_owned_title",
-                    normalized_title=old_title,
-                    owner_decision_number=target.num,
-                ),
-                acquire_content,
-            ),
-            publication=(
-                contract.ClaimIntent(
-                    kind="retain_title_owner",
-                    normalized_title=old_title,
-                    owner_decision_number=target.num,
-                ),
-                commit_content,
-            ),
-        )
-        return probes, intents
-    if new_title == old_title:
-        probes = (
-            contract.OwnedTitleClaimProbe(
-                normalized_title=old_title,
-                expected_owner_decision_number=target.num,
-            ),
-            content_probe,
-        )
-        intents = contract.ClaimIntents(
-            entry=(
-                contract.ClaimIntent(
-                    kind="acquire_title_transfer",
-                    normalized_title=old_title,
-                    from_owner_decision_number=target.num,
-                    to_owner_decision_number=new_number,
-                ),
-                acquire_content,
-            ),
-            publication=(
-                contract.ClaimIntent(
-                    kind="transfer_title_owner",
-                    normalized_title=old_title,
-                    from_owner_decision_number=target.num,
-                    to_owner_decision_number=new_number,
-                ),
-                commit_content,
-            ),
-        )
-        return probes, intents
-    probes = (
-        contract.OwnedTitleClaimProbe(
-            normalized_title=old_title,
-            expected_owner_decision_number=target.num,
-        ),
-        contract.AbsentTitleClaimProbe(normalized_title=new_title),
-        content_probe,
-    )
-    intents = contract.ClaimIntents(
-        entry=(
-            contract.ClaimIntent(
-                kind="hold_owned_title",
-                normalized_title=old_title,
-                owner_decision_number=target.num,
-            ),
-            contract.ClaimIntent(
-                kind="acquire_new_title",
-                normalized_title=new_title,
-                owner_decision_number=new_number,
-            ),
-            acquire_content,
-        ),
-        publication=(
-            contract.ClaimIntent(
-                kind="release_title_owner",
-                normalized_title=old_title,
-                owner_decision_number=target.num,
-            ),
-            contract.ClaimIntent(
-                kind="commit_title_owner",
-                normalized_title=new_title,
-                owner_decision_number=new_number,
-            ),
-            commit_content,
-        ),
-    )
-    return probes, intents
-
-
-def prepare_judgment_commit_impl(
+def prepare_judgment_commit(
     payload_bytes: bytes,
-    approval_attestation: contract.ApprovalAttestation,
-    committed_generation: contract.CommittedGeneration,
+    approval_attestation: ApprovalAttestation,
+    committed_generation: CommittedGeneration,
     expected_payload_digest: str | None = None,
     *,
     snapshot_format: Literal["serialized", "references"] = "serialized",
-) -> contract.PreparedJudgmentCommit:
+) -> PreparedJudgmentCommit:
     """Prepare immutable artifacts and semantic claim reads without I/O."""
     payload_bytes = bytes(payload_bytes)
-    digest = contract._sha256(payload_bytes)
+    digest = sha256_hex(payload_bytes)
     if expected_payload_digest is not None:
-        contract._validate_sha256(expected_payload_digest, field="expected_payload_digest")
+        validate_sha256(expected_payload_digest, field="expected_payload_digest")
         if digest != expected_payload_digest:
-            raise contract.ApprovedPayloadDigestMismatch(
+            raise ApprovedPayloadDigestMismatch(
                 "expected payload digest does not match approved payload bytes."
             )
-    payload = contract._parse_payload(payload_bytes)
+    payload = parse_payload(payload_bytes)
     if (
         payload.base_generation_id != committed_generation.generation_id
         or payload.base_decision_counter != committed_generation.decision_counter
     ):
-        raise contract.ApprovedBaseStale(
+        raise ApprovedBaseStale(
             "approved base generation and counter do not match the observed committed generation."
         )
-    current, decisions, stems_by_number = contract._parse_committed_generation(committed_generation)
-    target, target_stem = contract._target(payload.content, decisions, stems_by_number)
+    current, decisions, stems_by_number = _parse_committed_generation(committed_generation)
+    target, target_stem = _target(payload.content, decisions, stems_by_number)
     questions_bytes = current.get("open-questions.md")
     proposal = {
         "title": payload.content.title,
@@ -496,22 +290,22 @@ def prepare_judgment_commit_impl(
         "reversibility": payload.content.reversibility,
         "files_affected": list(payload.content.files_affected),
         "resolves_questions": list(payload.content.resolves_questions),
-        "source": contract.DecisionSource.mcp.value,
+        "source": DecisionSource.mcp.value,
         "base_commit": None,
     }
     questions_file = (
-        contract.OpenQuestionsFile.parse(questions_bytes.decode("utf-8"))
+        OpenQuestionsFile.parse(questions_bytes.decode("utf-8"))
         if questions_bytes is not None and payload.content.resolves_questions
         else None
     )
-    request_rejection = contract.validate_proposal_request(
+    request_rejection = validate_proposal_request(
         proposal,
         operation=payload.content.operation,
         questions_file=questions_file,
     )
     if request_rejection is not None:
-        raise contract.ProposalRejected(request_rejection)
-    evaluation = contract.evaluate_parsed_proposal(
+        raise ProposalRejected(request_rejection)
+    evaluation = evaluate_parsed_proposal(
         proposal,
         operation=payload.content.operation,
         decisions=decisions,
@@ -519,29 +313,27 @@ def prepare_judgment_commit_impl(
         affected_number=target.num if target is not None else None,
         enforce_claim_conflicts=False,
     )
-    if isinstance(evaluation, contract.ProposeDecisionResult):
-        raise contract.ProposalRejected(evaluation)
-    effective_at, provenance = contract._provenance(payload, approval_attestation)
-    artifacts, snapshot, primary, result, assigned, new_counter, primary_model = (
-        contract._build_artifacts(
-            payload=payload,
-            provenance=provenance,
-            effective_at=effective_at,
-            generation=committed_generation,
-            current=current,
-            evaluation=evaluation,
-            target=target,
-            target_stem=target_stem,
-            snapshot_format=snapshot_format,
-        )
+    if isinstance(evaluation, ProposeDecisionResult):
+        raise ProposalRejected(evaluation)
+    effective_at, provenance = derive_provenance(payload, approval_attestation)
+    artifacts, snapshot, primary, result, assigned, new_counter, primary_model = _build_artifacts(
+        payload=payload,
+        provenance=provenance,
+        effective_at=effective_at,
+        generation=committed_generation,
+        current=current,
+        evaluation=evaluation,
+        target=target,
+        target_stem=target_stem,
+        snapshot_format=snapshot_format,
     )
-    probes, intents = contract._claim_contract(payload.content.operation, target, primary_model)
-    return contract.PreparedJudgmentCommit(
+    probes, intents = build_claim_contract(payload.content.operation, target, primary_model)
+    return PreparedJudgmentCommit(
         payload_bytes=payload_bytes,
         payload_digest=digest,
         payload=payload,
         approval_attestation=approval_attestation,
-        base=contract.PreparedBase(
+        base=PreparedBase(
             generation_id=committed_generation.generation_id,
             decision_counter=committed_generation.decision_counter,
             observed_manifest_digest=committed_generation.observed_manifest_digest,
@@ -556,5 +348,5 @@ def prepare_judgment_commit_impl(
         primary_decision=primary,
         claim_probes=probes,
         claim_intents=intents,
-        result_projection=contract._CommittedResultProjection.from_result(result),
+        result_projection=_CommittedResultProjection.from_result(result),
     )

--- a/packages/nauro-core/src/nauro_core/operations/commit_plan.py
+++ b/packages/nauro-core/src/nauro_core/operations/commit_plan.py
@@ -1,910 +1,112 @@
-"""Pure two-phase planning for hosted judgment commits."""
+"""Pure two-phase planning for hosted judgment commits.
 
-# ruff: noqa: F401
+The contract module defines every type and helper; the prepare and finalize
+modules implement the two phases over it. This facade re-exports the public
+surface under the import path consumers pin.
+"""
 
-from __future__ import annotations
-
-import hashlib
-import json
-from collections.abc import Mapping, Sequence
-from datetime import date
-from typing import Annotated, Literal, TypeAlias
-
-from pydantic import (
-    BaseModel,
-    ConfigDict,
-    Field,
-    StrictInt,
-    StrictStr,
-    TypeAdapter,
-    ValidationError,
-    computed_field,
-    field_validator,
-    model_validator,
-)
-
-from nauro_core.constants import MAX_RATIONALE_LENGTH, MAX_TITLE_LENGTH
-from nauro_core.decision_model import (
-    Decision,
-    DecisionConfidence,
-    DecisionSource,
-    DecisionType,
-    RejectedAlternative,
-    Reversibility,
-    format_decision,
-    parse_decision,
-)
-from nauro_core.identifiers import IdentifierKind, validate_identifier
-from nauro_core.operations._decision_transitions import (
+from nauro_core.operations._commit_contract import (
+    AbsentContentClaimObservation,
+    AbsentContentClaimProbe,
+    AbsentTitleClaimObservation,
+    AbsentTitleClaimProbe,
+    ApprovalAttestation,
+    ApprovalAttestationRejected,
+    ApprovedBaseStale,
+    ApprovedPayload,
+    ApprovedPayloadDigestMismatch,
+    CanonicalPayloadRejected,
+    ClaimIntent,
+    ClaimIntents,
+    ClaimObservation,
+    ClaimObservationError,
+    ClaimProbe,
+    ClaimUnavailable,
+    CommittedArtifact,
+    CommittedContentClaimObservation,
+    CommittedGeneration,
+    CommittedGenerationCorrupt,
+    CommittedTitleClaimObservation,
+    ContentClaimConflict,
     DecisionProvenance,
-    append_decision_update,
-    attach_supersedes,
-    build_new_decision,
-    mark_superseded,
-    resolve_questions_content,
-    slugify_decision_title,
-)
-from nauro_core.operations._proposal_evaluation import (
-    ProposalEvaluation,
-    evaluate_parsed_proposal,
-    validate_proposal_request,
-)
-from nauro_core.operations.results import ErrorPayload, ProposeDecisionResult, RelatedDecision
-from nauro_core.parsing import _decision_number_prefix
-from nauro_core.protected_generation_membership import (
-    is_hosted_snapshot_content_member,
-    validate_protected_generation_path,
-)
-from nauro_core.provenance import validate_commit_sha, validate_utc_timestamp
-from nauro_core.questions import OpenQuestionsFile
-from nauro_core.snapshot import serialize_snapshot
-from nauro_core.validation import compute_hash, normalize_title
-
-_SHA256_HEX_LENGTH = 64
-
-
-class JudgmentCommitError(ValueError):
-    """Base class for deterministic judgment-commit planning failures."""
-
-
-class CanonicalPayloadRejected(JudgmentCommitError):
-    """Approved payload bytes are invalid or noncanonical."""
-
-
-class ApprovalAttestationRejected(JudgmentCommitError):
-    """Approval attestation conflicts with the approved payload."""
-
-
-class ApprovedPayloadDigestMismatch(JudgmentCommitError):
-    """The checked expected digest does not match the approved bytes."""
-
-
-class ApprovedBaseStale(JudgmentCommitError):
-    """The approved base is not the observed committed generation."""
-
-
-class CommittedGenerationCorrupt(JudgmentCommitError):
-    """The committed artifact corpus violates generation invariants."""
-
-
-class ProposalRejected(JudgmentCommitError):
-    """Proposal evaluation produced the existing rejected result shape."""
-
-    def __init__(self, result: ProposeDecisionResult) -> None:
-        self.result = result
-        super().__init__(result.assessment)
-
-
-class ClaimObservationError(JudgmentCommitError):
-    """Claim observations cannot finalize the prepared plan."""
-
-
-class MissingClaimObservation(ClaimObservationError):
-    pass
-
-
-class UnexpectedClaimObservation(ClaimObservationError):
-    pass
-
-
-class DuplicateClaimObservation(ClaimObservationError):
-    pass
-
-
-class MalformedClaimObservation(ClaimObservationError):
-    pass
-
-
-class MismatchedClaimObservation(ClaimObservationError):
-    pass
-
-
-class ClaimUnavailable(ClaimObservationError):
-    pass
-
-
-class TitleClaimConflict(ClaimObservationError):
-    pass
-
-
-class ContentClaimConflict(ClaimObservationError):
-    pass
-
-
-def _sha256(content: bytes) -> str:
-    return hashlib.sha256(content).hexdigest()
-
-
-def _validate_sha256(value: object, *, field: str) -> str:
-    if not isinstance(value, str):
-        raise ValueError(f"{field} must be a lowercase SHA-256 digest.")
-    if len(value) != _SHA256_HEX_LENGTH or any(char not in "0123456789abcdef" for char in value):
-        raise ValueError(f"{field} must be a lowercase SHA-256 digest.")
-    return value
-
-
-class _FrozenModel(BaseModel):
-    model_config = ConfigDict(frozen=True, extra="forbid")
-
-
-class _ImmutableResultList(list):
-    def _reject_mutation(self, *args: object, **kwargs: object) -> None:
-        raise TypeError("immutable result sequence")
-
-    __delitem__ = _reject_mutation
-    __iadd__ = _reject_mutation
-    __imul__ = _reject_mutation
-    __setitem__ = _reject_mutation
-    append = _reject_mutation
-    clear = _reject_mutation
-    extend = _reject_mutation
-    insert = _reject_mutation
-    pop = _reject_mutation
-    remove = _reject_mutation
-    reverse = _reject_mutation
-    sort = _reject_mutation
-
-
-class _CommittedResultProjection(_FrozenModel):
-    status: Literal["confirmed", "rejected"]
-    tier: StrictInt
-    operation: Literal["add", "update", "supersede", "reject"]
-    similar_decisions: tuple[RelatedDecision, ...]
-    assessment: StrictStr
-    decision_id: StrictStr | None
-    touched_decisions: tuple[StrictStr, ...]
-    resolved_questions: tuple[StrictStr, ...]
-    relocated_ids: tuple[StrictStr, ...] | None
-    skipped_prose_ids: tuple[StrictStr, ...] | None
-    error: ErrorPayload | None
-
-    @classmethod
-    def from_result(cls, result: ProposeDecisionResult) -> _CommittedResultProjection:
-        return cls.model_validate(result.model_dump())
-
-    def materialize(self) -> ProposeDecisionResult:
-        return ProposeDecisionResult.model_construct(
-            status=self.status,
-            tier=self.tier,
-            operation=self.operation,
-            similar_decisions=_ImmutableResultList(self.similar_decisions),
-            assessment=self.assessment,
-            decision_id=self.decision_id,
-            touched_decisions=_ImmutableResultList(self.touched_decisions),
-            resolved_questions=_ImmutableResultList(self.resolved_questions),
-            relocated_ids=self.relocated_ids,
-            skipped_prose_ids=self.skipped_prose_ids,
-            error=self.error,
-        )
-
-
-class RejectedSelection(_FrozenModel):
-    alternative: StrictStr
-    reason: StrictStr
-
-    @field_validator("alternative", "reason")
-    @classmethod
-    def _nonempty(cls, value: str) -> str:
-        if not value.strip():
-            raise ValueError("rejected alternative and reason must be non-empty.")
-        return value
-
-
-class JudgmentContent(_FrozenModel):
-    operation: Literal["add", "update", "supersede"]
-    affected_decision_id: StrictStr | None
-    title: StrictStr | None
-    rationale: StrictStr
-    rejected: tuple[RejectedSelection, ...]
-    confidence: Literal["high", "medium", "low"] | None
-    decision_type: (
-        Literal["architecture", "api_design", "infrastructure", "pattern", "refactor", "data_model"]
-        | None
-    )
-    reversibility: Literal["easy", "moderate", "hard"] | None
-    files_affected: tuple[StrictStr, ...]
-    resolves_questions: tuple[StrictStr, ...]
-
-    @model_validator(mode="after")
-    def _validate_operation_fields(self) -> JudgmentContent:
-        if len(self.rationale) > MAX_RATIONALE_LENGTH:
-            raise ValueError(f"rationale exceeds {MAX_RATIONALE_LENGTH} characters.")
-        if len(set(self.resolves_questions)) != len(self.resolves_questions):
-            raise ValueError("resolves_questions contains duplicate ids.")
-        if any(not value for value in self.files_affected):
-            raise ValueError("files_affected values must be non-empty strings.")
-        if self.operation == "add":
-            if self.affected_decision_id is not None:
-                raise ValueError("add requires affected_decision_id to be null.")
-        elif not self.affected_decision_id:
-            raise ValueError(f"{self.operation} requires affected_decision_id.")
-        if self.operation == "update":
-            return self
-        if self.title is not None and len(self.title) > MAX_TITLE_LENGTH:
-            raise ValueError(f"title exceeds {MAX_TITLE_LENGTH} characters.")
-        if self.confidence is None:
-            raise ValueError(f"{self.operation} requires an effective confidence value.")
-        return self
-
-
-class HostedPreTeamApprovalPayloadV1(_FrozenModel):
-    payload_schema: Literal["nauro.judgment_commit.pre_team.v1"]
-    approval_mode: Literal["pre_team_session"]
-    base_generation_id: StrictStr
-    base_decision_counter: StrictInt = Field(ge=0)
-    proposed_base_commit: None
-    content: JudgmentContent
-
-    @field_validator("base_generation_id")
-    @classmethod
-    def _generation_id(cls, value: str) -> str:
-        return validate_identifier(IdentifierKind.ulid, value, field="base_generation_id")
-
-
-class TeamProposalPayloadV1(_FrozenModel):
-    payload_schema: Literal["nauro.judgment_commit.team_proposal.v1"]
-    approval_mode: Literal["team_ratification"]
-    proposal_id: StrictStr
-    proposal_revision: StrictInt = Field(ge=1)
-    proposed_by: StrictStr
-    contributor_operation_id: StrictStr
-    base_generation_id: StrictStr
-    base_decision_counter: StrictInt = Field(ge=0)
-    proposed_base_commit: StrictStr | None
-    content: JudgmentContent
-
-    @field_validator("proposal_id", "proposed_by", "base_generation_id")
-    @classmethod
-    def _ulids(cls, value: str, info) -> str:
-        return validate_identifier(IdentifierKind.ulid, value, field=info.field_name)
-
-    @field_validator("contributor_operation_id")
-    @classmethod
-    def _operation_id(cls, value: str) -> str:
-        return validate_identifier(
-            IdentifierKind.operation_id, value, field="contributor_operation_id"
-        )
-
-    @field_validator("proposed_base_commit")
-    @classmethod
-    def _base_commit(cls, value: str | None) -> str | None:
-        if value is None:
-            return None
-        return validate_commit_sha(value, field="proposed_base_commit")
-
-
-ApprovedPayload: TypeAlias = Annotated[
-    HostedPreTeamApprovalPayloadV1 | TeamProposalPayloadV1,
-    Field(discriminator="payload_schema"),
-]
-_PAYLOAD_ADAPTER = TypeAdapter(ApprovedPayload)
-
-
-class PreTeamApprovalAttestation(_FrozenModel):
-    actor_id: StrictStr
-    operation_id: StrictStr
-    request_received_at: StrictStr
-
-    @field_validator("actor_id")
-    @classmethod
-    def _actor_id(cls, value: str) -> str:
-        return validate_identifier(IdentifierKind.ulid, value, field="actor_id")
-
-    @field_validator("operation_id")
-    @classmethod
-    def _operation_id(cls, value: str) -> str:
-        return validate_identifier(IdentifierKind.operation_id, value, field="operation_id")
-
-    @field_validator("request_received_at")
-    @classmethod
-    def _timestamp(cls, value: str) -> str:
-        return validate_utc_timestamp(value, field="request_received_at")
-
-
-class TeamRatificationAttestation(_FrozenModel):
-    approved_by: StrictStr
-    approved_at: StrictStr
-    ratification_action_id: StrictStr
-
-    @field_validator("approved_by", "ratification_action_id")
-    @classmethod
-    def _ulids(cls, value: str, info) -> str:
-        return validate_identifier(IdentifierKind.ulid, value, field=info.field_name)
-
-    @field_validator("approved_at")
-    @classmethod
-    def _timestamp(cls, value: str) -> str:
-        return validate_utc_timestamp(value, field="approved_at")
-
-
-ApprovalAttestation: TypeAlias = PreTeamApprovalAttestation | TeamRatificationAttestation
-
-
-class CommittedArtifact(_FrozenModel):
-    path: StrictStr
-    content: bytes
-    manifest_artifact_digest: StrictStr
-
-    @model_validator(mode="after")
-    def _validate_artifact(self) -> CommittedArtifact:
-        validate_protected_generation_path(self.path)
-        _validate_sha256(self.manifest_artifact_digest, field="manifest_artifact_digest")
-        if _sha256(self.content) != self.manifest_artifact_digest:
-            raise ValueError(f"artifact digest mismatch for {self.path!r}.")
-        return self
-
-
-class CommittedGeneration(_FrozenModel):
-    generation_id: StrictStr
-    decision_counter: StrictInt = Field(ge=0)
-    observed_manifest_digest: StrictStr
-    artifacts: tuple[CommittedArtifact, ...]
-
-    @field_validator("generation_id")
-    @classmethod
-    def _generation_id(cls, value: str) -> str:
-        return validate_identifier(IdentifierKind.ulid, value, field="generation_id")
-
-    @field_validator("observed_manifest_digest")
-    @classmethod
-    def _manifest_digest(cls, value: str) -> str:
-        return _validate_sha256(value, field="observed_manifest_digest")
-
-    @model_validator(mode="after")
-    def _unique_paths(self) -> CommittedGeneration:
-        paths = [artifact.path for artifact in self.artifacts]
-        if len(set(paths)) != len(paths):
-            raise ValueError("committed generation contains duplicate artifact paths.")
-        return self
-
-
-class PreparedBase(_FrozenModel):
-    generation_id: StrictStr
-    decision_counter: StrictInt = Field(ge=0)
-    observed_manifest_digest: StrictStr
-
-    @field_validator("generation_id")
-    @classmethod
-    def _generation_id(cls, value: str) -> str:
-        return validate_identifier(IdentifierKind.ulid, value, field="generation_id")
-
-    @field_validator("observed_manifest_digest")
-    @classmethod
-    def _manifest_digest(cls, value: str) -> str:
-        return _validate_sha256(value, field="observed_manifest_digest")
-
-
-class PlannedArtifact(_FrozenModel):
-    path: StrictStr
-    content: bytes
-
-    @field_validator("path")
-    @classmethod
-    def _path(cls, value: str) -> str:
-        return validate_protected_generation_path(value)
-
-    @computed_field
-    @property
-    def sha256(self) -> str:
-        return _sha256(self.content)
-
-    @computed_field
-    @property
-    def length(self) -> int:
-        return len(self.content)
-
-
-class PlannedSnapshot(_FrozenModel):
-    content: bytes
-
-    @computed_field
-    @property
-    def sha256(self) -> str:
-        return _sha256(self.content)
-
-    @computed_field
-    @property
-    def length(self) -> int:
-        return len(self.content)
-
-
-class PrimaryDecision(_FrozenModel):
-    decision_id: StrictStr
-    path: StrictStr
-    sha256: StrictStr
-
-    @field_validator("sha256")
-    @classmethod
-    def _digest(cls, value: str) -> str:
-        return _validate_sha256(value, field="primary_decision.sha256")
-
-    @model_validator(mode="after")
-    def _path_matches_id(self) -> PrimaryDecision:
-        if self.path != f"decisions/{self.decision_id}.md":
-            raise ValueError("primary decision path must derive from decision_id.")
-        return self
-
-
-def _validate_normalized_title(value: str) -> str:
-    if not value or normalize_title(value) != value:
-        raise ValueError("normalized_title must be non-empty canonical normalized title text.")
-    return value
-
-
-class AbsentTitleClaimProbe(_FrozenModel):
-    kind: Literal["absent_title"] = "absent_title"
-    normalized_title: StrictStr
-
-    _normalized = field_validator("normalized_title")(_validate_normalized_title)
-
-
-class OwnedTitleClaimProbe(_FrozenModel):
-    kind: Literal["owned_title"] = "owned_title"
-    normalized_title: StrictStr
-    expected_owner_decision_number: StrictInt = Field(gt=0)
-
-    _normalized = field_validator("normalized_title")(_validate_normalized_title)
-
-
-class AbsentContentClaimProbe(_FrozenModel):
-    kind: Literal["absent_content"] = "absent_content"
-    content_hash: StrictStr
-
-    @field_validator("content_hash")
-    @classmethod
-    def _content_hash(cls, value: str) -> str:
-        return _validate_sha256(value, field="content_hash")
-
-
-ClaimProbe: TypeAlias = Annotated[
-    AbsentTitleClaimProbe | OwnedTitleClaimProbe | AbsentContentClaimProbe,
-    Field(discriminator="kind"),
-]
-
-
-class AbsentTitleClaimObservation(_FrozenModel):
-    kind: Literal["absent_title"] = "absent_title"
-    normalized_title: StrictStr
-
-    _normalized = field_validator("normalized_title")(_validate_normalized_title)
-
-
-class CommittedTitleClaimObservation(_FrozenModel):
-    kind: Literal["committed_title"] = "committed_title"
-    normalized_title: StrictStr
-    owner_decision_number: StrictInt = Field(gt=0)
-
-    _normalized = field_validator("normalized_title")(_validate_normalized_title)
-
-
-class UnavailableTitleClaimObservation(_FrozenModel):
-    kind: Literal["unavailable_title"] = "unavailable_title"
-    normalized_title: StrictStr
-    reason: Literal["reserved", "recovery_required"]
-
-    _normalized = field_validator("normalized_title")(_validate_normalized_title)
-
-
-class AbsentContentClaimObservation(_FrozenModel):
-    kind: Literal["absent_content"] = "absent_content"
-    content_hash: StrictStr
-
-    @field_validator("content_hash")
-    @classmethod
-    def _content_hash(cls, value: str) -> str:
-        return _validate_sha256(value, field="content_hash")
-
-
-class CommittedContentClaimObservation(_FrozenModel):
-    kind: Literal["committed_content"] = "committed_content"
-    content_hash: StrictStr
-
-    @field_validator("content_hash")
-    @classmethod
-    def _content_hash(cls, value: str) -> str:
-        return _validate_sha256(value, field="content_hash")
-
-
-class UnavailableContentClaimObservation(_FrozenModel):
-    kind: Literal["unavailable_content"] = "unavailable_content"
-    content_hash: StrictStr
-    reason: Literal["reserved", "recovery_required"]
-
-    @field_validator("content_hash")
-    @classmethod
-    def _content_hash(cls, value: str) -> str:
-        return _validate_sha256(value, field="content_hash")
-
-
-ClaimObservation: TypeAlias = Annotated[
-    AbsentTitleClaimObservation
-    | CommittedTitleClaimObservation
-    | UnavailableTitleClaimObservation
-    | AbsentContentClaimObservation
-    | CommittedContentClaimObservation
-    | UnavailableContentClaimObservation,
-    Field(discriminator="kind"),
-]
-_OBSERVATION_ADAPTER = TypeAdapter(ClaimObservation)
-
-
-class ClaimIntent(_FrozenModel):
-    kind: Literal[
-        "acquire_new_title",
-        "hold_owned_title",
-        "acquire_title_transfer",
-        "acquire_new_content_hash",
-        "commit_title_owner",
-        "retain_title_owner",
-        "release_title_owner",
-        "transfer_title_owner",
-        "commit_content_hash",
-    ]
-    normalized_title: StrictStr | None = None
-    content_hash: StrictStr | None = None
-    owner_decision_number: StrictInt | None = Field(default=None, gt=0)
-    from_owner_decision_number: StrictInt | None = Field(default=None, gt=0)
-    to_owner_decision_number: StrictInt | None = Field(default=None, gt=0)
-
-
-class ClaimIntents(_FrozenModel):
-    entry: tuple[ClaimIntent, ...]
-    publication: tuple[ClaimIntent, ...]
-
-
-class FinalizedClaimPlan(_FrozenModel):
-    entry: tuple[ClaimIntent, ...]
-    publication: tuple[ClaimIntent, ...]
-
-
-class PreparedJudgmentCommit(_FrozenModel):
-    schema_version: Literal[1] = 1
-    transformation_version: Literal[1] = 1
-    payload_bytes: bytes
-    payload_digest: StrictStr
-    payload: ApprovedPayload
-    approval_attestation: ApprovalAttestation
-    base: PreparedBase
-    effective_at: StrictStr
-    decision_provenance: DecisionProvenance | None
-    assigned_decision_number: StrictInt | None = Field(default=None, gt=0)
-    new_decision_counter: StrictInt = Field(ge=0)
-    planned_artifacts: tuple[PlannedArtifact, ...]
-    snapshot: PlannedSnapshot
-    snapshot_format: Literal["serialized", "references"] = "serialized"
-    primary_decision: PrimaryDecision
-    claim_probes: tuple[ClaimProbe, ...]
-    claim_intents: ClaimIntents
-    result_projection: _CommittedResultProjection
-
-    @property
-    def committed_result(self) -> ProposeDecisionResult:
-        return self.result_projection.materialize()
-
-    @model_validator(mode="after")
-    def _cross_validate(self) -> PreparedJudgmentCommit:
-        if _sha256(self.payload_bytes) != self.payload_digest:
-            raise ValueError("payload digest does not derive from payload bytes.")
-        if _parse_payload(self.payload_bytes) != self.payload:
-            raise ValueError("parsed payload does not derive from payload bytes.")
-        if (
-            self.payload.base_generation_id != self.base.generation_id
-            or self.payload.base_decision_counter != self.base.decision_counter
-        ):
-            raise ValueError("prepared base does not match the approved payload.")
-        effective_at, provenance = _provenance(self.payload, self.approval_attestation)
-        if effective_at != self.effective_at or provenance != self.decision_provenance:
-            raise ValueError("approval attestation does not match effective provenance.")
-        paths = [artifact.path for artifact in self.planned_artifacts]
-        if paths != sorted(paths) or len(paths) != len(set(paths)):
-            raise ValueError("planned artifacts must be unique and path-sorted.")
-        primary = next(
-            (
-                artifact
-                for artifact in self.planned_artifacts
-                if artifact.path == self.primary_decision.path
-            ),
-            None,
-        )
-        if primary is None or primary.sha256 != self.primary_decision.sha256:
-            raise ValueError("primary decision does not match planned artifact bytes.")
-        primary_model = parse_decision(
-            primary.content.decode("utf-8"),
-            self.primary_decision.path.removeprefix("decisions/"),
-        )
-        target_model = None
-        if self.payload.content.affected_decision_id is not None:
-            target_path = f"decisions/{self.payload.content.affected_decision_id}.md"
-            target_artifact = next(
-                (artifact for artifact in self.planned_artifacts if artifact.path == target_path),
-                None,
-            )
-            if target_artifact is None:
-                raise ValueError("affected decision is absent from planned artifacts.")
-            target_model = parse_decision(
-                target_artifact.content.decode("utf-8"),
-                target_path.removeprefix("decisions/"),
-            )
-        probes, intents = _claim_contract(
-            self.payload.content.operation,
-            target_model,
-            primary_model,
-        )
-        if probes != self.claim_probes or intents != self.claim_intents:
-            raise ValueError("claim probes and intents do not derive from planned artifacts.")
-        if (
-            _derive_snapshot_bytes(
-                self.planned_artifacts,
-                payload=self.payload,
-                effective_at=self.effective_at,
-                snapshot_format=self.snapshot_format,
-            )
-            != self.snapshot.content
-        ):
-            raise ValueError("snapshot bytes do not derive from planned artifacts.")
-        expected_counter = self.base.decision_counter + (
-            1 if self.payload.content.operation in ("add", "supersede") else 0
-        )
-        if self.new_decision_counter != expected_counter:
-            raise ValueError("new decision counter does not match the operation.")
-        if self.payload.content.operation in ("add", "supersede"):
-            if self.assigned_decision_number != expected_counter:
-                raise ValueError("assigned number must equal counter plus one.")
-        elif self.assigned_decision_number is not None:
-            raise ValueError("update must not assign a decision number.")
-        expected_touched = [self.primary_decision.decision_id]
-        if self.payload.content.operation == "supersede":
-            assert self.payload.content.affected_decision_id is not None
-            expected_touched.append(self.payload.content.affected_decision_id)
-        if (
-            self.committed_result.status != "confirmed"
-            or self.committed_result.tier != 2
-            or self.committed_result.operation != self.payload.content.operation
-            or self.committed_result.decision_id != self.primary_decision.decision_id
-            or self.committed_result.touched_decisions != expected_touched
-            or self.committed_result.error is not None
-        ):
-            raise ValueError("committed result does not match the planned transition.")
-        return self
-
-
-class JudgmentCommitPlan(_FrozenModel):
-    schema_version: Literal[1] = 1
-    prepared: PreparedJudgmentCommit
-    validated_claim_observations: tuple[ClaimObservation, ...]
-    claim_plan: FinalizedClaimPlan
-    plan_record_bytes: bytes
-
-    @computed_field
-    @property
-    def plan_record_digest(self) -> str:
-        return _sha256(self.plan_record_bytes)
-
-    @property
-    def committed_result(self) -> ProposeDecisionResult:
-        return self.prepared.committed_result
-
-    @model_validator(mode="after")
-    def _verify_record(self) -> JudgmentCommitPlan:
-        if tuple(_observation_key(value) for value in self.validated_claim_observations) != tuple(
-            _probe_key(value) for value in self.prepared.claim_probes
-        ):
-            raise ValueError("validated observations do not match prepared probe order.")
-        for probe, observation in zip(
-            self.prepared.claim_probes,
-            self.validated_claim_observations,
-            strict=True,
-        ):
-            _validate_observation(probe, observation)
-        if self.claim_plan.entry != self.prepared.claim_intents.entry or (
-            self.claim_plan.publication != self.prepared.claim_intents.publication
-        ):
-            raise ValueError("finalized claim plan does not derive from prepared intents.")
-        if self.plan_record_bytes != _plan_record(self.prepared, self.validated_claim_observations):
-            raise ValueError("plan record bytes do not derive from the prepared plan.")
-        return self
-
-
-def canonical_judgment_payload_bytes(payload: Mapping[str, object]) -> bytes:
-    """Serialize the only accepted approved payload byte representation."""
-    return json.dumps(
-        payload,
-        sort_keys=True,
-        separators=(",", ":"),
-        ensure_ascii=False,
-        allow_nan=False,
-    ).encode("utf-8")
-
-
-def _reject_duplicate_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
-    from . import _commit_prepare
-
-    return _commit_prepare._reject_duplicate_keys_impl(pairs)
-
-
-def _parse_payload(payload_bytes: bytes) -> ApprovedPayload:
-    from . import _commit_prepare
-
-    return _commit_prepare._parse_payload_impl(payload_bytes)
-
-
-def _parse_committed_generation(
-    generation: CommittedGeneration,
-) -> tuple[dict[str, bytes], list[Decision], dict[int, str]]:
-    from . import _commit_prepare
-
-    return _commit_prepare._parse_committed_generation_impl(generation)
-
-
-def _rejected_result(
-    tier: int,
-    operation: Literal["add", "update", "supersede"],
-    assessment: str,
-) -> ProposalRejected:
-    from . import _commit_prepare
-
-    return _commit_prepare._rejected_result_impl(tier, operation, assessment)
-
-
-def _target(
-    content: JudgmentContent,
-    decisions: list[Decision],
-    stems_by_number: dict[int, str],
-) -> tuple[Decision | None, str | None]:
-    from . import _commit_prepare
-
-    return _commit_prepare._target_impl(content, decisions, stems_by_number)
-
-
-def _provenance(
-    payload: ApprovedPayload,
-    attestation: ApprovalAttestation,
-) -> tuple[str, DecisionProvenance | None]:
-    from . import _commit_prepare
-
-    return _commit_prepare._provenance_impl(payload, attestation)
-
-
-def _derive_snapshot_bytes(
-    artifacts: tuple[PlannedArtifact, ...],
-    *,
-    payload: ApprovedPayload,
-    effective_at: str,
-    snapshot_format: Literal["serialized", "references"] = "serialized",
-) -> bytes:
-    from . import _commit_prepare
-
-    return _commit_prepare._derive_snapshot_bytes_impl(
-        artifacts,
-        payload=payload,
-        effective_at=effective_at,
-        snapshot_format=snapshot_format,
-    )
-
-
-def _build_artifacts(
-    *,
-    payload: ApprovedPayload,
-    provenance: DecisionProvenance | None,
-    effective_at: str,
-    generation: CommittedGeneration,
-    current: dict[str, bytes],
-    evaluation: ProposalEvaluation,
-    target: Decision | None,
-    target_stem: str | None,
-    snapshot_format: Literal["serialized", "references"] = "serialized",
-) -> tuple[
-    tuple[PlannedArtifact, ...],
+    DuplicateClaimObservation,
+    FinalizedClaimPlan,
+    HostedPreTeamApprovalPayloadV1,
+    JudgmentCommitError,
+    JudgmentCommitPlan,
+    JudgmentContent,
+    MalformedClaimObservation,
+    MismatchedClaimObservation,
+    MissingClaimObservation,
+    OwnedTitleClaimProbe,
+    PlannedArtifact,
     PlannedSnapshot,
+    PreparedBase,
+    PreparedJudgmentCommit,
+    PreTeamApprovalAttestation,
     PrimaryDecision,
-    ProposeDecisionResult,
-    int | None,
-    int,
-    Decision,
-]:
-    from . import _commit_prepare
+    ProposalRejected,
+    RejectedSelection,
+    TeamProposalPayloadV1,
+    TeamRatificationAttestation,
+    TitleClaimConflict,
+    UnavailableContentClaimObservation,
+    UnavailableTitleClaimObservation,
+    UnexpectedClaimObservation,
+    canonical_judgment_payload_bytes,
+)
+from nauro_core.operations._commit_finalize import finalize_judgment_commit
+from nauro_core.operations._commit_prepare import prepare_judgment_commit
 
-    return _commit_prepare._build_artifacts_impl(
-        payload=payload,
-        provenance=provenance,
-        effective_at=effective_at,
-        generation=generation,
-        current=current,
-        evaluation=evaluation,
-        target=target,
-        target_stem=target_stem,
-        snapshot_format=snapshot_format,
-    )
-
-
-def _claim_contract(
-    operation: str,
-    target: Decision | None,
-    primary: Decision,
-) -> tuple[tuple[ClaimProbe, ...], ClaimIntents]:
-    from . import _commit_prepare
-
-    return _commit_prepare._claim_contract_impl(operation, target, primary)
-
-
-def prepare_judgment_commit(
-    payload_bytes: bytes,
-    approval_attestation: ApprovalAttestation,
-    committed_generation: CommittedGeneration,
-    expected_payload_digest: str | None = None,
-    *,
-    snapshot_format: Literal["serialized", "references"] = "serialized",
-) -> PreparedJudgmentCommit:
-    """Prepare immutable artifacts and semantic claim reads without I/O."""
-    from . import _commit_prepare
-
-    return _commit_prepare.prepare_judgment_commit_impl(
-        payload_bytes,
-        approval_attestation,
-        committed_generation,
-        expected_payload_digest,
-        snapshot_format=snapshot_format,
-    )
-
-
-def _probe_key(probe: ClaimProbe) -> tuple[str, str]:
-    from . import _commit_finalize
-
-    return _commit_finalize._probe_key_impl(probe)
-
-
-def _observation_key(observation: ClaimObservation) -> tuple[str, str]:
-    from . import _commit_finalize
-
-    return _commit_finalize._observation_key_impl(observation)
-
-
-def _validate_observation(probe: ClaimProbe, observation: ClaimObservation) -> None:
-    from . import _commit_finalize
-
-    return _commit_finalize._validate_observation_impl(probe, observation)
-
-
-def _artifact_inventory(prepared: PreparedJudgmentCommit) -> dict[str, object]:
-    from . import _commit_finalize
-
-    return _commit_finalize._artifact_inventory_impl(prepared)
-
-
-def _plan_record(
-    prepared: PreparedJudgmentCommit,
-    observations: tuple[ClaimObservation, ...],
-) -> bytes:
-    from . import _commit_finalize
-
-    return _commit_finalize._plan_record_impl(prepared, observations)
-
-
-def finalize_judgment_commit(
-    prepared: PreparedJudgmentCommit,
-    claim_observations: Sequence[ClaimObservation | Mapping[str, object]],
-) -> JudgmentCommitPlan:
-    """Validate claim observations and finalize the storage-neutral plan."""
-    from . import _commit_finalize
-
-    return _commit_finalize.finalize_judgment_commit_impl(prepared, claim_observations)
+__all__ = [
+    "AbsentContentClaimObservation",
+    "AbsentContentClaimProbe",
+    "AbsentTitleClaimObservation",
+    "AbsentTitleClaimProbe",
+    "ApprovalAttestation",
+    "ApprovalAttestationRejected",
+    "ApprovedBaseStale",
+    "ApprovedPayload",
+    "ApprovedPayloadDigestMismatch",
+    "CanonicalPayloadRejected",
+    "ClaimIntent",
+    "ClaimIntents",
+    "ClaimObservation",
+    "ClaimObservationError",
+    "ClaimProbe",
+    "ClaimUnavailable",
+    "CommittedArtifact",
+    "CommittedContentClaimObservation",
+    "CommittedGeneration",
+    "CommittedGenerationCorrupt",
+    "CommittedTitleClaimObservation",
+    "ContentClaimConflict",
+    "DecisionProvenance",
+    "DuplicateClaimObservation",
+    "FinalizedClaimPlan",
+    "HostedPreTeamApprovalPayloadV1",
+    "JudgmentCommitError",
+    "JudgmentCommitPlan",
+    "JudgmentContent",
+    "MalformedClaimObservation",
+    "MismatchedClaimObservation",
+    "MissingClaimObservation",
+    "OwnedTitleClaimProbe",
+    "PlannedArtifact",
+    "PlannedSnapshot",
+    "PreTeamApprovalAttestation",
+    "PreparedBase",
+    "PreparedJudgmentCommit",
+    "PrimaryDecision",
+    "ProposalRejected",
+    "RejectedSelection",
+    "TeamProposalPayloadV1",
+    "TeamRatificationAttestation",
+    "TitleClaimConflict",
+    "UnavailableContentClaimObservation",
+    "UnavailableTitleClaimObservation",
+    "UnexpectedClaimObservation",
+    "canonical_judgment_payload_bytes",
+    "finalize_judgment_commit",
+    "prepare_judgment_commit",
+]

--- a/packages/nauro-core/tests/operations/test_commit_plan.py
+++ b/packages/nauro-core/tests/operations/test_commit_plan.py
@@ -810,208 +810,36 @@ def test_final_plan_constructor_rejects_tampered_record_bytes() -> None:
         plan.__class__(**fields)
 
 
-_FACADE_NAME_MANIFEST = (
-    "AbsentContentClaimObservation",
-    "AbsentContentClaimProbe",
-    "AbsentTitleClaimObservation",
-    "AbsentTitleClaimProbe",
-    "Annotated",
-    "ApprovalAttestation",
-    "ApprovalAttestationRejected",
-    "ApprovedBaseStale",
-    "ApprovedPayload",
-    "ApprovedPayloadDigestMismatch",
-    "BaseModel",
-    "CanonicalPayloadRejected",
-    "ClaimIntent",
-    "ClaimIntents",
-    "ClaimObservation",
-    "ClaimObservationError",
-    "ClaimProbe",
-    "ClaimUnavailable",
-    "CommittedArtifact",
-    "CommittedContentClaimObservation",
-    "CommittedGeneration",
-    "CommittedGenerationCorrupt",
-    "CommittedTitleClaimObservation",
-    "ConfigDict",
-    "ContentClaimConflict",
-    "Decision",
-    "DecisionConfidence",
-    "DecisionProvenance",
-    "DecisionSource",
-    "DecisionType",
-    "DuplicateClaimObservation",
-    "ErrorPayload",
-    "Field",
-    "FinalizedClaimPlan",
-    "HostedPreTeamApprovalPayloadV1",
-    "IdentifierKind",
-    "JudgmentCommitError",
-    "JudgmentCommitPlan",
-    "JudgmentContent",
-    "Literal",
-    "MAX_RATIONALE_LENGTH",
-    "MAX_TITLE_LENGTH",
-    "MalformedClaimObservation",
-    "Mapping",
-    "MismatchedClaimObservation",
-    "MissingClaimObservation",
-    "OpenQuestionsFile",
-    "OwnedTitleClaimProbe",
-    "PlannedArtifact",
-    "PlannedSnapshot",
-    "PreTeamApprovalAttestation",
-    "PreparedBase",
-    "PreparedJudgmentCommit",
-    "PrimaryDecision",
-    "ProposalEvaluation",
-    "ProposalRejected",
-    "ProposeDecisionResult",
-    "RejectedAlternative",
-    "RejectedSelection",
-    "RelatedDecision",
-    "Reversibility",
-    "Sequence",
-    "StrictInt",
-    "StrictStr",
-    "TeamProposalPayloadV1",
-    "TeamRatificationAttestation",
-    "TitleClaimConflict",
-    "TypeAdapter",
-    "TypeAlias",
-    "UnavailableContentClaimObservation",
-    "UnavailableTitleClaimObservation",
-    "UnexpectedClaimObservation",
-    "ValidationError",
-    "_CommittedResultProjection",
-    "_FrozenModel",
-    "_ImmutableResultList",
-    "_OBSERVATION_ADAPTER",
-    "_PAYLOAD_ADAPTER",
-    "_SHA256_HEX_LENGTH",
+_CONTRACT_HELPERS = (
     "_artifact_inventory",
-    "_build_artifacts",
-    "_claim_contract",
-    "_decision_number_prefix",
-    "_derive_snapshot_bytes",
-    "_observation_key",
-    "_parse_committed_generation",
-    "_parse_payload",
-    "_plan_record",
-    "_probe_key",
-    "_provenance",
+    "build_claim_contract",
+    "derive_snapshot_bytes",
+    "observation_key",
+    "parse_payload",
+    "build_plan_record",
+    "probe_key",
+    "derive_provenance",
     "_reject_duplicate_keys",
-    "_rejected_result",
-    "_sha256",
-    "_target",
+    "sha256_hex",
     "_validate_normalized_title",
-    "_validate_observation",
-    "_validate_sha256",
-    "annotations",
-    "append_decision_update",
-    "attach_supersedes",
-    "build_new_decision",
+    "validate_observation",
+    "validate_sha256",
     "canonical_judgment_payload_bytes",
-    "compute_hash",
-    "computed_field",
-    "date",
-    "evaluate_parsed_proposal",
-    "field_validator",
-    "finalize_judgment_commit",
-    "format_decision",
-    "hashlib",
-    "is_hosted_snapshot_content_member",
-    "json",
-    "mark_superseded",
-    "model_validator",
-    "normalize_title",
-    "parse_decision",
-    "prepare_judgment_commit",
-    "resolve_questions_content",
-    "serialize_snapshot",
-    "slugify_decision_title",
-    "validate_commit_sha",
-    "validate_identifier",
-    "validate_proposal_request",
-    "validate_protected_generation_path",
-    "validate_utc_timestamp",
 )
 
-_FACADE_DEFINED_CLASSES = (
-    "AbsentContentClaimObservation",
-    "AbsentContentClaimProbe",
-    "AbsentTitleClaimObservation",
-    "AbsentTitleClaimProbe",
-    "ApprovalAttestationRejected",
-    "ApprovedBaseStale",
-    "ApprovedPayloadDigestMismatch",
-    "CanonicalPayloadRejected",
-    "ClaimIntent",
-    "ClaimIntents",
-    "ClaimObservationError",
-    "ClaimUnavailable",
-    "CommittedArtifact",
-    "CommittedContentClaimObservation",
-    "CommittedGeneration",
-    "CommittedGenerationCorrupt",
-    "CommittedTitleClaimObservation",
-    "ContentClaimConflict",
-    "DuplicateClaimObservation",
-    "FinalizedClaimPlan",
-    "HostedPreTeamApprovalPayloadV1",
-    "JudgmentCommitError",
-    "JudgmentCommitPlan",
-    "JudgmentContent",
-    "MalformedClaimObservation",
-    "MismatchedClaimObservation",
-    "MissingClaimObservation",
-    "OwnedTitleClaimProbe",
-    "PlannedArtifact",
-    "PlannedSnapshot",
-    "PreTeamApprovalAttestation",
-    "PreparedBase",
-    "PreparedJudgmentCommit",
-    "PrimaryDecision",
-    "ProposalRejected",
-    "RejectedSelection",
-    "TeamProposalPayloadV1",
-    "TeamRatificationAttestation",
-    "TitleClaimConflict",
-    "UnavailableContentClaimObservation",
-    "UnavailableTitleClaimObservation",
-    "UnexpectedClaimObservation",
-    "_CommittedResultProjection",
-    "_FrozenModel",
-    "_ImmutableResultList",
-)
-
-_FACADE_DEFINED_FUNCTIONS = (
-    "_artifact_inventory",
+_PREPARE_HELPERS = (
     "_build_artifacts",
-    "_claim_contract",
-    "_derive_snapshot_bytes",
-    "_observation_key",
     "_parse_committed_generation",
-    "_parse_payload",
-    "_plan_record",
-    "_probe_key",
-    "_provenance",
-    "_reject_duplicate_keys",
     "_rejected_result",
-    "_sha256",
     "_target",
-    "_validate_normalized_title",
-    "_validate_observation",
-    "_validate_sha256",
-    "canonical_judgment_payload_bytes",
-    "finalize_judgment_commit",
     "prepare_judgment_commit",
 )
+
+_FINALIZE_HELPERS = ("finalize_judgment_commit",)
 
 _MOVED_FUNCTION_METADATA = {
     "_reject_duplicate_keys": ("(pairs: 'list[tuple[str, object]]') -> 'dict[str, object]'", None),
-    "_parse_payload": ("(payload_bytes: 'bytes') -> 'ApprovedPayload'", None),
+    "parse_payload": ("(payload_bytes: 'bytes') -> 'ApprovedPayload'", None),
     "_parse_committed_generation": (
         "(generation: 'CommittedGeneration') -> "
         "'tuple[dict[str, bytes], list[Decision], dict[int, str]]'",
@@ -1027,12 +855,12 @@ _MOVED_FUNCTION_METADATA = {
         "stems_by_number: 'dict[int, str]') -> 'tuple[Decision | None, str | None]'",
         None,
     ),
-    "_provenance": (
+    "derive_provenance": (
         "(payload: 'ApprovedPayload', attestation: 'ApprovalAttestation') -> "
         "'tuple[str, DecisionProvenance | None]'",
         None,
     ),
-    "_derive_snapshot_bytes": (
+    "derive_snapshot_bytes": (
         "(artifacts: 'tuple[PlannedArtifact, ...]', *, payload: 'ApprovedPayload', "
         "effective_at: 'str', "
         "snapshot_format: \"Literal['serialized', 'references']\" = 'serialized') -> 'bytes'",
@@ -1048,7 +876,7 @@ _MOVED_FUNCTION_METADATA = {
         "PrimaryDecision, ProposeDecisionResult, int | None, int, Decision]'",
         None,
     ),
-    "_claim_contract": (
+    "build_claim_contract": (
         "(operation: 'str', target: 'Decision | None', primary: 'Decision') -> "
         "'tuple[tuple[ClaimProbe, ...], ClaimIntents]'",
         None,
@@ -1061,12 +889,12 @@ _MOVED_FUNCTION_METADATA = {
         "-> 'PreparedJudgmentCommit'",
         "Prepare immutable artifacts and semantic claim reads without I/O.",
     ),
-    "_probe_key": ("(probe: 'ClaimProbe') -> 'tuple[str, str]'", None),
-    "_observation_key": (
+    "probe_key": ("(probe: 'ClaimProbe') -> 'tuple[str, str]'", None),
+    "observation_key": (
         "(observation: 'ClaimObservation') -> 'tuple[str, str]'",
         None,
     ),
-    "_validate_observation": (
+    "validate_observation": (
         "(probe: 'ClaimProbe', observation: 'ClaimObservation') -> 'None'",
         None,
     ),
@@ -1074,7 +902,7 @@ _MOVED_FUNCTION_METADATA = {
         "(prepared: 'PreparedJudgmentCommit') -> 'dict[str, object]'",
         None,
     ),
-    "_plan_record": (
+    "build_plan_record": (
         "(prepared: 'PreparedJudgmentCommit', observations: "
         "'tuple[ClaimObservation, ...]') -> 'bytes'",
         None,
@@ -1110,17 +938,32 @@ def _observations_for(prepared):
     return observations
 
 
-def test_commit_plan_facade_manifest_and_module_identity_are_stable() -> None:
+def test_commit_plan_facade_exports_only_contract_and_phase_entry_points() -> None:
     import inspect
 
     import nauro_core.operations.commit_plan as contract
-    from nauro_core.operations import _commit_finalize, _commit_prepare
+    from nauro_core.operations import _commit_contract, _commit_finalize, _commit_prepare
+    from nauro_core.operations._decision_transitions import DecisionProvenance
 
-    assert tuple(sorted(name for name in vars(contract) if not name.startswith("__"))) == (
-        _FACADE_NAME_MANIFEST
-    )
-    for name in _FACADE_DEFINED_CLASSES + _FACADE_DEFINED_FUNCTIONS:
-        assert getattr(contract, name).__module__ == contract.__name__
+    exported = sorted(name for name in vars(contract) if not name.startswith("_"))
+    assert exported == sorted(contract.__all__)
+    assert "prepare_judgment_commit" in exported and "finalize_judgment_commit" in exported
+    assert contract.prepare_judgment_commit is _commit_prepare.prepare_judgment_commit
+    assert contract.finalize_judgment_commit is _commit_finalize.finalize_judgment_commit
+    for name in exported:
+        value = getattr(contract, name)
+        if value is DecisionProvenance:
+            continue
+        if inspect.isclass(value):
+            assert value.__module__ == _commit_contract.__name__, name
+        elif inspect.isfunction(value):
+            owner = {
+                "prepare_judgment_commit": _commit_prepare,
+                "finalize_judgment_commit": _commit_finalize,
+            }.get(name, _commit_contract)
+            assert value.__module__ == owner.__name__, name
+        else:
+            assert value is getattr(_commit_contract, name), name
     for private_module in (_commit_prepare, _commit_finalize):
         assert not [
             name
@@ -1132,12 +975,15 @@ def test_commit_plan_facade_manifest_and_module_identity_are_stable() -> None:
 def test_commit_plan_moved_function_metadata_is_stable() -> None:
     import inspect
 
-    import nauro_core.operations.commit_plan as contract
+    from nauro_core.operations import _commit_contract, _commit_finalize, _commit_prepare
 
+    owners = {name: _commit_contract for name in _CONTRACT_HELPERS}
+    owners.update({name: _commit_prepare for name in _PREPARE_HELPERS})
+    owners.update({name: _commit_finalize for name in _FINALIZE_HELPERS})
     actual = {
         name: (
-            str(inspect.signature(getattr(contract, name))),
-            inspect.getdoc(getattr(contract, name)),
+            str(inspect.signature(getattr(owners[name], name))),
+            inspect.getdoc(getattr(owners[name], name)),
         )
         for name in _MOVED_FUNCTION_METADATA
     }
@@ -1355,10 +1201,32 @@ def _facade_model_contract_projection(contract):
     return models
 
 
-def test_commit_plan_facade_model_contract_digest_is_stable() -> None:
-    import nauro_core.operations.commit_plan as contract
+def _with_module(value, *, source: str, target: str):
+    """Rewrite every ``module`` key equal to ``source`` into ``target``, recursively."""
+    if isinstance(value, dict):
+        return {
+            key: (
+                target
+                if key == "module" and item == source
+                else _with_module(item, source=source, target=target)
+            )
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_with_module(item, source=source, target=target) for item in value]
+    return value
 
-    projection = _facade_model_contract_projection(contract)
+
+def test_commit_plan_facade_model_contract_digest_is_stable() -> None:
+    import nauro_core.operations.commit_plan as facade
+    from nauro_core.operations import _commit_contract
+
+    # The digest pins model shape, not location: module keys normalize to the facade.
+    projection = _with_module(
+        _facade_model_contract_projection(_commit_contract),
+        source=_commit_contract.__name__,
+        target=facade.__name__,
+    )
     projection_bytes = json.dumps(
         projection,
         sort_keys=True,
@@ -1400,61 +1268,9 @@ def test_commit_plan_facade_model_contract_digest_is_stable() -> None:
     )
 
 
-@pytest.mark.parametrize("operation", ["add", "supersede"])
-def test_private_implementation_matches_facade_for_two_phase_plans(operation: str) -> None:
-    import nauro_core.operations.commit_plan as contract
-    from nauro_core.operations import _commit_finalize, _commit_prepare
-
-    if operation == "add":
-        generation = _generation(("project.md", b"# Test\n"), counter=4)
-        payload = _preteam_payload(generation)
-    else:
-        existing = _decision(3, "Existing decision")
-        generation = _generation(existing, counter=8)
-        target = existing[0].removeprefix("decisions/").removesuffix(".md")
-        payload = _preteam_payload(
-            generation,
-            operation="supersede",
-            target=target,
-            title="Replacement decision",
-        )
-    attestation = _preteam_attestation()
-    facade_prepared = contract.prepare_judgment_commit(payload, attestation, generation)
-    private_prepared = _commit_prepare.prepare_judgment_commit_impl(
-        payload,
-        attestation,
-        generation,
-    )
-
-    assert private_prepared == facade_prepared
-    assert private_prepared.payload_bytes == facade_prepared.payload_bytes
-    assert private_prepared.payload_digest == facade_prepared.payload_digest
-    assert private_prepared.planned_artifacts == facade_prepared.planned_artifacts
-    assert private_prepared.snapshot == facade_prepared.snapshot
-    assert private_prepared.claim_probes == facade_prepared.claim_probes
-    assert private_prepared.claim_intents == facade_prepared.claim_intents
-    assert private_prepared.committed_result == facade_prepared.committed_result
-
-    observations = _observations_for(facade_prepared)
-    facade_plan = contract.finalize_judgment_commit(
-        facade_prepared,
-        list(reversed(observations)),
-    )
-    private_plan = _commit_finalize.finalize_judgment_commit_impl(
-        private_prepared,
-        list(reversed(observations)),
-    )
-
-    assert private_plan == facade_plan
-    assert private_plan.validated_claim_observations == tuple(observations)
-    assert private_plan.claim_plan == facade_plan.claim_plan
-    assert private_plan.plan_record_bytes == facade_plan.plan_record_bytes
-    assert private_plan.plan_record_digest == facade_plan.plan_record_digest
-    assert private_plan.committed_result == facade_plan.committed_result
-
-
 def test_prepare_validation_precedence_survives_delegation(monkeypatch) -> None:
     import nauro_core.operations.commit_plan as contract
+    from nauro_core.operations import _commit_prepare
 
     generation = _generation(("project.md", b"# Test\n"), counter=2)
     with pytest.raises(ApprovedPayloadDigestMismatch):
@@ -1468,7 +1284,7 @@ def test_prepare_validation_precedence_survives_delegation(monkeypatch) -> None:
     raw = json.loads(_preteam_payload(generation))
     raw["base_generation_id"] = PROPOSAL_ID
     monkeypatch.setattr(
-        contract,
+        _commit_prepare,
         "_parse_committed_generation",
         lambda value: pytest.fail("committed generation parsed before stale-base rejection"),
     )
@@ -1564,7 +1380,8 @@ def test_commit_plan_import_order_is_cycle_free_in_clean_subprocess(
         "import importlib, pickle\n"
         f"modules = [importlib.import_module(name) for name in {module_order!r}]\n"
         "contract = importlib.import_module('nauro_core.operations.commit_plan')\n"
-        "assert contract.PreparedJudgmentCommit.__module__ == contract.__name__\n"
+        "assert contract.PreparedJudgmentCommit.__module__ == "
+        "'nauro_core.operations._commit_contract'\n"
         "assert pickle.loads(pickle.dumps(contract.prepare_judgment_commit)) is "
         "contract.prepare_judgment_commit\n"
     )

--- a/packages/nauro-core/tests/snapshots/hosted_consumer_contract_v1.json
+++ b/packages/nauro-core/tests/snapshots/hosted_consumer_contract_v1.json
@@ -278,7 +278,7 @@
     },
     "nauro_core.operations.commit_plan.AbsentContentClaimObservation": {
       "bases": [
-        "nauro_core.operations.commit_plan._FrozenModel"
+        "nauro_core.operations._commit_contract._FrozenModel"
       ],
       "fields": {
         "content_hash": "str",
@@ -286,12 +286,12 @@
       },
       "frozen": true,
       "kind": "class",
-      "module": "nauro_core.operations.commit_plan",
+      "module": "nauro_core.operations._commit_contract",
       "qualname": "AbsentContentClaimObservation"
     },
     "nauro_core.operations.commit_plan.AbsentContentClaimProbe": {
       "bases": [
-        "nauro_core.operations.commit_plan._FrozenModel"
+        "nauro_core.operations._commit_contract._FrozenModel"
       ],
       "fields": {
         "content_hash": "str",
@@ -299,12 +299,12 @@
       },
       "frozen": true,
       "kind": "class",
-      "module": "nauro_core.operations.commit_plan",
+      "module": "nauro_core.operations._commit_contract",
       "qualname": "AbsentContentClaimProbe"
     },
     "nauro_core.operations.commit_plan.AbsentTitleClaimObservation": {
       "bases": [
-        "nauro_core.operations.commit_plan._FrozenModel"
+        "nauro_core.operations._commit_contract._FrozenModel"
       ],
       "fields": {
         "kind": "Literal['absent_title']",
@@ -312,12 +312,12 @@
       },
       "frozen": true,
       "kind": "class",
-      "module": "nauro_core.operations.commit_plan",
+      "module": "nauro_core.operations._commit_contract",
       "qualname": "AbsentTitleClaimObservation"
     },
     "nauro_core.operations.commit_plan.AbsentTitleClaimProbe": {
       "bases": [
-        "nauro_core.operations.commit_plan._FrozenModel"
+        "nauro_core.operations._commit_contract._FrozenModel"
       ],
       "fields": {
         "kind": "Literal['absent_title']",
@@ -325,43 +325,43 @@
       },
       "frozen": true,
       "kind": "class",
-      "module": "nauro_core.operations.commit_plan",
+      "module": "nauro_core.operations._commit_contract",
       "qualname": "AbsentTitleClaimProbe"
     },
     "nauro_core.operations.commit_plan.ApprovalAttestation": {
       "kind": "union",
       "members": [
-        "nauro_core.operations.commit_plan.PreTeamApprovalAttestation",
-        "nauro_core.operations.commit_plan.TeamRatificationAttestation"
+        "nauro_core.operations._commit_contract.PreTeamApprovalAttestation",
+        "nauro_core.operations._commit_contract.TeamRatificationAttestation"
       ]
     },
     "nauro_core.operations.commit_plan.ApprovalAttestationRejected": {
       "bases": [
-        "nauro_core.operations.commit_plan.JudgmentCommitError"
+        "nauro_core.operations._commit_contract.JudgmentCommitError"
       ],
       "kind": "class",
-      "module": "nauro_core.operations.commit_plan",
+      "module": "nauro_core.operations._commit_contract",
       "qualname": "ApprovalAttestationRejected"
     },
     "nauro_core.operations.commit_plan.ApprovedBaseStale": {
       "bases": [
-        "nauro_core.operations.commit_plan.JudgmentCommitError"
+        "nauro_core.operations._commit_contract.JudgmentCommitError"
       ],
       "kind": "class",
-      "module": "nauro_core.operations.commit_plan",
+      "module": "nauro_core.operations._commit_contract",
       "qualname": "ApprovedBaseStale"
     },
     "nauro_core.operations.commit_plan.CanonicalPayloadRejected": {
       "bases": [
-        "nauro_core.operations.commit_plan.JudgmentCommitError"
+        "nauro_core.operations._commit_contract.JudgmentCommitError"
       ],
       "kind": "class",
-      "module": "nauro_core.operations.commit_plan",
+      "module": "nauro_core.operations._commit_contract",
       "qualname": "CanonicalPayloadRejected"
     },
     "nauro_core.operations.commit_plan.ClaimIntent": {
       "bases": [
-        "nauro_core.operations.commit_plan._FrozenModel"
+        "nauro_core.operations._commit_contract._FrozenModel"
       ],
       "fields": {
         "content_hash": "None | str",
@@ -373,7 +373,7 @@
       },
       "frozen": true,
       "kind": "class",
-      "module": "nauro_core.operations.commit_plan",
+      "module": "nauro_core.operations._commit_contract",
       "qualname": "ClaimIntent"
     },
     "nauro_core.operations.commit_plan.ClaimObservation": {
@@ -386,15 +386,15 @@
     },
     "nauro_core.operations.commit_plan.ClaimUnavailable": {
       "bases": [
-        "nauro_core.operations.commit_plan.ClaimObservationError"
+        "nauro_core.operations._commit_contract.ClaimObservationError"
       ],
       "kind": "class",
-      "module": "nauro_core.operations.commit_plan",
+      "module": "nauro_core.operations._commit_contract",
       "qualname": "ClaimUnavailable"
     },
     "nauro_core.operations.commit_plan.CommittedArtifact": {
       "bases": [
-        "nauro_core.operations.commit_plan._FrozenModel"
+        "nauro_core.operations._commit_contract._FrozenModel"
       ],
       "fields": {
         "content": "bytes",
@@ -403,12 +403,12 @@
       },
       "frozen": true,
       "kind": "class",
-      "module": "nauro_core.operations.commit_plan",
+      "module": "nauro_core.operations._commit_contract",
       "qualname": "CommittedArtifact"
     },
     "nauro_core.operations.commit_plan.CommittedContentClaimObservation": {
       "bases": [
-        "nauro_core.operations.commit_plan._FrozenModel"
+        "nauro_core.operations._commit_contract._FrozenModel"
       ],
       "fields": {
         "content_hash": "str",
@@ -416,35 +416,35 @@
       },
       "frozen": true,
       "kind": "class",
-      "module": "nauro_core.operations.commit_plan",
+      "module": "nauro_core.operations._commit_contract",
       "qualname": "CommittedContentClaimObservation"
     },
     "nauro_core.operations.commit_plan.CommittedGeneration": {
       "bases": [
-        "nauro_core.operations.commit_plan._FrozenModel"
+        "nauro_core.operations._commit_contract._FrozenModel"
       ],
       "fields": {
-        "artifacts": "tuple[nauro_core.operations.commit_plan.CommittedArtifact, Ellipsis]",
+        "artifacts": "tuple[nauro_core.operations._commit_contract.CommittedArtifact, Ellipsis]",
         "decision_counter": "int",
         "generation_id": "str",
         "observed_manifest_digest": "str"
       },
       "frozen": true,
       "kind": "class",
-      "module": "nauro_core.operations.commit_plan",
+      "module": "nauro_core.operations._commit_contract",
       "qualname": "CommittedGeneration"
     },
     "nauro_core.operations.commit_plan.CommittedGenerationCorrupt": {
       "bases": [
-        "nauro_core.operations.commit_plan.JudgmentCommitError"
+        "nauro_core.operations._commit_contract.JudgmentCommitError"
       ],
       "kind": "class",
-      "module": "nauro_core.operations.commit_plan",
+      "module": "nauro_core.operations._commit_contract",
       "qualname": "CommittedGenerationCorrupt"
     },
     "nauro_core.operations.commit_plan.CommittedTitleClaimObservation": {
       "bases": [
-        "nauro_core.operations.commit_plan._FrozenModel"
+        "nauro_core.operations._commit_contract._FrozenModel"
       ],
       "fields": {
         "kind": "Literal['committed_title']",
@@ -453,15 +453,15 @@
       },
       "frozen": true,
       "kind": "class",
-      "module": "nauro_core.operations.commit_plan",
+      "module": "nauro_core.operations._commit_contract",
       "qualname": "CommittedTitleClaimObservation"
     },
     "nauro_core.operations.commit_plan.ContentClaimConflict": {
       "bases": [
-        "nauro_core.operations.commit_plan.ClaimObservationError"
+        "nauro_core.operations._commit_contract.ClaimObservationError"
       ],
       "kind": "class",
-      "module": "nauro_core.operations.commit_plan",
+      "module": "nauro_core.operations._commit_contract",
       "qualname": "ContentClaimConflict"
     },
     "nauro_core.operations.commit_plan.DecisionProvenance": {
@@ -481,85 +481,85 @@
     },
     "nauro_core.operations.commit_plan.DuplicateClaimObservation": {
       "bases": [
-        "nauro_core.operations.commit_plan.ClaimObservationError"
+        "nauro_core.operations._commit_contract.ClaimObservationError"
       ],
       "kind": "class",
-      "module": "nauro_core.operations.commit_plan",
+      "module": "nauro_core.operations._commit_contract",
       "qualname": "DuplicateClaimObservation"
     },
     "nauro_core.operations.commit_plan.FinalizedClaimPlan": {
       "bases": [
-        "nauro_core.operations.commit_plan._FrozenModel"
+        "nauro_core.operations._commit_contract._FrozenModel"
       ],
       "fields": {
-        "entry": "tuple[nauro_core.operations.commit_plan.ClaimIntent, Ellipsis]",
-        "publication": "tuple[nauro_core.operations.commit_plan.ClaimIntent, Ellipsis]"
+        "entry": "tuple[nauro_core.operations._commit_contract.ClaimIntent, Ellipsis]",
+        "publication": "tuple[nauro_core.operations._commit_contract.ClaimIntent, Ellipsis]"
       },
       "frozen": true,
       "kind": "class",
-      "module": "nauro_core.operations.commit_plan",
+      "module": "nauro_core.operations._commit_contract",
       "qualname": "FinalizedClaimPlan"
     },
     "nauro_core.operations.commit_plan.HostedPreTeamApprovalPayloadV1": {
       "bases": [
-        "nauro_core.operations.commit_plan._FrozenModel"
+        "nauro_core.operations._commit_contract._FrozenModel"
       ],
       "fields": {
         "approval_mode": "Literal['pre_team_session']",
         "base_decision_counter": "int",
         "base_generation_id": "str",
-        "content": "nauro_core.operations.commit_plan.JudgmentContent",
+        "content": "nauro_core.operations._commit_contract.JudgmentContent",
         "payload_schema": "Literal['nauro.judgment_commit.pre_team.v1']",
         "proposed_base_commit": "None"
       },
       "frozen": true,
       "kind": "class",
-      "module": "nauro_core.operations.commit_plan",
+      "module": "nauro_core.operations._commit_contract",
       "qualname": "HostedPreTeamApprovalPayloadV1"
     },
     "nauro_core.operations.commit_plan.JudgmentCommitPlan": {
       "bases": [
-        "nauro_core.operations.commit_plan._FrozenModel"
+        "nauro_core.operations._commit_contract._FrozenModel"
       ],
       "fields": {
-        "claim_plan": "nauro_core.operations.commit_plan.FinalizedClaimPlan",
+        "claim_plan": "nauro_core.operations._commit_contract.FinalizedClaimPlan",
         "plan_record_bytes": "bytes",
-        "prepared": "nauro_core.operations.commit_plan.PreparedJudgmentCommit",
+        "prepared": "nauro_core.operations._commit_contract.PreparedJudgmentCommit",
         "schema_version": "Literal[1]",
-        "validated_claim_observations": "tuple[nauro_core.operations.commit_plan.AbsentContentClaimObservation | nauro_core.operations.commit_plan.AbsentTitleClaimObservation | nauro_core.operations.commit_plan.CommittedContentClaimObservation | nauro_core.operations.commit_plan.CommittedTitleClaimObservation | nauro_core.operations.commit_plan.UnavailableContentClaimObservation | nauro_core.operations.commit_plan.UnavailableTitleClaimObservation, Ellipsis]"
+        "validated_claim_observations": "tuple[nauro_core.operations._commit_contract.AbsentContentClaimObservation | nauro_core.operations._commit_contract.AbsentTitleClaimObservation | nauro_core.operations._commit_contract.CommittedContentClaimObservation | nauro_core.operations._commit_contract.CommittedTitleClaimObservation | nauro_core.operations._commit_contract.UnavailableContentClaimObservation | nauro_core.operations._commit_contract.UnavailableTitleClaimObservation, Ellipsis]"
       },
       "frozen": true,
       "kind": "class",
-      "module": "nauro_core.operations.commit_plan",
+      "module": "nauro_core.operations._commit_contract",
       "qualname": "JudgmentCommitPlan"
     },
     "nauro_core.operations.commit_plan.MalformedClaimObservation": {
       "bases": [
-        "nauro_core.operations.commit_plan.ClaimObservationError"
+        "nauro_core.operations._commit_contract.ClaimObservationError"
       ],
       "kind": "class",
-      "module": "nauro_core.operations.commit_plan",
+      "module": "nauro_core.operations._commit_contract",
       "qualname": "MalformedClaimObservation"
     },
     "nauro_core.operations.commit_plan.MismatchedClaimObservation": {
       "bases": [
-        "nauro_core.operations.commit_plan.ClaimObservationError"
+        "nauro_core.operations._commit_contract.ClaimObservationError"
       ],
       "kind": "class",
-      "module": "nauro_core.operations.commit_plan",
+      "module": "nauro_core.operations._commit_contract",
       "qualname": "MismatchedClaimObservation"
     },
     "nauro_core.operations.commit_plan.MissingClaimObservation": {
       "bases": [
-        "nauro_core.operations.commit_plan.ClaimObservationError"
+        "nauro_core.operations._commit_contract.ClaimObservationError"
       ],
       "kind": "class",
-      "module": "nauro_core.operations.commit_plan",
+      "module": "nauro_core.operations._commit_contract",
       "qualname": "MissingClaimObservation"
     },
     "nauro_core.operations.commit_plan.OwnedTitleClaimProbe": {
       "bases": [
-        "nauro_core.operations.commit_plan._FrozenModel"
+        "nauro_core.operations._commit_contract._FrozenModel"
       ],
       "fields": {
         "expected_owner_decision_number": "int",
@@ -568,12 +568,12 @@
       },
       "frozen": true,
       "kind": "class",
-      "module": "nauro_core.operations.commit_plan",
+      "module": "nauro_core.operations._commit_contract",
       "qualname": "OwnedTitleClaimProbe"
     },
     "nauro_core.operations.commit_plan.PreTeamApprovalAttestation": {
       "bases": [
-        "nauro_core.operations.commit_plan._FrozenModel"
+        "nauro_core.operations._commit_contract._FrozenModel"
       ],
       "fields": {
         "actor_id": "str",
@@ -582,12 +582,12 @@
       },
       "frozen": true,
       "kind": "class",
-      "module": "nauro_core.operations.commit_plan",
+      "module": "nauro_core.operations._commit_contract",
       "qualname": "PreTeamApprovalAttestation"
     },
     "nauro_core.operations.commit_plan.PreparedBase": {
       "bases": [
-        "nauro_core.operations.commit_plan._FrozenModel"
+        "nauro_core.operations._commit_contract._FrozenModel"
       ],
       "fields": {
         "decision_counter": "int",
@@ -596,12 +596,12 @@
       },
       "frozen": true,
       "kind": "class",
-      "module": "nauro_core.operations.commit_plan",
+      "module": "nauro_core.operations._commit_contract",
       "qualname": "PreparedBase"
     },
     "nauro_core.operations.commit_plan.PrimaryDecision": {
       "bases": [
-        "nauro_core.operations.commit_plan._FrozenModel"
+        "nauro_core.operations._commit_contract._FrozenModel"
       ],
       "fields": {
         "decision_id": "str",
@@ -610,28 +610,28 @@
       },
       "frozen": true,
       "kind": "class",
-      "module": "nauro_core.operations.commit_plan",
+      "module": "nauro_core.operations._commit_contract",
       "qualname": "PrimaryDecision"
     },
     "nauro_core.operations.commit_plan.ProposalRejected": {
       "bases": [
-        "nauro_core.operations.commit_plan.JudgmentCommitError"
+        "nauro_core.operations._commit_contract.JudgmentCommitError"
       ],
       "kind": "class",
-      "module": "nauro_core.operations.commit_plan",
+      "module": "nauro_core.operations._commit_contract",
       "qualname": "ProposalRejected"
     },
     "nauro_core.operations.commit_plan.TitleClaimConflict": {
       "bases": [
-        "nauro_core.operations.commit_plan.ClaimObservationError"
+        "nauro_core.operations._commit_contract.ClaimObservationError"
       ],
       "kind": "class",
-      "module": "nauro_core.operations.commit_plan",
+      "module": "nauro_core.operations._commit_contract",
       "qualname": "TitleClaimConflict"
     },
     "nauro_core.operations.commit_plan.UnavailableContentClaimObservation": {
       "bases": [
-        "nauro_core.operations.commit_plan._FrozenModel"
+        "nauro_core.operations._commit_contract._FrozenModel"
       ],
       "fields": {
         "content_hash": "str",
@@ -640,12 +640,12 @@
       },
       "frozen": true,
       "kind": "class",
-      "module": "nauro_core.operations.commit_plan",
+      "module": "nauro_core.operations._commit_contract",
       "qualname": "UnavailableContentClaimObservation"
     },
     "nauro_core.operations.commit_plan.UnavailableTitleClaimObservation": {
       "bases": [
-        "nauro_core.operations.commit_plan._FrozenModel"
+        "nauro_core.operations._commit_contract._FrozenModel"
       ],
       "fields": {
         "kind": "Literal['unavailable_title']",
@@ -654,32 +654,32 @@
       },
       "frozen": true,
       "kind": "class",
-      "module": "nauro_core.operations.commit_plan",
+      "module": "nauro_core.operations._commit_contract",
       "qualname": "UnavailableTitleClaimObservation"
     },
     "nauro_core.operations.commit_plan.UnexpectedClaimObservation": {
       "bases": [
-        "nauro_core.operations.commit_plan.ClaimObservationError"
+        "nauro_core.operations._commit_contract.ClaimObservationError"
       ],
       "kind": "class",
-      "module": "nauro_core.operations.commit_plan",
+      "module": "nauro_core.operations._commit_contract",
       "qualname": "UnexpectedClaimObservation"
     },
     "nauro_core.operations.commit_plan.canonical_judgment_payload_bytes": {
       "kind": "function",
-      "module": "nauro_core.operations.commit_plan",
+      "module": "nauro_core.operations._commit_contract",
       "qualname": "canonical_judgment_payload_bytes",
       "signature": "(payload: Mapping[str, object]) -> bytes"
     },
     "nauro_core.operations.commit_plan.finalize_judgment_commit": {
       "kind": "function",
-      "module": "nauro_core.operations.commit_plan",
+      "module": "nauro_core.operations._commit_finalize",
       "qualname": "finalize_judgment_commit",
       "signature": "(prepared: PreparedJudgmentCommit, claim_observations: Sequence[ClaimObservation | Mapping[str, object]]) -> JudgmentCommitPlan"
     },
     "nauro_core.operations.commit_plan.prepare_judgment_commit": {
       "kind": "function",
-      "module": "nauro_core.operations.commit_plan",
+      "module": "nauro_core.operations._commit_prepare",
       "qualname": "prepare_judgment_commit",
       "signature": "(payload_bytes: bytes, approval_attestation: ApprovalAttestation, committed_generation: CommittedGeneration, expected_payload_digest: str | None = None, *, snapshot_format: Literal['serialized', 'references'] = 'serialized') -> PreparedJudgmentCommit"
     },

--- a/scripts/ruff_budget_baseline.jsonl
+++ b/scripts/ruff_budget_baseline.jsonl
@@ -11,10 +11,10 @@
 {"path":"packages/nauro-core/src/nauro_core/graph.py","rule":"PERF401","count":1}
 {"path":"packages/nauro-core/src/nauro_core/identifiers.py","rule":"N818","count":1}
 {"path":"packages/nauro-core/src/nauro_core/instructions.py","rule":"PERF401","count":1}
-{"path":"packages/nauro-core/src/nauro_core/operations/commit_plan.py","rule":"C901","count":1}
-{"path":"packages/nauro-core/src/nauro_core/operations/commit_plan.py","rule":"N818","count":14}
-{"path":"packages/nauro-core/src/nauro_core/operations/commit_plan.py","rule":"PLR0912","count":1}
-{"path":"packages/nauro-core/src/nauro_core/operations/commit_plan.py","rule":"TRY004","count":1}
+{"path":"packages/nauro-core/src/nauro_core/operations/_commit_contract.py","rule":"C901","count":1}
+{"path":"packages/nauro-core/src/nauro_core/operations/_commit_contract.py","rule":"N818","count":14}
+{"path":"packages/nauro-core/src/nauro_core/operations/_commit_contract.py","rule":"PLR0912","count":1}
+{"path":"packages/nauro-core/src/nauro_core/operations/_commit_contract.py","rule":"TRY004","count":1}
 {"path":"packages/nauro-core/src/nauro_core/operations/decision_lookup.py","rule":"BLE001","count":2}
 {"path":"packages/nauro-core/src/nauro_core/operations/diff_since_last_session.py","rule":"PERF401","count":6}
 {"path":"packages/nauro-core/src/nauro_core/operations/planning.py","rule":"N818","count":1}


### PR DESCRIPTION
## Why

`nauro_core.operations.commit_plan` was both the contract and a facade that reached its two phase modules through sixteen function-local imports, while each phase module imported the facade back. The cycle forced lazy imports and hid where each derivation lived.

## What changed

- The contract types move to `_commit_contract.py` with the derivations its self-validating models recompute (payload parsing, provenance, the claim contract, snapshot bytes, claim keys, observation validation, the plan record). The phase modules keep only orchestration and import the contract directly.
- `commit_plan.py` is a re-export of the public surface with an unchanged `__all__`; the lazy snapshot-descriptor import is top level.
- The hosted consumer snapshot regenerates only the module qualifier of the moved classes.

## Risk / what to review

- Objects the hosted consumer pickles now serialize with the `_commit_contract` module path. Old pickles load through the facade; a rolling deploy that mixes nauro-core versions and pickles plans between phases would not load new pickles on the old version. Confirm that is not a live path.
- The hosted symbol manifest is not regenerated: the local mcp-server clone is at a different revision and the manifest script needs Python 3.12.
- 713 added lines with copy detection; git sees the extracted module as new text.

## Test plan

Full pytest for both packages on the rebased branch: 6955 passed, 121 skipped, 12 failed. The 12 are permission-denial tests that fail identically on origin/main under this container's root user. ruff check and format, the ruff and docstring budgets, the single-sourced check and the import-linter contracts all pass.