### PR TITLE
Replace copied prologues and string dispatch with tables and a decorator

### DIFF
--- a/packages/nauro/src/nauro/mcp/tools.py
+++ b/packages/nauro/src/nauro/mcp/tools.py
@@ -122,15 +122,34 @@ def _stamp_identity(func: Callable[..., Any]) -> Callable[..., Any]:
     @functools.wraps(func)
     def wrapper(*args: Any, **kwargs: Any) -> Any:
         result = func(*args, **kwargs)
-        store_path = args[0] if args else kwargs.get("store_path")
+        store_path = _store_path_argument(args, kwargs)
         if (
             isinstance(result, dict)
-            and isinstance(store_path, Path)
+            and store_path is not None
             and result.get("store") == "local"
             and "project" not in result
         ):
             result["project"] = _project_identity(store_path)
         return result
+
+    return wrapper
+
+
+def _store_path_argument(args: tuple, kwargs: dict) -> Path | None:
+    """The adapter's leading ``store_path`` argument, or None when the call carries none."""
+    store_path = args[0] if args else kwargs.get("store_path")
+    return store_path if isinstance(store_path, Path) else None
+
+
+def requires_store(func: Callable[..., Any]) -> Callable[..., Any]:
+    """Answer with the no-project guidance envelope when ``store_path`` does not exist."""
+
+    @functools.wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        store_path = _store_path_argument(args, kwargs)
+        if store_path is not None and not store_path.exists():
+            return {"store": "local", "status": "error", "guidance": WELCOME_NO_PROJECT}
+        return func(*args, **kwargs)
 
     return wrapper
 
@@ -239,13 +258,6 @@ def _reject_if_envelope_token(value: str, field_name: str) -> dict | None:
     }
 
 
-def _check_store_exists(store_path: Path) -> str | None:
-    """Return guidance string if the store is missing, None if it exists."""
-    if not store_path.exists():
-        return WELCOME_NO_PROJECT
-    return None
-
-
 def _has_decisions(store_path: Path) -> bool:
     """Check whether the store has any decision files."""
     decisions_dir = store_path / "decisions"
@@ -324,12 +336,9 @@ def _snapshot_diff_section(store_path: Path) -> str:
 
 
 @_stamp_identity
+@requires_store
 def tool_get_context(store_path: Path, level: int | str = "L0") -> dict:
     """Return project context at the requested detail level."""
-    guidance = _check_store_exists(store_path)
-    if guidance:
-        return {"store": "local", "status": "error", "guidance": guidance}
-
     level_int = _coerce_level(level)
     result = _get_context_op(FilesystemStore(store_path), level_int)
     envelope: dict = {"store": "local", **result.model_dump(mode="json", exclude_none=True)}
@@ -360,6 +369,7 @@ def tool_get_context(store_path: Path, level: int | str = "L0") -> dict:
 
 @_stamp_identity
 @journaled(operation="propose_decision", target=DECISIONS_DIR)
+@requires_store
 def tool_propose_decision(
     store_path: Path,
     title: str = "",
@@ -377,10 +387,6 @@ def tool_propose_decision(
     base_commit: str | None = None,
 ) -> dict:
     """Propose a new decision through the validation pipeline."""
-    guidance = _check_store_exists(store_path)
-    if guidance:
-        return {"store": "local", "status": "error", "guidance": guidance}
-
     for err in (
         _reject_if_too_long(title, "Title", MAX_TITLE_LENGTH),
         _reject_if_too_long(rationale, "Rationale", MAX_RATIONALE_LENGTH),
@@ -521,16 +527,13 @@ Args:
 
 
 @_stamp_identity
+@requires_store
 def tool_check_decision(
     store_path: Path,
     proposed_approach: str,
     context: str | None = None,
 ) -> dict:
     """Surface related existing decisions without writing anything."""
-    guidance = _check_store_exists(store_path)
-    if guidance:
-        return {"store": "local", "status": "error", "guidance": guidance}
-
     result = _check_decision_op(
         FilesystemStore(store_path),
         proposed_approach,
@@ -555,6 +558,7 @@ Surface related existing decisions without writing anything.
 
 @_stamp_identity
 @journaled(operation="flag_question", target=OPEN_QUESTIONS_MD)
+@requires_store
 def tool_flag_question(
     store_path: Path,
     question: str | None = None,
@@ -567,10 +571,6 @@ def tool_flag_question(
     """With ``resolved_by`` set, resolve the ``targets`` entries; otherwise append
     ``question`` as a new flag. Both are writes: snapshot and push run on success
     and neither runs on rejection."""
-    guidance = _check_store_exists(store_path)
-    if guidance:
-        return {"store": "local", "status": "error", "guidance": guidance}
-
     if resolved_by is not None:
         return _flag_question_resolve(store_path, question, targets, resolved_by)
 
@@ -761,12 +761,9 @@ def _miss_envelope(store_path: Path, path: str, root: _PreparedStoreRoot) -> dic
 
 
 @_stamp_identity
+@requires_store
 def tool_get_raw_file(store_path: Path, path: str) -> dict:
     """Return raw content of any file in the project store."""
-    guidance = _check_store_exists(store_path)
-    if guidance:
-        return {"store": "local", "status": "error", "guidance": guidance}
-
     try:
         root = _prepare_store_root(store_path)
     except _StoreRootPreparationError:
@@ -812,39 +809,32 @@ def tool_get_raw_file(store_path: Path, path: str) -> dict:
 
 
 @_stamp_identity
+@requires_store
 def tool_list_decisions(
     store_path: Path,
     limit: int = 20,
     include_superseded: bool = False,
 ) -> dict:
     """List decision summaries, sorted by number descending."""
-    guidance = _check_store_exists(store_path)
-    if guidance:
-        return {"store": "local", "status": "error", "guidance": guidance}
     result = _list_decisions_op(FilesystemStore(store_path), limit, include_superseded)
     return {"store": "local", **result.model_dump(mode="json", exclude_none=True)}
 
 
 @_stamp_identity
+@requires_store
 def tool_get_decision(store_path: Path, number: int, mode: str = "full") -> dict:
     """Return a specific decision by number (full body, or header projection)."""
-    guidance = _check_store_exists(store_path)
-    if guidance:
-        return {"store": "local", "status": "error", "guidance": guidance}
     result = _get_decision_op(FilesystemStore(store_path), number, mode)
     return {"store": "local", **result.model_dump(mode="json", exclude_none=True)}
 
 
 @_stamp_identity
+@requires_store
 def tool_diff_since_last_session(
     store_path: Path,
     days: int | None = None,
 ) -> dict:
     """Show what changed since the last session or N days ago."""
-    guidance = _check_store_exists(store_path)
-    if guidance:
-        return {"store": "local", "status": "error", "guidance": guidance}
-
     baseline, latest, cutoff = resolve_diff_snapshots(store_path, days)
 
     # Days-based one-snapshot-covers-range case: resolve_diff_snapshots
@@ -882,6 +872,7 @@ def tool_diff_since_last_session(
 
 
 @_stamp_identity
+@requires_store
 def tool_search_decisions(
     store_path: Path,
     query: str,
@@ -889,9 +880,6 @@ def tool_search_decisions(
     include_superseded: bool = False,
 ) -> dict:
     """Search decisions by keyword. Returns matching decisions with snippets."""
-    guidance = _check_store_exists(store_path)
-    if guidance:
-        return {"store": "local", "status": "error", "guidance": guidance}
     result = _search_decisions_op(
         FilesystemStore(store_path),
         query,
@@ -904,6 +892,7 @@ def tool_search_decisions(
 
 @_stamp_identity
 @journaled(operation="update_state", target=STATE_CURRENT_FILENAME)
+@requires_store
 def tool_update_state(
     store_path: Path,
     delta: str,
@@ -911,10 +900,6 @@ def tool_update_state(
     origin: OriginDescriptor | None = None,
 ) -> dict:
     """Update current project state. Returns a warning on keyword overlap."""
-    guidance = _check_store_exists(store_path)
-    if guidance:
-        return {"store": "local", "status": "error", "guidance": guidance}
-
     # Length validation stays adapter-side — the kernel writes whatever the
     # adapter passes through.
     err = _reject_if_too_long(delta, "Delta", MAX_DELTA_LENGTH)

--- a/packages/nauro/src/nauro/skills/__init__.py
+++ b/packages/nauro/src/nauro/skills/__init__.py
@@ -16,6 +16,8 @@ tests anchor on.
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from dataclasses import dataclass, field
 from importlib import resources
 from typing import Literal
 
@@ -152,74 +154,102 @@ _CURSOR_LOOP_PROGRAM_DELIVERY_LIFECYCLE = (
     "self-contained Delivery prompt."
 )
 
-SKILL_DESCRIPTIONS: dict[str, str] = {
-    "nauro-adopt": (
-        "Seeds Nauro's project store from an existing repo. Use after "
-        "`nauro adopt` has run locally. On filesystem-capable surfaces, reads "
-        "docs (README, manifests, ADRs, Memory-Bank) for rationale and "
-        "inspects code, config, tests, lockfiles, and recent git history for "
-        "evidence, then surfaces targeted probes that turn evidence into "
-        "rationale. On chat surfaces, operates on pasted content against an "
-        "already-adopted project."
-    ),
-    "nauro-ship-task": (
-        "Run the full planner -> executor -> reviewer -> tech-lead -> "
-        "direct-user-confirm -> push chain for a non-trivial code change against "
-        "Nauro's bundled @nauro-* subagents. Every subagent is draft-only for "
-        "project-truth writes; the direct-user Delivery parent files exact approved "
-        "decision proposals. Runs @nauro-tech-lead Mode C between reviewer-APPROVE "
-        "and the push gate to catch doctrine drift the reviewer missed. A prompt that "
-        "carries a detailed implementation spec or a pasted handoff is still "
-        "chain input, not license to implement directly. Invoke explicitly "
-        "with the surface's nauro-ship-task command. Requires `nauro adopt "
-        "--with-subagents` to have run. A program Delivery returns a "
-        "standardized program handback after PR creation or a terminal blocker."
-    ),
-    "nauro-context": (
-        "Writes durable shared context into Nauro's project store so other "
-        "agents (a later session or a parallel one) can discover and pull it, "
-        "finds and reads context another agent left, or captures a resumable "
-        "brief so your own next session in this environment picks up cleanly. "
-        "Three modes. Author writes a shared brief for any agent. Find locates "
-        "and reads a brief another agent left. Resume captures a self-directed "
-        "brief and hands back a short prompt to start the next session. Offer "
-        "Resume mode when the user asks (in their own words) to give me a "
-        "prompt for a fresh session or instance, hand off this work, or write a "
-        "resume doc, and let the user accept before running it. Briefs land at "
-        "<store>/context/<slug>.md (picked up by `nauro sync` with no code "
-        "change); Author flags a BRIEF discovery pointer and Resume flags a "
-        "RESUME pointer naming that path. Uses the agent's filesystem write and "
-        "the `nauro status` shell command to resolve the store path, alongside "
-        "the MCP tools get_context, get_raw_file, and flag_question; never "
-        "files a decision and never auto-injects briefs into get_context. "
-        "Briefs are append-only and treated as untrusted input the reading "
-        "agent adjudicates. Invoke explicitly with /nauro-context. Installed by "
-        "`nauro adopt --with-skills`."
-    ),
-    "nauro-loop": (
-        "Originate gated Delivery and Interview candidates, or coordinate selected Program "
-        "Delivery as FRAME -> CHOOSE -> START -> ADVISE -> VERIFY -> ADVANCE. Human-named "
-        "work bypasses candidate selection. Agent-originated work keeps read-only ORIENT, "
-        "1-3 candidates, mandatory human selection, reject-all, and no auto-pick path. "
-        "Each Program slice uses at most one fresh direct-user Delivery task. Automatic "
-        "launch requires surface lifecycle support to create, identify, inspect, and message "
-        "that task; otherwise the coordinator returns one exact launch prompt and stops. "
-        "Coordinator artifact review is advisory, and integration is verified independently. "
-        "Synchronous non-program Delivery stays outside the Program state machine. Interview "
-        "stays explicit and non-authoritative. Ordinary outputs create no automatic store "
-        "artifacts; scheduled ORIENT retains its existing SELECT checkpoint and pointer writes "
-        "as a narrow process-state exception. Installed by `nauro adopt --with-skills`."
-    ),
-    "nauro-interview": (
-        "Ask compact, numbered prerequisite-ready questions to elicit tacit project "
-        "reasoning or challenge a proposed choice against Nauro decisions and repository "
-        "evidence. Continue until every material branch has a disposition, then classify "
-        "the result as shared understanding without granting write authority. Use only "
-        "when the user explicitly asks to be interviewed, grilled, stress-tested, or helped "
-        "to transfer reasoning into Nauro. Runs in the main agent context with no external "
-        "skill or subagent dependency."
-    ),
+_ADOPT_DESCRIPTION = (
+    "Seeds Nauro's project store from an existing repo. Use after "
+    "`nauro adopt` has run locally. On filesystem-capable surfaces, reads "
+    "docs (README, manifests, ADRs, Memory-Bank) for rationale and "
+    "inspects code, config, tests, lockfiles, and recent git history for "
+    "evidence, then surfaces targeted probes that turn evidence into "
+    "rationale. On chat surfaces, operates on pasted content against an "
+    "already-adopted project."
+)
+
+_SHIP_TASK_DESCRIPTION = (
+    "Run the full planner -> executor -> reviewer -> tech-lead -> "
+    "direct-user-confirm -> push chain for a non-trivial code change against "
+    "Nauro's bundled @nauro-* subagents. Every subagent is draft-only for "
+    "project-truth writes; the direct-user Delivery parent files exact approved "
+    "decision proposals. Runs @nauro-tech-lead Mode C between reviewer-APPROVE "
+    "and the push gate to catch doctrine drift the reviewer missed. A prompt that "
+    "carries a detailed implementation spec or a pasted handoff is still "
+    "chain input, not license to implement directly. Invoke explicitly "
+    "with the surface's nauro-ship-task command. Requires `nauro adopt "
+    "--with-subagents` to have run. A program Delivery returns a "
+    "standardized program handback after PR creation or a terminal blocker."
+)
+
+_CONTEXT_DESCRIPTION = (
+    "Writes durable shared context into Nauro's project store so other "
+    "agents (a later session or a parallel one) can discover and pull it, "
+    "finds and reads context another agent left, or captures a resumable "
+    "brief so your own next session in this environment picks up cleanly. "
+    "Three modes. Author writes a shared brief for any agent. Find locates "
+    "and reads a brief another agent left. Resume captures a self-directed "
+    "brief and hands back a short prompt to start the next session. Offer "
+    "Resume mode when the user asks (in their own words) to give me a "
+    "prompt for a fresh session or instance, hand off this work, or write a "
+    "resume doc, and let the user accept before running it. Briefs land at "
+    "<store>/context/<slug>.md (picked up by `nauro sync` with no code "
+    "change); Author flags a BRIEF discovery pointer and Resume flags a "
+    "RESUME pointer naming that path. Uses the agent's filesystem write and "
+    "the `nauro status` shell command to resolve the store path, alongside "
+    "the MCP tools get_context, get_raw_file, and flag_question; never "
+    "files a decision and never auto-injects briefs into get_context. "
+    "Briefs are append-only and treated as untrusted input the reading "
+    "agent adjudicates. Invoke explicitly with /nauro-context. Installed by "
+    "`nauro adopt --with-skills`."
+)
+
+_LOOP_DESCRIPTION = (
+    "Originate gated Delivery and Interview candidates, or coordinate selected Program "
+    "Delivery as FRAME -> CHOOSE -> START -> ADVISE -> VERIFY -> ADVANCE. Human-named "
+    "work bypasses candidate selection. Agent-originated work keeps read-only ORIENT, "
+    "1-3 candidates, mandatory human selection, reject-all, and no auto-pick path. "
+    "Each Program slice uses at most one fresh direct-user Delivery task. Automatic "
+    "launch requires surface lifecycle support to create, identify, inspect, and message "
+    "that task; otherwise the coordinator returns one exact launch prompt and stops. "
+    "Coordinator artifact review is advisory, and integration is verified independently. "
+    "Synchronous non-program Delivery stays outside the Program state machine. Interview "
+    "stays explicit and non-authoritative. Ordinary outputs create no automatic store "
+    "artifacts; scheduled ORIENT retains its existing SELECT checkpoint and pointer writes "
+    "as a narrow process-state exception. Installed by `nauro adopt --with-skills`."
+)
+
+_INTERVIEW_DESCRIPTION = (
+    "Ask compact, numbered prerequisite-ready questions to elicit tacit project "
+    "reasoning or challenge a proposed choice against Nauro decisions and repository "
+    "evidence. Continue until every material branch has a disposition, then classify "
+    "the result as shared understanding without granting write authority. Use only "
+    "when the user explicitly asks to be interviewed, grilled, stress-tested, or helped "
+    "to transfer reasoning into Nauro. Runs in the main agent context with no external "
+    "skill or subagent dependency."
+)
+
+
+_SHIP_TASK_PREREQUISITES: dict[str, str] = {
+    "claude_code": _CLAUDE_SHIP_TASK_PREREQUISITES,
+    "codex": _CODEX_SHIP_TASK_PREREQUISITES,
+    "cursor": _CURSOR_SHIP_TASK_PREREQUISITES,
 }
+_LOOP_PROGRAM_DELIVERY_LIFECYCLES: dict[str, str] = {
+    "claude_code": _CLAUDE_LOOP_PROGRAM_DELIVERY_LIFECYCLE,
+    "codex": _CODEX_LOOP_PROGRAM_DELIVERY_LIFECYCLE,
+    "cursor": _CURSOR_LOOP_PROGRAM_DELIVERY_LIFECYCLE,
+}
+_CURSOR_COMMAND_AGENTS = ("nauro-planner", "nauro-executor", "nauro-reviewer", "nauro-tech-lead")
+_NAMED_FRONTMATTER = "---\nname: {skill_name}\ndescription: {description}\n---\n\n"
+_FRONTMATTER_TEMPLATES: dict[str, str] = {
+    "claude_code": _NAMED_FRONTMATTER,
+    "codex": _NAMED_FRONTMATTER,
+    "cursor": "---\ndescription: {description}\nalwaysApply: false\n---\n\n",
+}
+
+
+def _for_surface(table: dict[str, str], surface: str) -> str:
+    try:
+        return table[surface]
+    except KeyError:
+        raise ValueError(f"unknown surface: {surface!r}") from None
 
 
 def _strip_template_header(text: str) -> str:
@@ -252,17 +282,10 @@ def load_ship_task_body(surface: str = "claude_code") -> str:
     """
     raw = resources.files(__package__).joinpath("ship_task_body.md").read_text(encoding="utf-8")
     body = substitute_protocol_fragments(_strip_template_header(raw))
-    if surface == "codex":
-        prerequisites = _CODEX_SHIP_TASK_PREREQUISITES
-    elif surface == "claude_code":
-        prerequisites = _CLAUDE_SHIP_TASK_PREREQUISITES
-    elif surface == "cursor":
-        prerequisites = _CURSOR_SHIP_TASK_PREREQUISITES
-    else:
-        raise ValueError(f"unknown surface: {surface!r}")
+    prerequisites = _for_surface(_SHIP_TASK_PREREQUISITES, surface)
     body = body.replace(_SHIP_TASK_PREREQUISITES_TOKEN, prerequisites)
     if surface == "cursor":
-        for name in ("nauro-planner", "nauro-executor", "nauro-reviewer", "nauro-tech-lead"):
+        for name in _CURSOR_COMMAND_AGENTS:
             body = body.replace(f"`@{name}`", f"`/{name}`")
     return body
 
@@ -277,14 +300,7 @@ def load_loop_body(surface: str = "claude_code") -> str:
     """Return the ``/nauro-loop`` skill body (no frontmatter) for ``surface``."""
     raw = resources.files(__package__).joinpath("loop_body.md").read_text(encoding="utf-8")
     body = substitute_protocol_fragments(_strip_template_header(raw))
-    if surface == "claude_code":
-        lifecycle = _CLAUDE_LOOP_PROGRAM_DELIVERY_LIFECYCLE
-    elif surface == "codex":
-        lifecycle = _CODEX_LOOP_PROGRAM_DELIVERY_LIFECYCLE
-    elif surface == "cursor":
-        lifecycle = _CURSOR_LOOP_PROGRAM_DELIVERY_LIFECYCLE
-    else:
-        raise ValueError(f"unknown surface: {surface!r}")
+    lifecycle = _for_surface(_LOOP_PROGRAM_DELIVERY_LIFECYCLES, surface)
     return body.replace(_LOOP_PROGRAM_DELIVERY_LIFECYCLE_TOKEN, lifecycle)
 
 
@@ -294,32 +310,36 @@ def load_interview_body() -> str:
     return substitute_protocol_fragments(_strip_template_header(raw))
 
 
-def _load_body(surface: str, skill_name: str) -> str:
-    if skill_name == "nauro-adopt":
-        return load_adopt_body()
-    if skill_name == "nauro-ship-task":
-        return load_ship_task_body(surface)
-    if skill_name == "nauro-context":
-        return load_context_body()
-    if skill_name == "nauro-loop":
-        return load_loop_body(surface)
-    if skill_name == "nauro-interview":
-        return load_interview_body()
-    raise ValueError(f"unknown skill: {skill_name!r}")
+@dataclass(frozen=True)
+class _Skill:
+    """One bundled skill: its description, per-surface overrides, and body loader."""
+
+    description: str
+    load_body: Callable[[str], str]
+    surface_descriptions: dict[str, str] = field(default_factory=dict)
+
+    def description_for(self, surface: str) -> str:
+        return self.surface_descriptions.get(surface, self.description)
 
 
-def _frontmatter(surface: str, skill_name: str) -> str:
+_SKILLS: dict[str, _Skill] = {
+    "nauro-adopt": _Skill(_ADOPT_DESCRIPTION, lambda surface: load_adopt_body()),
+    "nauro-ship-task": _Skill(
+        _SHIP_TASK_DESCRIPTION,
+        load_ship_task_body,
+        surface_descriptions={"cursor": _CURSOR_SHIP_TASK_DESCRIPTION},
+    ),
+    "nauro-context": _Skill(_CONTEXT_DESCRIPTION, lambda surface: load_context_body()),
+    "nauro-loop": _Skill(_LOOP_DESCRIPTION, load_loop_body),
+    "nauro-interview": _Skill(_INTERVIEW_DESCRIPTION, lambda surface: load_interview_body()),
+}
+SKILL_DESCRIPTIONS: dict[str, str] = {name: skill.description for name, skill in _SKILLS.items()}
+
+
+def _frontmatter(surface: str, skill_name: str, skill: _Skill) -> str:
     """Build the YAML frontmatter block (terminated by a blank line)."""
-    if skill_name not in SKILL_DESCRIPTIONS:
-        raise ValueError(f"unknown skill: {skill_name!r}")
-    description = SKILL_DESCRIPTIONS[skill_name]
-    if surface == "cursor" and skill_name == "nauro-ship-task":
-        description = _CURSOR_SHIP_TASK_DESCRIPTION
-    if surface in ("claude_code", "codex"):
-        return f"---\nname: {skill_name}\ndescription: {description}\n---\n\n"
-    if surface == "cursor":
-        return f"---\ndescription: {description}\nalwaysApply: false\n---\n\n"
-    raise ValueError(f"unknown surface: {surface!r}")
+    template = _for_surface(_FRONTMATTER_TEMPLATES, surface)
+    return template.format(skill_name=skill_name, description=skill.description_for(surface))
 
 
 def render_skill(surface: str, skill_name: str) -> str:
@@ -327,7 +347,11 @@ def render_skill(surface: str, skill_name: str) -> str:
 
     Single render path: drift tests byte-compare the committed dogfood files against it.
     """
-    return _frontmatter(surface, skill_name) + _load_body(surface, skill_name)
+    try:
+        skill = _SKILLS[skill_name]
+    except KeyError:
+        raise ValueError(f"unknown skill: {skill_name!r}") from None
+    return _frontmatter(surface, skill_name, skill) + skill.load_body(surface)
 
 
 __all__ = [

--- a/packages/nauro/src/nauro/store/registry.py
+++ b/packages/nauro/src/nauro/store/registry.py
@@ -78,6 +78,19 @@ class RegistryEntryV2(BaseModel):
     def has_store_path(self) -> bool:
         return "store_path" in self.model_fields_set
 
+    def bound_store_path(self, project_id: str) -> Path | None:
+        """The registered store path, or None when the entry leaves it to the default home.
+        A store path that is present but blank is a binding error, not an absent path.
+        """
+        if not self.has_store_path:
+            return None
+        if self.store_path is None or not self.store_path.strip():
+            raise StoreBindingError(
+                "connected_record_invalid",
+                f"Registered store path for {project_id!r} must be a nonempty string.",
+            )
+        return Path(self.store_path)
+
 
 def validate_registry_entry_v2(project_id: str, raw_entry: object) -> RegistryEntryV2:
     """Parse an untrusted registry entry into its typed in-memory form."""
@@ -300,40 +313,26 @@ def resolve_registered_store_path_v2(
     # structurally incomplete default store resolves, and downstream tools
     # degrade gracefully, instead of dead-ending every command in a
     # connected_record_invalid state that reconnect cannot restore.
-    if not entry.has_store_path:
+    bound = entry.bound_store_path(project_id)
+    if bound is None:
         return _validate_store_structure(
             project_id,
             get_store_path_v2(project_id),
             require_store=require_store,
             strict_store=False,
         )
-
-    raw_store_path = entry.store_path
-    if raw_store_path is None or not raw_store_path.strip():
-        raise StoreBindingError(
-            "connected_record_invalid",
-            f"Registered store path for {project_id!r} must be a nonempty string.",
-        )
     return _validate_registered_store_path(
-        project_id,
-        Path(raw_store_path),
-        require_store=require_store,
-        strict_store=True,
+        project_id, bound, require_store=require_store, strict_store=True
     )
 
 
 def registered_store_path_hint_v2(project_id: str, entry: object) -> Path | None:
     """Return a display-only store hint without trusting malformed registry data."""
     try:
-        typed_entry = validate_registry_entry_v2(project_id, entry)
+        bound = validate_registry_entry_v2(project_id, entry).bound_store_path(project_id)
     except StoreBindingError:
         return None
-    if not typed_entry.has_store_path:
-        return get_store_path_v2(project_id)
-    raw_store_path = typed_entry.store_path
-    if raw_store_path is None or not raw_store_path.strip():
-        return None
-    return Path(raw_store_path)
+    return get_store_path_v2(project_id) if bound is None else bound
 
 
 def bind_project_store_v2(
@@ -615,8 +614,8 @@ def rename_project_id_v2(
 
         existing = validate_registry_entry_v2(old_id, registry["projects"].pop(old_id))
         entry = existing.model_dump(mode="json", exclude_unset=True)
-        if not existing.has_store_path:
-            raw_store_path = None
+        bound_store = existing.bound_store_path(old_id)
+        if bound_store is None:
             old_store = _validate_store_structure(
                 old_id,
                 get_store_path_v2(old_id),
@@ -624,17 +623,8 @@ def rename_project_id_v2(
                 strict_store=True,
             )
         else:
-            raw_store_path = existing.store_path
-            if raw_store_path is None or not raw_store_path.strip():
-                raise StoreBindingError(
-                    "connected_record_invalid",
-                    f"Registered store path for {old_id!r} must be a nonempty string.",
-                )
             old_store = _validate_registered_store_path(
-                old_id,
-                Path(raw_store_path),
-                require_store=rename_store,
-                strict_store=True,
+                old_id, bound_store, require_store=rename_store, strict_store=True
             )
         if mode is not None:
             if mode not in _VALID_MODES_V2:
@@ -652,8 +642,10 @@ def rename_project_id_v2(
             mode="json", exclude_unset=True
         )
 
-        new_store = old_store.with_name(new_id) if raw_store_path else get_store_path_v2(new_id)
-        if raw_store_path and get_store_path_v2(new_id).exists():
+        new_store = (
+            get_store_path_v2(new_id) if bound_store is None else old_store.with_name(new_id)
+        )
+        if bound_store is not None and get_store_path_v2(new_id).exists():
             raise StoreBindingError(
                 "connected_binding_conflict",
                 f"Default store already exists for new project id {new_id!r}.",
@@ -662,7 +654,7 @@ def rename_project_id_v2(
             if new_store.exists():
                 raise ValueError(f"Cannot rename store: destination already exists at {new_store}.")
             shutil.move(str(old_store), str(new_store))
-        if raw_store_path:
+        if bound_store is not None:
             entry["store_path"] = str(new_store)
         else:
             entry.pop("store_path", None)

--- a/packages/nauro/tests/test_registry_v2.py
+++ b/packages/nauro/tests/test_registry_v2.py
@@ -362,3 +362,26 @@ class TestIsCloudProject:
         gate degrades to False rather than crashing."""
         _write_v1_registry(tmp_path, {"v1name": {"repo_paths": [str(tmp_path)]}})
         assert is_cloud_project("v1name") is False
+
+
+@pytest.mark.parametrize("store_path", [None, "", "   "])
+def test_present_blank_store_path_is_rejected_when_binding(store_path):
+    """A registry entry that sets store_path to nothing usable still parses, so
+    recovery can rewrite it, but binding to it is refused in one place."""
+    entry = validate_registry_entry_v2(
+        "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+        {"name": "demo", "mode": "local", "store_path": store_path},
+    )
+    with pytest.raises(StoreBindingError, match="must be a nonempty string") as excinfo:
+        entry.bound_store_path("01ARZ3NDEKTSV4RRFFQ69G5FAV")
+    assert excinfo.value.reason_code == "connected_record_invalid"
+
+
+def test_absent_store_path_binds_to_nothing_and_present_path_binds_typed():
+    project_id = "01ARZ3NDEKTSV4RRFFQ69G5FAV"
+    absent = validate_registry_entry_v2(project_id, {"name": "d", "mode": "local"})
+    assert absent.bound_store_path(project_id) is None
+    present = validate_registry_entry_v2(
+        project_id, {"name": "d", "mode": "local", "store_path": "/tmp/s"}
+    )
+    assert present.bound_store_path(project_id) == Path("/tmp/s")

--- a/packages/nauro/tests/test_skills_dispatch.py
+++ b/packages/nauro/tests/test_skills_dispatch.py
@@ -1,0 +1,29 @@
+"""Skill rendering dispatches on surface and skill name through tables, not chains."""
+
+import pytest
+
+from nauro.skills import SKILL_DESCRIPTIONS, render_skill
+
+SURFACES = ("claude_code", "codex", "cursor")
+CURSOR_REWORDED = {("cursor", "nauro-ship-task")}
+
+
+@pytest.mark.parametrize("surface", SURFACES)
+@pytest.mark.parametrize("skill_name", sorted(SKILL_DESCRIPTIONS))
+def test_every_surface_and_skill_renders_frontmatter_and_body(surface: str, skill_name: str):
+    rendered = render_skill(surface, skill_name)
+    assert rendered.startswith("---\n")
+    assert "\ndescription: " in rendered
+    described = SKILL_DESCRIPTIONS[skill_name] in rendered
+    assert described is not ((surface, skill_name) in CURSOR_REWORDED)
+    assert "<!-- surface:" not in rendered
+
+
+def test_unknown_surface_is_rejected():
+    with pytest.raises(ValueError, match="unknown surface"):
+        render_skill("emacs", "nauro-adopt")
+
+
+def test_unknown_skill_is_rejected():
+    with pytest.raises(ValueError, match="unknown skill"):
+        render_skill("claude_code", "nauro-teleport")

--- a/packages/nauro/tests/test_tools_requires_store.py
+++ b/packages/nauro/tests/test_tools_requires_store.py
@@ -1,0 +1,34 @@
+"""Every local tool answers a missing store with the no-project guidance envelope."""
+
+import inspect
+from pathlib import Path
+
+import pytest
+
+from nauro.cli.autogen import AUTOGEN_ALLOWLIST
+from nauro.mcp import tools
+from nauro.onboarding import WELCOME_NO_PROJECT
+
+TOOLS = sorted(name for name in vars(tools) if name.startswith("tool_"))
+
+
+def _placeholder(parameter: inspect.Parameter) -> object:
+    return 1 if parameter.annotation in ("int", int) else "placeholder"
+
+
+@pytest.mark.parametrize("name", TOOLS)
+def test_missing_store_short_circuits_before_any_argument_is_used(tmp_path: Path, name: str):
+    tool = getattr(tools, name)
+    required = {
+        parameter.name: _placeholder(parameter)
+        for parameter in inspect.signature(tool).parameters.values()
+        if parameter.default is inspect.Parameter.empty and parameter.name != "store_path"
+    }
+    envelope = tool(tmp_path / "missing", **required)
+    assert envelope["store"] == "local"
+    assert envelope["status"] == "error"
+    assert envelope["guidance"] == WELCOME_NO_PROJECT
+
+
+def test_guarded_tools_are_exactly_the_local_tool_allowlist():
+    assert {name.removeprefix("tool_") for name in TOOLS} == set(AUTOGEN_ALLOWLIST)

--- a/scripts/ruff_budget_baseline.jsonl
+++ b/scripts/ruff_budget_baseline.jsonl
@@ -118,7 +118,7 @@
 {"path":"packages/nauro/src/nauro/mcp/rendering.py","rule":"BLE001","count":1}
 {"path":"packages/nauro/src/nauro/mcp/stdio_server.py","rule":"BLE001","count":2}
 {"path":"packages/nauro/src/nauro/mcp/tools.py","rule":"BLE001","count":4}
-{"path":"packages/nauro/src/nauro/mcp/tools.py","rule":"C901","count":2}
+{"path":"packages/nauro/src/nauro/mcp/tools.py","rule":"C901","count":1}
 {"path":"packages/nauro/src/nauro/mcp/tools.py","rule":"PLR0911","count":1}
 {"path":"packages/nauro/src/nauro/mcp/tools.py","rule":"PLR0912","count":1}
 {"path":"packages/nauro/src/nauro/store/generation_authority.py","rule":"TRY300","count":1}


### PR DESCRIPTION
## Why

Three places repeated the same shape by hand: every MCP tool adapter opened with the same missing-store prologue, three registry call sites re-checked a raw store_path string, and the skills package selected surface text and loaders through four if-chains.

## What changed

- `mcp/tools.py`: a `requires_store` decorator answers a missing store with the no-project guidance envelope. It sits innermost so the identity and journal decorators see the envelope they always saw.
- `store/registry.py`: `RegistryEntryV2` exposes the bound store path as a typed Path or None and rejects a present but blank path at binding time; the three call sites read the typed field. Parsing stays lenient so recovery can rewrite a broken entry.
- `skills/__init__.py`: dicts keyed by surface and by skill name replace the if-chains. Rendered skill files are byte-identical, as the drift tests assert.
- The ruff budget drops one complexity entry.

## Test plan

Full pytest for both packages on the rebased branch: 6997 passed, 121 skipped, 12 failed. The 12 are permission-denial tests that fail identically on origin/main under this container's root user. ruff check and format, the ruff and docstring budgets, the single-sourced check and the import-linter contracts all pass.