### PR TITLE
Report failed setup writes as typed outcomes and exit nonzero

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/adopt.py
+++ b/packages/nauro/src/nauro/cli/commands/adopt.py
@@ -19,10 +19,12 @@ from __future__ import annotations
 import shutil
 import subprocess
 from pathlib import Path
+from typing import NoReturn
 
 import typer
 
 from nauro.agents import AGENT_NAMES
+from nauro.cli.integrations.echo import echo_outcomes
 from nauro.cli.integrations.orchestrator import (
     SHIP_TASK_NEEDS_SUBAGENTS_NOTICE,
     SUBAGENTS_CONNECTOR_NAME_NOTICE,
@@ -33,7 +35,6 @@ from nauro.cli.nauro_command import _find_nauro_command
 from nauro.cli.utils import refuse_global_config_collision, refuse_repo_config_symlink
 from nauro.constants import REPO_CONFIG_MODE_LOCAL
 from nauro.setup.git_hygiene import public_surface_git_warnings
-from nauro.setup.render import render
 from nauro.skills import load_adopt_body
 from nauro.store.registry import (
     RegistrySchemaError,
@@ -139,6 +140,17 @@ def _check_collision(name: str, repo_root: Path) -> str | None:
     return None
 
 
+def _exit_writes_failed(rerun: str) -> NoReturn:
+    """Name the failed writes above and exit 1 so a script never sees the step as complete.
+    Un-adopt calls this before it deletes the repo config or deregisters, so the re-run works.
+    """
+    typer.echo(
+        f"\nSome files could not be written (see above). Fix them, then re-run '{rerun}'.",
+        err=True,
+    )
+    raise typer.Exit(code=1)
+
+
 def _install_into_adopted_repo(
     repo_root: Path,
     *,
@@ -161,19 +173,21 @@ def _install_into_adopted_repo(
         pass
 
     typer.echo("Repo already adopted. Installing requested artifacts across surfaces:\n")
-    for outcome in setup_all_surfaces(
-        project_repos,
-        remove=False,
-        with_subagents=with_subagents,
-        force_overwrite=force_overwrite,
-        with_skills=with_skills,
-    ):
-        for line in render(outcome):
-            typer.echo(line)
+    failed = echo_outcomes(
+        setup_all_surfaces(
+            project_repos,
+            remove=False,
+            with_subagents=with_subagents,
+            force_overwrite=force_overwrite,
+            with_skills=with_skills,
+        )
+    )
     if with_skills and not with_subagents:
         typer.echo(f"\n{SHIP_TASK_NEEDS_SUBAGENTS_NOTICE}")
     if with_subagents:
         typer.echo(f"\n{SUBAGENTS_CONNECTOR_NAME_NOTICE}")
+    if failed:
+        _exit_writes_failed("nauro setup all")
     typer.echo("\nNext: restart your agent so it picks up the newly installed files.")
 
 
@@ -306,17 +320,19 @@ def _remove_adoption(repo_root: Path, *, purge_store: bool, assume_yes: bool) ->
     # (absent artifacts are a no-op) and the shared-user-scope guard still
     # protects subagents/skills/codex when other projects remain.
     typer.echo("\nRemoving Nauro integration across surfaces:")
-    for outcome in setup_all_surfaces(
-        [repo_root],
-        remove=True,
-        current_project_key=pid,
-        with_subagents=True,
-        with_skills=True,
-        with_hooks=True,
-        clear_user_scope_override=None if is_last_repo else False,
-    ):
-        for line in render(outcome):
-            typer.echo(line)
+    failed = echo_outcomes(
+        setup_all_surfaces(
+            [repo_root],
+            remove=True,
+            current_project_key=pid,
+            with_subagents=True,
+            with_skills=True,
+            with_hooks=True,
+            clear_user_scope_override=None if is_last_repo else False,
+        )
+    )
+    if failed:
+        _exit_writes_failed("nauro adopt --remove")
 
     # ── delete the per-repo config (and the .nauro dir if it is now empty) ──
     try:
@@ -564,19 +580,20 @@ def adopt(
     typer.echo(f"  Repo:  {repo_root}")
 
     # ── wire MCP + materialize skills ──────────────────────────────────────
+    failed = False
     if not no_setup_and_skills:
         typer.echo("\nWiring MCP and installing skills across surfaces:")
-        for outcome in setup_all_surfaces(
-            [repo_root],
-            remove=False,
-            current_project_key=pid,
-            store_path=store_path,
-            with_subagents=with_subagents,
-            force_overwrite=force_overwrite,
-            with_skills=with_skills,
-        ):
-            for line in render(outcome):
-                typer.echo(line)
+        failed = echo_outcomes(
+            setup_all_surfaces(
+                [repo_root],
+                remove=False,
+                current_project_key=pid,
+                store_path=store_path,
+                with_subagents=with_subagents,
+                force_overwrite=force_overwrite,
+                with_skills=with_skills,
+            )
+        )
 
         if with_skills and not with_subagents:
             typer.echo(f"\n{SHIP_TASK_NEEDS_SUBAGENTS_NOTICE}")
@@ -588,6 +605,8 @@ def adopt(
         if warning:
             typer.echo(warning, err=True)
 
+    if failed:
+        _exit_writes_failed("nauro setup all")
     typer.echo(
         "\nNext: restart your agent and invoke the nauro-adopt skill to seed "
         "context from this repo. Use /nauro-adopt in Claude Code or "

--- a/packages/nauro/src/nauro/cli/commands/setup.py
+++ b/packages/nauro/src/nauro/cli/commands/setup.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 import typer
 
+from nauro.cli.integrations.echo import echo_outcomes
 from nauro.cli.integrations.orchestrator import (
     SHIP_TASK_NEEDS_SUBAGENTS_NOTICE,
     SUBAGENTS_CONNECTOR_NAME_NOTICE,
@@ -23,7 +24,7 @@ from nauro.cli.integrations.orchestrator import (
     setup_all_surfaces,
 )
 from nauro.cli.utils import _resolve_project_entry, resolve_target_project
-from nauro.setup.render import render
+from nauro.setup.outcomes import ArtifactOutcome
 
 setup_app = typer.Typer(help="Configure tool integrations.")
 
@@ -32,6 +33,12 @@ setup_app = typer.Typer(help="Configure tool integrations.")
 # against the local store, so users don't have to wait for an agent
 # restart to see Nauro do something useful.
 CHECK_HINT_LINE = 'Try it now from this shell: nauro check-decision "<approach>"'
+
+
+def _echo_outcomes(outcomes: list[ArtifactOutcome]) -> None:
+    """Echo every outcome, then exit 1 when any write did not land."""
+    if echo_outcomes(outcomes):
+        raise typer.Exit(code=1)
 
 
 @setup_app.command(name="claude-code")
@@ -59,16 +66,16 @@ def claude_code(
 
     action = "Removed" if remove else "Configured"
     typer.echo(f"{action} Nauro for project '{project_name}':\n")
-    for outcome in claude_code_surfaces(
-        project_repos,
-        remove=remove,
-        with_hooks=with_hooks,
-        store_name=_store_path.name,
-        store_path=_store_path,
-        warn=lambda msg: typer.echo(msg, err=True),
-    ):
-        for line in render(outcome):
-            typer.echo(line)
+    _echo_outcomes(
+        claude_code_surfaces(
+            project_repos,
+            remove=remove,
+            with_hooks=with_hooks,
+            store_name=_store_path.name,
+            store_path=_store_path,
+            warn=lambda msg: typer.echo(msg, err=True),
+        )
+    )
 
     if not remove:
         typer.echo(
@@ -105,9 +112,7 @@ def cursor(
 
     action = "Removed" if remove else "Configured"
     typer.echo(f"{action} Nauro (Cursor) for project '{project_name}':\n")
-    for outcome in cursor_surfaces(project_repos, remove=remove):
-        for line in render(outcome):
-            typer.echo(line)
+    _echo_outcomes(cursor_surfaces(project_repos, remove=remove))
 
     if not remove:
         typer.echo("\nNext: open this repo in Cursor and start a chat - Nauro MCP will connect.")
@@ -138,9 +143,7 @@ def codex(
     ),
 ) -> None:
     """Configure Codex CLI to use Nauro (writes '~/.codex/config.toml')."""
-    for outcome in codex_surfaces(remove=remove, with_hooks=with_hooks):
-        for line in render(outcome):
-            typer.echo(line)
+    _echo_outcomes(codex_surfaces(remove=remove, with_hooks=with_hooks))
 
     if not remove:
         typer.echo("\nNext: run a Codex session - it reads ~/.codex/config.toml on start.")
@@ -225,18 +228,18 @@ def all_(
     project_repos = [Path(rp) for rp in entry["repo_paths"]]
     action = "Removed" if remove else "Configured"
     typer.echo(f"{action} Nauro for project '{project_name}' across all surfaces:\n")
-    for outcome in setup_all_surfaces(
-        project_repos,
-        remove=remove,
-        current_project_key=_store_path.name,
-        store_path=_store_path,
-        with_subagents=with_subagents,
-        force_overwrite=force_overwrite,
-        with_skills=with_skills,
-        with_hooks=with_hooks,
-    ):
-        for line in render(outcome):
-            typer.echo(line)
+    _echo_outcomes(
+        setup_all_surfaces(
+            project_repos,
+            remove=remove,
+            current_project_key=_store_path.name,
+            store_path=_store_path,
+            with_subagents=with_subagents,
+            force_overwrite=force_overwrite,
+            with_skills=with_skills,
+            with_hooks=with_hooks,
+        )
+    )
 
     if not remove and with_skills and not with_subagents:
         typer.echo(f"\n{SHIP_TASK_NEEDS_SUBAGENTS_NOTICE}")

--- a/packages/nauro/src/nauro/cli/integrations/agents.py
+++ b/packages/nauro/src/nauro/cli/integrations/agents.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from nauro.setup.outcomes import AgentKind, AgentOutcome
+from nauro.setup.outcomes import AgentKind, AgentOutcome, WriteFailure
 from nauro.store.write_safety import (
     SymlinkRefusal,
     UserSymlinkRefusal,
@@ -137,6 +137,29 @@ def _install_bundled_agent(
     Absent writes the body, byte-equal is a no-op, ``force_overwrite`` overwrites in place, and a
     differing file is refreshed with its prior content stashed to a sibling ``.bak``.
     """
+    try:
+        return _install_bundled_agent_io(
+            target, bundled, force_overwrite=force_overwrite, repo=repo
+        )
+    except UnicodeDecodeError:
+        return AgentOutcome(AgentKind.PRESERVED_UNDECODABLE, target=target)
+    except OSError as exc:
+        return _agent_write_failed(target, exc)
+
+
+def _agent_write_failed(target: Path, exc: OSError) -> AgentOutcome:
+    return AgentOutcome(
+        AgentKind.WRITE_FAILED, target=target, write_failure=WriteFailure.of(target, exc)
+    )
+
+
+def _install_bundled_agent_io(
+    target: Path,
+    bundled: str,
+    *,
+    force_overwrite: bool,
+    repo: Path | None = None,
+) -> AgentOutcome:
     if target.is_file():
         current = target.read_text(encoding="utf-8")
         if current == bundled:
@@ -160,6 +183,15 @@ def _remove_bundled_agent(target: Path, bundled: str) -> AgentOutcome:
     """Remove one bundled agent file, returning its outcome.
     Absent skips, byte-equal to the bundle unlinks, and a differing file is preserved.
     """
+    try:
+        return _remove_bundled_agent_io(target, bundled)
+    except UnicodeDecodeError:
+        return AgentOutcome(AgentKind.PRESERVED_UNDECODABLE, target=target)
+    except OSError as exc:
+        return _agent_write_failed(target, exc)
+
+
+def _remove_bundled_agent_io(target: Path, bundled: str) -> AgentOutcome:
     if not target.is_file():
         return AgentOutcome(AgentKind.ABSENT, target=target)
     current = target.read_text(encoding="utf-8")

--- a/packages/nauro/src/nauro/cli/integrations/claude_hooks.py
+++ b/packages/nauro/src/nauro/cli/integrations/claude_hooks.py
@@ -16,7 +16,12 @@ from nauro.setup.git_hygiene import (
     remove_wiring_ignore_entry,
     wiring_path_is_tracked,
 )
-from nauro.setup.outcomes import ClaudeHookKind, ClaudeHookOutcome, SharedStripFailed
+from nauro.setup.outcomes import (
+    ClaudeHookKind,
+    ClaudeHookOutcome,
+    SharedStripFailed,
+    WriteFailure,
+)
 from nauro.store.write_safety import find_symlink
 
 # Claude Code merges hooks across the project settings layers. The Nauro hook
@@ -117,8 +122,18 @@ def _settings_shared_path(repo: Path) -> Path:
 def materialize_hooks_claude_code(repo: Path, *, remove: bool) -> ClaudeHookOutcome:
     """Add or remove the Nauro advisory hook in ``<repo>/.claude/settings.local.json``.
     Add appends idempotently to ``hooks.UserPromptSubmit[].hooks[]``, git-ignores that file, and
-    strips a stale entry from shared settings. Remove reverses both layers, keeping user hooks.
-    """
+    strips a stale entry from shared settings. Remove reverses both layers, keeping user hooks."""
+    try:
+        return _edit_claude_hooks(repo, remove=remove)
+    except OSError as exc:
+        return ClaudeHookOutcome(
+            ClaudeHookKind.WRITE_FAILED,
+            repo,
+            write_failure=WriteFailure.of(repo / SETTINGS_LOCAL_REL, exc),
+        )
+
+
+def _edit_claude_hooks(repo: Path, *, remove: bool) -> ClaudeHookOutcome:
     for rel in (SETTINGS_LOCAL_REL, SETTINGS_SHARED_REL):
         refusal = find_symlink(repo, rel)
         if refusal is not None:

--- a/packages/nauro/src/nauro/cli/integrations/codex_config.py
+++ b/packages/nauro/src/nauro/cli/integrations/codex_config.py
@@ -10,7 +10,7 @@ from tomlkit.exceptions import ParseError as TOMLParseError
 from tomlkit.items import InlineTable
 
 from nauro.cli.nauro_command import _find_nauro_command
-from nauro.setup.outcomes import CodexConfigKind, CodexConfigOutcome
+from nauro.setup.outcomes import CodexConfigKind, CodexConfigOutcome, WriteFailure
 from nauro.store._atomic import atomic_write_text
 from nauro.store.local_files import UnreadableFileError
 from nauro.store.write_safety import find_file_symlink
@@ -94,7 +94,19 @@ def _configure_codex(
     ``args`` are rewritten. The remove path preserves the entry unless ``clear_user_scope``.
     """
     config_path = config_path or codex_config_path()
+    try:
+        return _edit_codex_config(config_path, remove=remove, clear_user_scope=clear_user_scope)
+    except OSError as exc:
+        return CodexConfigOutcome(
+            CodexConfigKind.WRITE_FAILED,
+            config_path,
+            write_failure=WriteFailure.of(config_path, exc),
+        )
 
+
+def _edit_codex_config(
+    config_path: Path, *, remove: bool, clear_user_scope: bool
+) -> CodexConfigOutcome:
     if remove and not clear_user_scope:
         return CodexConfigOutcome(CodexConfigKind.PRESERVED_OTHER_PROJECTS, config_path)
 

--- a/packages/nauro/src/nauro/cli/integrations/codex_hooks.py
+++ b/packages/nauro/src/nauro/cli/integrations/codex_hooks.py
@@ -19,7 +19,7 @@ from nauro.setup.git_hygiene import (
     remove_wiring_ignore_entry,
     wiring_path_is_tracked,
 )
-from nauro.setup.outcomes import CodexHookKind, CodexHookOutcome
+from nauro.setup.outcomes import CodexHookKind, CodexHookOutcome, WriteFailure
 from nauro.store._atomic import atomic_write_text
 from nauro.store.write_safety import find_symlink
 
@@ -41,6 +41,17 @@ def _codex_hooks_path(repo: Path) -> Path:
 
 def materialize_hooks_codex(repo: Path, *, remove: bool) -> CodexHookOutcome:
     """Add or remove project-scoped Codex lifecycle hooks for ``repo``."""
+    try:
+        return _edit_codex_hooks(repo, remove=remove)
+    except OSError as exc:
+        return CodexHookOutcome(
+            CodexHookKind.WRITE_FAILED,
+            repo,
+            write_failure=WriteFailure.of(_codex_hooks_path(repo), exc),
+        )
+
+
+def _edit_codex_hooks(repo: Path, *, remove: bool) -> CodexHookOutcome:
     refusal = find_symlink(repo, ".codex/hooks.json")
     if refusal is not None:
         return CodexHookOutcome(CodexHookKind.REFUSED_SYMLINK, repo, refusal=refusal)

--- a/packages/nauro/src/nauro/cli/integrations/echo.py
+++ b/packages/nauro/src/nauro/cli/integrations/echo.py
@@ -1,0 +1,16 @@
+"""Echo rendered setup outcomes for the commands that wire surfaces."""
+
+from __future__ import annotations
+
+import typer
+
+from nauro.setup.outcomes import ArtifactOutcome, is_failure
+from nauro.setup.render import render
+
+
+def echo_outcomes(outcomes: list[ArtifactOutcome]) -> bool:
+    """Echo every outcome's status lines; True when any write did not land."""
+    for outcome in outcomes:
+        for line in render(outcome):
+            typer.echo(line)
+    return any(is_failure(outcome) for outcome in outcomes)

--- a/packages/nauro/src/nauro/cli/integrations/json_mcp.py
+++ b/packages/nauro/src/nauro/cli/integrations/json_mcp.py
@@ -17,7 +17,7 @@ from nauro.setup.git_hygiene import (
     remove_wiring_ignore_entry,
     wiring_path_is_tracked,
 )
-from nauro.setup.outcomes import JsonMcpKind, JsonMcpOutcome
+from nauro.setup.outcomes import JsonMcpKind, JsonMcpOutcome, WriteFailure
 from nauro.store.local_files import UnreadableFileError, read_text_or_absent
 from nauro.store.write_safety import find_symlink
 
@@ -77,8 +77,27 @@ def _configure_json_mcp(
 ) -> JsonMcpOutcome:
     """Add or remove the Nauro MCP entry in the JSON config at ``repo_path / config_rel_path``.
     Shared shape behind ``.mcp.json`` and ``.cursor/mcp.json``: only the relative path and the
-    status ``label`` vary. Writes mutate the raw dict, so key order and siblings stay identical.
-    """
+    status ``label`` vary. Writes mutate the raw dict, so key order and siblings stay identical."""
+    try:
+        return _edit_json_mcp(
+            repo_path, config_rel_path=config_rel_path, label=label, remove=remove
+        )
+    except OSError as exc:
+        return JsonMcpOutcome(
+            JsonMcpKind.WRITE_FAILED,
+            repo_path,
+            label,
+            write_failure=WriteFailure.of(repo_path / config_rel_path, exc),
+        )
+
+
+def _edit_json_mcp(
+    repo_path: Path,
+    *,
+    config_rel_path: str,
+    label: str,
+    remove: bool,
+) -> JsonMcpOutcome:
     refusal = find_symlink(repo_path, config_rel_path)
     if refusal is not None:
         return JsonMcpOutcome(JsonMcpKind.REFUSED_SYMLINK, repo_path, label, refusal=refusal)

--- a/packages/nauro/src/nauro/cli/integrations/orchestrator.py
+++ b/packages/nauro/src/nauro/cli/integrations/orchestrator.py
@@ -19,14 +19,17 @@ from nauro.cli.integrations.skills import (
 )
 from nauro.cli.integrations.user_scope import _registered_project_keys, _user_scope_safe_to_clear
 from nauro.cli.utils import _resolve_project_entry, resolve_target_project
+from nauro.constants import AGENTS_MD
 from nauro.setup.claude_bridge import remove_claude_bridge
 from nauro.setup.outcomes import (
+    AgentsMdKind,
+    AgentsMdOutcome,
     ArtifactOutcome,
     BridgeOutcome,
-    HandlerErrorOutcome,
     JsonMcpKind,
     JsonMcpOutcome,
     RawLine,
+    WriteFailure,
 )
 from nauro.store.registry import get_repo_paths
 from nauro.store.resolution import resolve_from_cwd
@@ -39,8 +42,6 @@ def _every_repo_mcp_wired(outcomes: list[ArtifactOutcome]) -> bool:
     The user-scope HTTP prune assumes project-scope stdio is canonical, so a refused or failed
     repo write must keep the user-scope entry rather than delete the only working connection.
     """
-    if any(isinstance(o, HandlerErrorOutcome) for o in outcomes):
-        return False
     mcp_outcomes = [o for o in outcomes if isinstance(o, JsonMcpOutcome)]
     return bool(mcp_outcomes) and all(o.kind is JsonMcpKind.WROTE for o in mcp_outcomes)
 
@@ -70,12 +71,7 @@ def claude_code_surfaces(
             legacy_results.append(legacy)
         mcp_results.append(_configure_mcp(repo_path, remove=remove))
         if with_hooks or remove:
-            try:
-                hook_results.append(materialize_hooks_claude_code(repo_path, remove=remove))
-            except Exception as exc:
-                hook_results.append(
-                    HandlerErrorOutcome(f"  {repo_path}: hook wiring error - {exc}")
-                )
+            hook_results.append(materialize_hooks_claude_code(repo_path, remove=remove))
 
     if not remove and _every_repo_mcp_wired(mcp_results):
         pruned = _prune_redundant_user_scope_mcp()
@@ -93,25 +89,33 @@ def claude_code_surfaces(
         outcomes.extend(legacy_results)
 
     if not remove:
-        # Regenerate AGENTS.md so context is fresh from the start. The store
-        # dir name is the project id used by the registry-aware lookup.
-        # warn_then_regen surfaces missing-repo, symlink-refusal, and
-        # git-hygiene warnings through the warn callback (stderr), never the
-        # returned outcomes.
-        bridge_outcomes: list[BridgeOutcome] = []
-        updated_repos = warn_then_regen(
-            store_name, store_path, warn=warn, bridge_sink=bridge_outcomes
-        )
-        if updated_repos:
+        regenerated = _regenerated_agents_md_lines(store_name, store_path, warn=warn)
+        if regenerated:
             outcomes.append(RawLine("\nAGENTS.md:"))
-            # The bridge outcomes parallel updated_repos: the shared regen seam
-            # ensures the Claude Code bridge on every AGENTS.md write and fills
-            # the sink in the same order.
-            for repo_path, bridge_outcome in zip(updated_repos, bridge_outcomes):
-                outcomes.append(RawLine(f"  {repo_path}: regenerated AGENTS.md"))
-                outcomes.append(bridge_outcome)
+            outcomes.extend(regenerated)
 
     return outcomes
+
+
+def _regenerated_agents_md_lines(
+    project_key: str, store_path: Path, *, warn: Callable[[str], None]
+) -> list[ArtifactOutcome]:
+    """Regenerate AGENTS.md across the project's repos and return one line per repo written.
+    Each write is followed by its Claude Code bridge outcome, which the regen seam ensures in
+    the same order. A write the seam could not land becomes the single failure outcome.
+    """
+    bridge_outcomes: list[BridgeOutcome] = []
+    try:
+        updated = warn_then_regen(project_key, store_path, warn=warn, bridge_sink=bridge_outcomes)
+    except OSError as exc:
+        return [
+            AgentsMdOutcome(AgentsMdKind.WRITE_FAILED, write_failure=WriteFailure.of(None, exc))
+        ]
+    lines: list[ArtifactOutcome] = []
+    for repo_path, bridge_outcome in zip(updated, bridge_outcomes):
+        lines.append(RawLine(f"  {repo_path}: regenerated AGENTS.md"))
+        lines.append(bridge_outcome)
+    return lines
 
 
 def cursor_surfaces(project_repos: list[Path], *, remove: bool) -> list[ArtifactOutcome]:
@@ -188,12 +192,7 @@ def codex_surfaces(*, remove: bool, with_hooks: bool) -> list[ArtifactOutcome]:
             if not repo_path.is_dir():
                 outcomes.append(RawLine(f"  {repo_path}: repo path missing, skipped"))
                 continue
-            try:
-                outcomes.append(materialize_hooks_codex(repo_path, remove=remove))
-            except Exception as exc:
-                outcomes.append(
-                    HandlerErrorOutcome(f"  {repo_path}: Codex hook wiring error - {exc}")
-                )
+            outcomes.append(materialize_hooks_codex(repo_path, remove=remove))
 
     return outcomes
 
@@ -217,47 +216,35 @@ def _all_claude_code_lines(
         if not repo.is_dir():
             outcomes.append(RawLine(f"  {repo}: repo path missing, skipped"))
             continue
-        try:
-            outcomes.append(_configure_mcp(repo, remove=remove))
-        except Exception as exc:
-            outcomes.append(HandlerErrorOutcome(f"Claude Code MCP ({repo}): error - {exc}"))
+        outcomes.append(_configure_mcp(repo, remove=remove))
     if not remove and _every_repo_mcp_wired(outcomes):
         pruned = _prune_redundant_user_scope_mcp()
         if pruned:
             outcomes.append(pruned)
-    try:
-        outcomes.extend(
-            materialize_skills_claude_code(
-                remove=remove,
-                clear_user_scope=clear_user_scope,
-                with_skills=with_skills,
-                force_overwrite=force_overwrite,
-            )
+    outcomes.extend(
+        materialize_skills_claude_code(
+            remove=remove,
+            clear_user_scope=clear_user_scope,
+            with_skills=with_skills,
+            force_overwrite=force_overwrite,
         )
-    except Exception as exc:
-        outcomes.append(HandlerErrorOutcome(f"Claude Code skills: error - {exc}"))
+    )
 
     if with_subagents:
-        try:
-            outcomes.extend(
-                materialize_agents(
-                    "claude_code",
-                    remove=remove,
-                    force_overwrite=force_overwrite,
-                    clear_user_scope=clear_user_scope,
-                )
+        outcomes.extend(
+            materialize_agents(
+                "claude_code",
+                remove=remove,
+                force_overwrite=force_overwrite,
+                clear_user_scope=clear_user_scope,
             )
-        except Exception as exc:
-            outcomes.append(HandlerErrorOutcome(f"Claude Code agents: error - {exc}"))
+        )
 
     if with_hooks or remove:
         for repo in project_repos:
             if not repo.is_dir():
                 continue
-            try:
-                outcomes.append(materialize_hooks_claude_code(repo, remove=remove))
-            except Exception as exc:
-                outcomes.append(HandlerErrorOutcome(f"Claude Code hook ({repo}): error - {exc}"))
+            outcomes.append(materialize_hooks_claude_code(repo, remove=remove))
     return outcomes
 
 
@@ -274,32 +261,23 @@ def _all_cursor_lines(
     for repo in project_repos:
         if not repo.is_dir():
             continue
-        try:
-            outcomes.append(_configure_cursor_for_repo(repo, remove=remove))
-        except Exception as exc:
-            outcomes.append(HandlerErrorOutcome(f"Cursor MCP ({repo}): error - {exc}"))
-        try:
+        outcomes.append(_configure_cursor_for_repo(repo, remove=remove))
+        outcomes.extend(
+            materialize_skills_cursor_for_repo(
+                repo,
+                remove=remove,
+                with_skills=with_skills,
+                force_overwrite=force_overwrite,
+            )
+        )
+        if with_subagents:
             outcomes.extend(
-                materialize_skills_cursor_for_repo(
+                materialize_agents_cursor_for_repo(
                     repo,
                     remove=remove,
-                    with_skills=with_skills,
                     force_overwrite=force_overwrite,
                 )
             )
-        except Exception as exc:
-            outcomes.append(HandlerErrorOutcome(f"Cursor skills ({repo}): error - {exc}"))
-        if with_subagents:
-            try:
-                outcomes.extend(
-                    materialize_agents_cursor_for_repo(
-                        repo,
-                        remove=remove,
-                        force_overwrite=force_overwrite,
-                    )
-                )
-            except Exception as exc:
-                outcomes.append(HandlerErrorOutcome(f"Cursor agents ({repo}): error - {exc}"))
     return outcomes
 
 
@@ -315,43 +293,31 @@ def _all_codex_lines(
 ) -> list[ArtifactOutcome]:
     """Codex surface lines: MCP, skills, optional subagents, then hooks."""
     outcomes: list[ArtifactOutcome] = []
-    try:
-        outcomes.append(_configure_codex(remove=remove, clear_user_scope=clear_user_scope))
-    except Exception as exc:
-        outcomes.append(HandlerErrorOutcome(f"Codex MCP: error - {exc}"))
-    try:
-        outcomes.extend(
-            materialize_skills_codex(
-                remove=remove,
-                clear_user_scope=clear_user_scope,
-                with_skills=with_skills,
-                force_overwrite=force_overwrite,
-            )
+    outcomes.append(_configure_codex(remove=remove, clear_user_scope=clear_user_scope))
+    outcomes.extend(
+        materialize_skills_codex(
+            remove=remove,
+            clear_user_scope=clear_user_scope,
+            with_skills=with_skills,
+            force_overwrite=force_overwrite,
         )
-    except Exception as exc:
-        outcomes.append(HandlerErrorOutcome(f"Codex skills: error - {exc}"))
+    )
 
     if with_subagents:
-        try:
-            outcomes.extend(
-                materialize_agents(
-                    "codex",
-                    remove=remove,
-                    force_overwrite=force_overwrite,
-                    clear_user_scope=clear_user_scope,
-                )
+        outcomes.extend(
+            materialize_agents(
+                "codex",
+                remove=remove,
+                force_overwrite=force_overwrite,
+                clear_user_scope=clear_user_scope,
             )
-        except Exception as exc:
-            outcomes.append(HandlerErrorOutcome(f"Codex agents: error - {exc}"))
+        )
 
     if with_hooks or remove:
         for repo in project_repos:
             if not repo.is_dir():
                 continue
-            try:
-                outcomes.append(materialize_hooks_codex(repo, remove=remove))
-            except Exception as exc:
-                outcomes.append(HandlerErrorOutcome(f"Codex hooks ({repo}): error - {exc}"))
+            outcomes.append(materialize_hooks_codex(repo, remove=remove))
     return outcomes
 
 
@@ -367,26 +333,14 @@ def _all_agents_md_lines(
     missing-repo, symlink-refusal and git-hygiene warnings land on stdout in position.
     """
     outcomes: list[ArtifactOutcome] = []
-    # Regenerate AGENTS.md once so context is fresh from the start on every
-    # entry point that wires surfaces. Guarded on the add path and on having a
-    # store to read from. warn_then_regen routes missing-repo, symlink-refusal,
-    # and git-hygiene warnings into the status lines.
     if not remove and current_project_key is not None and store_path is not None:
-        try:
-            bridge_outcomes: list[BridgeOutcome] = []
-            updated = warn_then_regen(
+        outcomes.extend(
+            _regenerated_agents_md_lines(
                 current_project_key,
                 store_path,
                 warn=lambda message: outcomes.append(RawLine(message)),
-                bridge_sink=bridge_outcomes,
             )
-            # The sink parallels updated: the shared regen seam ensures the
-            # Claude Code bridge on every AGENTS.md write, in the same order.
-            for repo_path, bridge_outcome in zip(updated, bridge_outcomes):
-                outcomes.append(RawLine(f"  {repo_path}: regenerated AGENTS.md"))
-                outcomes.append(bridge_outcome)
-        except Exception as exc:
-            outcomes.append(HandlerErrorOutcome(f"AGENTS.md regeneration: error - {exc}"))
+        )
 
     # Mirror of the regen above: strip the generated AGENTS.md on teardown so a
     # removed integration leaves no orphaned context file. User content in a
@@ -402,8 +356,14 @@ def _all_agents_md_lines(
                 # Mirror of the add-path bridge write: strip the owned bridge
                 # alongside the generated AGENTS.md it imported.
                 outcomes.append(remove_claude_bridge(repo))
-            except Exception as exc:
-                outcomes.append(HandlerErrorOutcome(f"AGENTS.md removal ({repo}) failed: {exc}"))
+            except OSError as exc:
+                outcomes.append(
+                    AgentsMdOutcome(
+                        AgentsMdKind.WRITE_FAILED,
+                        repo,
+                        write_failure=WriteFailure.of(repo / AGENTS_MD, exc),
+                    )
+                )
     return outcomes
 
 
@@ -419,8 +379,8 @@ def setup_all_surfaces(
     with_hooks: bool = False,
     clear_user_scope_override: bool | None = None,
 ) -> list[ArtifactOutcome]:
-    """Wire/unwire MCP/skills per ``remove`` for Claude Code, Cursor, Codex, collecting status
-    lines past per-handler errors. AGENTS.md regen on add: ``current_project_key``+``store_path``.
+    """Wire/unwire MCP/skills per ``remove`` for Claude Code, Cursor, Codex; a write that fails
+    is one typed outcome. AGENTS.md regen on add: ``current_project_key``+``store_path``.
     Multi-repo un-adopt passes ``clear_user_scope_override=False`` (default: project-granular)."""
     if clear_user_scope_override is not None:
         clear_user_scope = clear_user_scope_override

--- a/packages/nauro/src/nauro/cli/integrations/skills.py
+++ b/packages/nauro/src/nauro/cli/integrations/skills.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from nauro.setup.outcomes import SkillKind, SkillOutcome
+from nauro.setup.outcomes import SkillKind, SkillOutcome, WriteFailure
 from nauro.store.write_safety import (
     SymlinkRefusal,
     UserSymlinkRefusal,
@@ -33,6 +33,12 @@ def _codex_skill_dir() -> Path:
     return Path.home() / ".agents" / "skills"
 
 
+# The legacy ~/.codex/skills copy is moved aside only once its replacement exists.
+_REPLACEMENT_IN_PLACE = frozenset(
+    {SkillKind.WROTE, SkillKind.UNCHANGED, SkillKind.OVERWROTE, SkillKind.UPDATED}
+)
+
+
 def _skill_refusal(target: Path, repo: Path | None) -> SymlinkRefusal | UserSymlinkRefusal | None:
     if repo is None:
         return find_file_symlink(target)
@@ -40,6 +46,29 @@ def _skill_refusal(target: Path, repo: Path | None) -> SymlinkRefusal | UserSyml
 
 
 def _install_bundled_skill(
+    target: Path,
+    bundled: str,
+    *,
+    force_overwrite: bool,
+    repo: Path | None = None,
+) -> SkillOutcome:
+    try:
+        return _install_bundled_skill_io(
+            target, bundled, force_overwrite=force_overwrite, repo=repo
+        )
+    except UnicodeDecodeError:
+        return SkillOutcome(SkillKind.PRESERVED_UNDECODABLE, target=target, repo=repo)
+    except OSError as exc:
+        return _skill_write_failed(target, repo, exc)
+
+
+def _skill_write_failed(target: Path, repo: Path | None, exc: OSError) -> SkillOutcome:
+    return SkillOutcome(
+        SkillKind.WRITE_FAILED, target=target, repo=repo, write_failure=WriteFailure.of(target, exc)
+    )
+
+
+def _install_bundled_skill_io(
     target: Path,
     bundled: str,
     *,
@@ -91,6 +120,21 @@ def _remove_bundled_skill(
     Without the bound the parent walk could rmdir the surface base (``~/.claude/skills/``,
     ``<repo>/.cursor/rules/``).
     """
+    try:
+        return _remove_bundled_skill_io(target, bundled, stop_above=stop_above, repo=repo)
+    except UnicodeDecodeError:
+        return SkillOutcome(SkillKind.PRESERVED_UNDECODABLE, target=target, repo=repo)
+    except OSError as exc:
+        return _skill_write_failed(target, repo, exc)
+
+
+def _remove_bundled_skill_io(
+    target: Path,
+    bundled: str,
+    *,
+    stop_above: Path,
+    repo: Path | None = None,
+) -> SkillOutcome:
     refusal = _skill_refusal(target, repo)
     if refusal is not None:
         return SkillOutcome(SkillKind.REFUSED_SYMLINK, target=target, refusal=refusal, repo=repo)
@@ -111,6 +155,15 @@ def _remove_bundled_skill(
 
 def _migrate_legacy_codex_skill(name: str) -> SkillOutcome | None:
     source = Path.home() / ".codex" / "skills" / name
+    try:
+        return _migrate_legacy_codex_skill_io(source, name)
+    except OSError as exc:
+        return SkillOutcome(
+            SkillKind.WRITE_FAILED, source=source, write_failure=WriteFailure.of(source, exc)
+        )
+
+
+def _migrate_legacy_codex_skill_io(source: Path, name: str) -> SkillOutcome | None:
     if source.is_symlink():
         return SkillOutcome(
             SkillKind.REFUSED_SYMLINK,
@@ -213,7 +266,7 @@ def materialize_skills_codex(
                 force_overwrite=force_overwrite,
             )
             results.append(installed)
-            if installed.kind is not SkillKind.REFUSED_SYMLINK:
+            if installed.kind in _REPLACEMENT_IN_PLACE:
                 migrated = _migrate_legacy_codex_skill(name)
                 if migrated is not None:
                     results.append(migrated)

--- a/packages/nauro/src/nauro/setup/outcomes.py
+++ b/packages/nauro/src/nauro/setup/outcomes.py
@@ -9,8 +9,8 @@ codecs stay free of presentation and of Typer.
 
 ``RawLine`` remains for the orchestrator's own policy text (section headers,
 advisory paragraphs, the standalone codex count-phrase) that no codec owns.
-``HandlerErrorOutcome`` carries the message an orchestrator ``except`` arm
-built at the catch site.
+A write that did not land is a ``WRITE_FAILED`` kind carrying a ``WriteFailure``;
+``is_failure`` is the one test the commands use to decide their exit code.
 """
 
 from __future__ import annotations
@@ -20,7 +20,25 @@ from enum import Enum, auto
 from pathlib import Path
 
 from nauro.setup.git_hygiene import GitIgnoreResult
+from nauro.store._atomic import is_tmp_sibling
 from nauro.store.write_safety import SymlinkRefusal, UserSymlinkRefusal
+
+
+@dataclass(frozen=True)
+class WriteFailure:
+    """An OS error on a codec's write path: the file it names, its errno and its reason."""
+
+    path: Path | None
+    errno: int | None
+    reason: str
+
+    @classmethod
+    def of(cls, path: Path | None, exc: OSError) -> WriteFailure:
+        """Name the file ``exc`` reports unless that is a tmp sibling, else the codec's ``path``."""
+        named = Path(exc.filename) if isinstance(exc.filename, str) else None
+        if named is None or is_tmp_sibling(named.name):
+            named = path
+        return cls(named, exc.errno, exc.strerror or str(exc))
 
 
 @dataclass(frozen=True)
@@ -39,6 +57,7 @@ class JsonMcpKind(Enum):
     WROTE = auto()
     REMOVED = auto()
     NOTHING_TO_REMOVE = auto()
+    WRITE_FAILED = auto()
 
 
 @dataclass(frozen=True)
@@ -52,6 +71,7 @@ class JsonMcpOutcome:
     detail: str | None = None
     git_warnings: tuple[str, ...] = ()
     gitignore: GitIgnoreResult | None = None
+    write_failure: WriteFailure | None = None
 
 
 class ClaudeHookKind(Enum):
@@ -66,6 +86,7 @@ class ClaudeHookKind(Enum):
     REMOVED = auto()
     NOTHING_TO_REMOVE = auto()
     SHARED_STRIP_FAILED = auto()
+    WRITE_FAILED = auto()
 
 
 @dataclass(frozen=True)
@@ -91,6 +112,7 @@ class ClaudeHookOutcome:
     legacy_cleaned: bool = False
     local_cleaned: bool = False
     shared_strip: SharedStripFailed | None = None
+    write_failure: WriteFailure | None = None
 
 
 class ClaudeUserConfigKind(Enum):
@@ -158,6 +180,7 @@ class CodexConfigKind(Enum):
     REMOVED = auto()
     ALREADY_CONFIGURED = auto()
     WROTE = auto()
+    WRITE_FAILED = auto()
 
 
 @dataclass(frozen=True)
@@ -168,6 +191,7 @@ class CodexConfigOutcome:
     config_path: Path
     refusal: UserSymlinkRefusal | None = None
     detail: str | None = None
+    write_failure: WriteFailure | None = None
 
 
 class CodexHookKind(Enum):
@@ -180,6 +204,7 @@ class CodexHookKind(Enum):
     WROTE = auto()
     REMOVED = auto()
     NOTHING_TO_REMOVE = auto()
+    WRITE_FAILED = auto()
 
 
 @dataclass(frozen=True)
@@ -192,12 +217,14 @@ class CodexHookOutcome:
     detail: str | None = None
     git_warnings: tuple[str, ...] = ()
     gitignore: GitIgnoreResult | None = None
+    write_failure: WriteFailure | None = None
 
 
 class SkillKind(Enum):
     REFUSED_SYMLINK = auto()
     PRESERVED = auto()
     PRESERVED_MODIFIED = auto()
+    PRESERVED_UNDECODABLE = auto()
     WROTE = auto()
     UNCHANGED = auto()
     OVERWROTE = auto()
@@ -205,6 +232,7 @@ class SkillKind(Enum):
     MIGRATED_LEGACY = auto()
     REMOVED = auto()
     ABSENT = auto()
+    WRITE_FAILED = auto()
 
 
 @dataclass(frozen=True)
@@ -219,12 +247,14 @@ class SkillOutcome:
     source: Path | None = None
     backup_path: Path | None = None
     backup_name: str | None = None
+    write_failure: WriteFailure | None = None
 
 
 class AgentKind(Enum):
     REFUSED_SYMLINK = auto()
     PRESERVED = auto()
     PRESERVED_MODIFIED = auto()
+    PRESERVED_UNDECODABLE = auto()
     SURFACE_INVALID = auto()
     UNCHANGED = auto()
     OVERWROTE = auto()
@@ -232,6 +262,7 @@ class AgentKind(Enum):
     INSTALLED = auto()
     ABSENT = auto()
     REMOVED = auto()
+    WRITE_FAILED = auto()
 
 
 @dataclass(frozen=True)
@@ -244,17 +275,25 @@ class AgentOutcome:
     surface: str | None = None
     detail: str | None = None
     backup_name: str | None = None
+    write_failure: WriteFailure | None = None
+
+
+class AgentsMdKind(Enum):
+    WRITE_FAILED = auto()
 
 
 @dataclass(frozen=True)
-class HandlerErrorOutcome:
-    """A caught per-handler failure the orchestrator reports as one line."""
+class AgentsMdOutcome:
+    """Result of an AGENTS.md regeneration or removal the orchestrator drives itself."""
 
-    message: str
+    kind: AgentsMdKind
+    repo: Path | None = None
+    write_failure: WriteFailure | None = None
 
 
 ArtifactOutcome = (
     RawLine
+    | AgentsMdOutcome
     | JsonMcpOutcome
     | ClaudeHookOutcome
     | ClaudeUserConfigOutcome
@@ -264,5 +303,25 @@ ArtifactOutcome = (
     | CodexHookOutcome
     | SkillOutcome
     | AgentOutcome
-    | HandlerErrorOutcome
 )
+
+
+_FAILED_KINDS: frozenset[Enum] = frozenset(
+    {
+        JsonMcpKind.WRITE_FAILED,
+        ClaudeHookKind.WRITE_FAILED,
+        CodexConfigKind.WRITE_FAILED,
+        CodexHookKind.WRITE_FAILED,
+        SkillKind.WRITE_FAILED,
+        AgentKind.WRITE_FAILED,
+        AgentsMdKind.WRITE_FAILED,
+        BridgeKind.FAILED,
+    }
+)
+
+
+def is_failure(outcome: ArtifactOutcome) -> bool:
+    """Whether ``outcome`` reports a write that did not land."""
+    if isinstance(outcome, RawLine):
+        return False
+    return outcome.kind in _FAILED_KINDS

--- a/packages/nauro/src/nauro/setup/render.py
+++ b/packages/nauro/src/nauro/setup/render.py
@@ -13,6 +13,8 @@ from nauro.setup.git_hygiene import GitIgnoreKind, GitIgnoreResult
 from nauro.setup.outcomes import (
     AgentKind,
     AgentOutcome,
+    AgentsMdKind,
+    AgentsMdOutcome,
     ArtifactOutcome,
     BridgeKind,
     BridgeOutcome,
@@ -24,7 +26,6 @@ from nauro.setup.outcomes import (
     CodexConfigOutcome,
     CodexHookKind,
     CodexHookOutcome,
-    HandlerErrorOutcome,
     JsonMcpKind,
     JsonMcpOutcome,
     LegacyKind,
@@ -32,6 +33,7 @@ from nauro.setup.outcomes import (
     RawLine,
     SkillKind,
     SkillOutcome,
+    WriteFailure,
 )
 
 
@@ -39,8 +41,8 @@ def render(outcome: ArtifactOutcome) -> list[str]:
     """Flatten one outcome into the status lines a command echoes."""
     if isinstance(outcome, RawLine):
         return [outcome.text]
-    if isinstance(outcome, HandlerErrorOutcome):
-        return [outcome.message]
+    if isinstance(outcome, AgentsMdOutcome):
+        return _render_agents_md(outcome)
     if isinstance(outcome, JsonMcpOutcome):
         return _render_json_mcp(outcome)
     if isinstance(outcome, ClaudeHookOutcome):
@@ -107,8 +109,27 @@ def _render_gitignore(result: GitIgnoreResult | None) -> list[str]:
             raise TypeError(f"unrenderable GitIgnoreResult kind: {result.kind!r}")
 
 
+def _failed_write(failure: WriteFailure | None) -> str:
+    if failure is None:
+        raise TypeError("a WRITE_FAILED outcome carries its write failure")
+    if failure.path is None:
+        return f"write failed - {failure.reason}"
+    return f"could not write {failure.path} - {failure.reason}"
+
+
+def _render_agents_md(o: AgentsMdOutcome) -> list[str]:
+    match o.kind:
+        case AgentsMdKind.WRITE_FAILED:
+            where = f"  {o.repo}: " if o.repo is not None else "AGENTS.md regeneration: "
+            return [f"{where}{_failed_write(o.write_failure)}"]
+        case _:
+            raise TypeError(f"unrenderable AgentsMdOutcome kind: {o.kind!r}")
+
+
 def _render_json_mcp(o: JsonMcpOutcome) -> list[str]:
     match o.kind:
+        case JsonMcpKind.WRITE_FAILED:
+            return [f"  {o.repo_path}: {_failed_write(o.write_failure)}"]
         case JsonMcpKind.REFUSED_SYMLINK:
             return [f"  {o.repo_path}: {o.refusal.message}"]
         case JsonMcpKind.REFUSED_TRACKED:
@@ -136,20 +157,52 @@ def _render_json_mcp(o: JsonMcpOutcome) -> list[str]:
             raise TypeError(f"unrenderable JsonMcpOutcome kind: {o.kind!r}")
 
 
+def _local_removed_lines(o: ClaudeHookOutcome) -> list[str]:
+    if not o.local_cleaned:
+        return []
+    return [f"  {o.repo}: removed nauro hook from .claude/settings.local.json"]
+
+
+def _removed_layers(o: ClaudeHookOutcome) -> str:
+    """Name the settings layers a hook was removed from, joined for one line."""
+    cleaned = (
+        (".claude/settings.local.json", o.local_cleaned),
+        (".claude/settings.json", o.legacy_cleaned),
+    )
+    return " and ".join(layer for layer, removed in cleaned if removed)
+
+
+def _legacy_cleanup_lines(o: ClaudeHookOutcome) -> list[str]:
+    if not o.legacy_cleaned:
+        return []
+    return [
+        "    moved stale nauro hook out of .claude/settings.json "
+        "(machine-local wiring lives in .claude/settings.local.json; "
+        "commit the cleanup)"
+    ]
+
+
+def _shared_strip_lines(o: ClaudeHookOutcome) -> list[str]:
+    if o.shared_strip is None:
+        return []
+    return [f"    .claude/settings.json - {o.shared_strip.detail}"]
+
+
+_CLAUDE_HOOK_SKIPS: dict[ClaudeHookKind, str] = {
+    ClaudeHookKind.NOT_JSON_OBJECT: ".claude/settings.local.json is not a JSON object, skipped",
+    ClaudeHookKind.HOOKS_NOT_OBJECT: "hooks key is not a JSON object, skipped",
+    ClaudeHookKind.EVENT_NOT_ARRAY: "hooks.UserPromptSubmit is not a JSON array, skipped",
+}
+
+
 def _render_claude_hook(o: ClaudeHookOutcome) -> list[str]:
-    legacy_cleanup_add = (
-        [
-            "    moved stale nauro hook out of .claude/settings.json "
-            "(machine-local wiring lives in .claude/settings.local.json; "
-            "commit the cleanup)"
-        ]
-        if o.legacy_cleaned
-        else []
-    )
-    shared_strip_failed_add = (
-        [f"    .claude/settings.json - {o.shared_strip.detail}"] if o.shared_strip else []
-    )
+    if o.kind in _CLAUDE_HOOK_SKIPS:
+        return [f"  {o.repo}: {_CLAUDE_HOOK_SKIPS[o.kind]}"]
+    legacy_cleanup_add = _legacy_cleanup_lines(o)
+    shared_strip_failed_add = _shared_strip_lines(o)
     match o.kind:
+        case ClaudeHookKind.WRITE_FAILED:
+            return [f"  {o.repo}: {_failed_write(o.write_failure)}"]
         case ClaudeHookKind.REFUSED_SYMLINK:
             return [f"  {o.repo}: {o.refusal.message}"]
         case ClaudeHookKind.REFUSED_TRACKED:
@@ -158,12 +211,6 @@ def _render_claude_hook(o: ClaudeHookOutcome) -> list[str]:
             )
         case ClaudeHookKind.PARSE_ERROR:
             return [f"  {o.repo}: could not parse .claude/settings.local.json - {o.detail}"]
-        case ClaudeHookKind.NOT_JSON_OBJECT:
-            return [f"  {o.repo}: .claude/settings.local.json is not a JSON object, skipped"]
-        case ClaudeHookKind.HOOKS_NOT_OBJECT:
-            return [f"  {o.repo}: hooks key is not a JSON object, skipped"]
-        case ClaudeHookKind.EVENT_NOT_ARRAY:
-            return [f"  {o.repo}: hooks.UserPromptSubmit is not a JSON array, skipped"]
         case ClaudeHookKind.ALREADY_PRESENT:
             return [
                 f"  {o.repo}: nauro hook already present in .claude/settings.local.json",
@@ -182,27 +229,14 @@ def _render_claude_hook(o: ClaudeHookOutcome) -> list[str]:
         case ClaudeHookKind.NOTHING_TO_REMOVE:
             return [f"  {o.repo}: no nauro hook to remove", *_render_gitignore(o.gitignore)]
         case ClaudeHookKind.SHARED_STRIP_FAILED:
-            local_removed = (
-                [f"  {o.repo}: removed nauro hook from .claude/settings.local.json"]
-                if o.local_cleaned
-                else []
-            )
             return [
-                *local_removed,
+                *_local_removed_lines(o),
                 f"  {o.repo}: .claude/settings.json - {o.shared_strip.detail}",
                 *_render_gitignore(o.gitignore),
             ]
         case ClaudeHookKind.REMOVED:
-            layers = [
-                layer
-                for layer, cleaned in (
-                    (".claude/settings.local.json", o.local_cleaned),
-                    (".claude/settings.json", o.legacy_cleaned),
-                )
-                if cleaned
-            ]
             return [
-                f"  {o.repo}: removed nauro hook from {' and '.join(layers)}",
+                f"  {o.repo}: removed nauro hook from {_removed_layers(o)}",
                 *_render_gitignore(o.gitignore),
             ]
         case _:
@@ -267,6 +301,8 @@ def _render_bridge(o: BridgeOutcome) -> list[str]:
 
 def _render_codex_config(o: CodexConfigOutcome) -> list[str]:
     match o.kind:
+        case CodexConfigKind.WRITE_FAILED:
+            return [f"Codex: {_failed_write(o.write_failure)}"]
         case CodexConfigKind.PRESERVED_OTHER_PROJECTS:
             return [
                 f"Codex: preserved nauro entry in {o.config_path} "
@@ -294,6 +330,8 @@ def _render_codex_config(o: CodexConfigOutcome) -> list[str]:
 
 def _render_codex_hook(o: CodexHookOutcome) -> list[str]:
     match o.kind:
+        case CodexHookKind.WRITE_FAILED:
+            return [f"  {o.repo}: {_failed_write(o.write_failure)}"]
         case CodexHookKind.REFUSED_SYMLINK:
             return [f"  {o.repo}: {o.refusal.message}"]
         case CodexHookKind.REFUSED_TRACKED:
@@ -331,36 +369,58 @@ def _render_codex_hook(o: CodexHookOutcome) -> list[str]:
             raise TypeError(f"unrenderable CodexHookOutcome kind: {o.kind!r}")
 
 
+def _skill_refusal_line(o: SkillOutcome) -> str:
+    prefix = f"  {o.repo}: " if o.repo is not None else "  "
+    return f"{prefix}{o.refusal.message}"
+
+
+# Kinds whose whole line is a verdict on the target file.
+_SKILL_TARGET_LINES: dict[SkillKind, str] = {
+    SkillKind.PRESERVED_MODIFIED: "  preserved {target} (locally modified)",
+    SkillKind.PRESERVED_UNDECODABLE: "  preserved {target} (not UTF-8 text, left alone)",
+    SkillKind.WROTE: "  wrote {target}",
+    SkillKind.UNCHANGED: "  unchanged {target}",
+    SkillKind.OVERWROTE: "  overwrote {target}",
+    SkillKind.REMOVED: "  removed {target}",
+    SkillKind.ABSENT: "  no skill at {target}",
+}
+
+
 def _render_skill(o: SkillOutcome) -> list[str]:
+    if o.kind in _SKILL_TARGET_LINES:
+        return [_SKILL_TARGET_LINES[o.kind].format(target=o.target)]
     match o.kind:
+        case SkillKind.WRITE_FAILED:
+            return [f"  {_failed_write(o.write_failure)}"]
         case SkillKind.REFUSED_SYMLINK:
-            if o.repo is not None:
-                return [f"  {o.repo}: {o.refusal.message}"]
-            return [f"  {o.refusal.message}"]
+            return [_skill_refusal_line(o)]
         case SkillKind.PRESERVED:
             return [f"  preserved {o.base_label}/nauro-* (other nauro projects still registered)"]
-        case SkillKind.PRESERVED_MODIFIED:
-            return [f"  preserved {o.target} (locally modified)"]
-        case SkillKind.WROTE:
-            return [f"  wrote {o.target}"]
-        case SkillKind.UNCHANGED:
-            return [f"  unchanged {o.target}"]
-        case SkillKind.OVERWROTE:
-            return [f"  overwrote {o.target}"]
         case SkillKind.UPDATED:
             return [f"  updated {o.target} (previous saved to {o.backup_name})"]
         case SkillKind.MIGRATED_LEGACY:
             return [f"  moved legacy skill {o.source} to {o.backup_path}"]
-        case SkillKind.REMOVED:
-            return [f"  removed {o.target}"]
-        case SkillKind.ABSENT:
-            return [f"  no skill at {o.target}"]
         case _:
             raise TypeError(f"unrenderable SkillOutcome kind: {o.kind!r}")
 
 
+_AGENT_TARGET_LINES: dict[AgentKind, str] = {
+    AgentKind.UNCHANGED: "  unchanged {target}",
+    AgentKind.OVERWROTE: "  overwrote {target}",
+    AgentKind.INSTALLED: "  installed {target}",
+    AgentKind.ABSENT: "  no agent at {target}",
+    AgentKind.REMOVED: "  removed {target}",
+    AgentKind.PRESERVED_MODIFIED: "  preserved {target} (locally modified)",
+    AgentKind.PRESERVED_UNDECODABLE: "  preserved {target} (not UTF-8 text, left alone)",
+}
+
+
 def _render_agent(o: AgentOutcome) -> list[str]:
+    if o.kind in _AGENT_TARGET_LINES:
+        return [_AGENT_TARGET_LINES[o.kind].format(target=o.target)]
     match o.kind:
+        case AgentKind.WRITE_FAILED:
+            return [f"  {_failed_write(o.write_failure)}"]
         case AgentKind.SURFACE_INVALID:
             return [f"  skipped agents on surface {o.surface!r}: {o.detail}"]
         case AgentKind.PRESERVED:
@@ -368,19 +428,7 @@ def _render_agent(o: AgentOutcome) -> list[str]:
             return [f"  preserved {base}/nauro-* (other nauro projects still registered)"]
         case AgentKind.REFUSED_SYMLINK:
             return [f"  {o.refusal.message}"]
-        case AgentKind.UNCHANGED:
-            return [f"  unchanged {o.target}"]
-        case AgentKind.OVERWROTE:
-            return [f"  overwrote {o.target}"]
         case AgentKind.UPDATED:
             return [f"  updated {o.target} (previous saved to {o.backup_name})"]
-        case AgentKind.INSTALLED:
-            return [f"  installed {o.target}"]
-        case AgentKind.ABSENT:
-            return [f"  no agent at {o.target}"]
-        case AgentKind.REMOVED:
-            return [f"  removed {o.target}"]
-        case AgentKind.PRESERVED_MODIFIED:
-            return [f"  preserved {o.target} (locally modified)"]
         case _:
             raise TypeError(f"unrenderable AgentOutcome kind: {o.kind!r}")

--- a/packages/nauro/tests/test_integration_outcomes.py
+++ b/packages/nauro/tests/test_integration_outcomes.py
@@ -17,6 +17,8 @@ from nauro.setup.git_hygiene import GitIgnoreKind, GitIgnoreResult
 from nauro.setup.outcomes import (
     AgentKind,
     AgentOutcome,
+    AgentsMdKind,
+    AgentsMdOutcome,
     BridgeKind,
     BridgeOutcome,
     ClaudeHookKind,
@@ -27,7 +29,6 @@ from nauro.setup.outcomes import (
     CodexConfigOutcome,
     CodexHookKind,
     CodexHookOutcome,
-    HandlerErrorOutcome,
     JsonMcpKind,
     JsonMcpOutcome,
     LegacyKind,
@@ -36,6 +37,7 @@ from nauro.setup.outcomes import (
     SharedStripFailed,
     SkillKind,
     SkillOutcome,
+    WriteFailure,
 )
 from nauro.setup.render import render
 from nauro.store.write_safety import SymlinkRefusal, UserSymlinkRefusal
@@ -69,9 +71,51 @@ def test_rawline_is_frozen():
 
 # One entry per (outcome, exact rendered lines). Covers every Kind member of
 # every codec, so a wording change to any branch fails here.
+WRITE_FAILURE = WriteFailure(REPO / "AGENTS.md", 13, "Permission denied")
+
 RENDER_CASES = [
     (RawLine("verbatim"), ["verbatim"]),
-    (HandlerErrorOutcome("handler blew up"), ["handler blew up"]),
+    (
+        AgentsMdOutcome(AgentsMdKind.WRITE_FAILED, REPO, write_failure=WRITE_FAILURE),
+        [f"  {REPO}: could not write {REPO / 'AGENTS.md'} - Permission denied"],
+    ),
+    (
+        AgentsMdOutcome(AgentsMdKind.WRITE_FAILED, write_failure=WRITE_FAILURE),
+        [f"AGENTS.md regeneration: could not write {REPO / 'AGENTS.md'} - Permission denied"],
+    ),
+    (
+        AgentsMdOutcome(
+            AgentsMdKind.WRITE_FAILED,
+            write_failure=WriteFailure(None, 28, "No space left on device"),
+        ),
+        ["AGENTS.md regeneration: write failed - No space left on device"],
+    ),
+    (
+        JsonMcpOutcome(JsonMcpKind.WRITE_FAILED, REPO, ".mcp.json", write_failure=WRITE_FAILURE),
+        [f"  {REPO}: could not write {REPO / 'AGENTS.md'} - Permission denied"],
+    ),
+    (
+        ClaudeHookOutcome(ClaudeHookKind.WRITE_FAILED, REPO, write_failure=WRITE_FAILURE),
+        [f"  {REPO}: could not write {REPO / 'AGENTS.md'} - Permission denied"],
+    ),
+    (
+        CodexConfigOutcome(
+            CodexConfigKind.WRITE_FAILED, REPO / "config.toml", write_failure=WRITE_FAILURE
+        ),
+        [f"Codex: could not write {REPO / 'AGENTS.md'} - Permission denied"],
+    ),
+    (
+        CodexHookOutcome(CodexHookKind.WRITE_FAILED, REPO, write_failure=WRITE_FAILURE),
+        [f"  {REPO}: could not write {REPO / 'AGENTS.md'} - Permission denied"],
+    ),
+    (
+        SkillOutcome(SkillKind.WRITE_FAILED, target=TARGET, write_failure=WRITE_FAILURE),
+        [f"  could not write {REPO / 'AGENTS.md'} - Permission denied"],
+    ),
+    (
+        AgentOutcome(AgentKind.WRITE_FAILED, target=TARGET, write_failure=WRITE_FAILURE),
+        [f"  could not write {REPO / 'AGENTS.md'} - Permission denied"],
+    ),
     # ── JsonMcp ──
     (
         JsonMcpOutcome(JsonMcpKind.REFUSED_SYMLINK, REPO, ".mcp.json", refusal=REPO_REFUSAL),
@@ -527,6 +571,10 @@ RENDER_CASES = [
         SkillOutcome(SkillKind.PRESERVED_MODIFIED, target=TARGET),
         [f"  preserved {TARGET} (locally modified)"],
     ),
+    (
+        SkillOutcome(SkillKind.PRESERVED_UNDECODABLE, target=TARGET),
+        [f"  preserved {TARGET} (not UTF-8 text, left alone)"],
+    ),
     (SkillOutcome(SkillKind.WROTE, target=TARGET), [f"  wrote {TARGET}"]),
     (SkillOutcome(SkillKind.UNCHANGED, target=TARGET), [f"  unchanged {TARGET}"]),
     (SkillOutcome(SkillKind.OVERWROTE, target=TARGET), [f"  overwrote {TARGET}"]),
@@ -574,6 +622,10 @@ RENDER_CASES = [
         AgentOutcome(AgentKind.PRESERVED_MODIFIED, target=TARGET),
         [f"  preserved {TARGET} (locally modified)"],
     ),
+    (
+        AgentOutcome(AgentKind.PRESERVED_UNDECODABLE, target=TARGET),
+        [f"  preserved {TARGET} (not UTF-8 text, left alone)"],
+    ),
 ]
 
 
@@ -594,6 +646,7 @@ def test_render_covers_every_kind_member():
         CodexHookKind,
         SkillKind,
         AgentKind,
+        AgentsMdKind,
     ]
     covered = {outcome.kind for outcome, _ in RENDER_CASES if hasattr(outcome, "kind")}
     for enum in kind_enums:

--- a/packages/nauro/tests/test_setup_atomic_writes.py
+++ b/packages/nauro/tests/test_setup_atomic_writes.py
@@ -280,18 +280,21 @@ def test_interrupted_write_leaves_target_and_no_temps(driver, tmp_path: Path, mo
     """A write that fails mid-flight leaves the original bytes and no temps.
 
     Same seam as ``test_atomic.py``: ``os.replace`` raising stands in for any
-    failure between temp write and rename. The prune sink must additionally
-    keep its soft-fail contract and report ``None`` instead of raising.
+    failure between temp write and rename. A codec reports the failure as a
+    typed WRITE_FAILED outcome naming the file; the prune sink keeps its
+    soft-fail contract and reports ``None``.
     """
     target = driver.seed(tmp_path)
     before = target.read_bytes()
     monkeypatch.setattr(_atomic.os, "replace", _failing_replace)
 
+    outcome = driver.run(tmp_path)
     if driver.soft_fails:
-        assert driver.run(tmp_path) is None
+        assert outcome is None
     else:
-        with pytest.raises(OSError, match="replace failed"):
-            driver.run(tmp_path)
+        assert outcome.kind.name == "WRITE_FAILED"
+        assert outcome.write_failure is not None
+        assert "replace failed" in outcome.write_failure.reason
 
     assert target.read_bytes() == before
     assert _tmp_siblings(target) == []
@@ -330,8 +333,8 @@ def test_interrupted_fresh_add_leaves_no_partial_target(tmp_path: Path, monkeypa
     repo.mkdir()
     monkeypatch.setattr(_atomic.os, "replace", _failing_replace)
 
-    with pytest.raises(OSError, match="replace failed"):
-        _configure_mcp(repo, remove=False)
+    outcome = _configure_mcp(repo, remove=False)
 
+    assert outcome.kind.name == "WRITE_FAILED"
     assert not (repo / ".mcp.json").exists()
     assert _tmp_siblings(repo / ".mcp.json") == []

--- a/packages/nauro/tests/test_setup_hooks.py
+++ b/packages/nauro/tests/test_setup_hooks.py
@@ -28,7 +28,6 @@ from nauro.setup.outcomes import (
     ClaudeHookKind,
     ClaudeHookOutcome,
     CodexHookKind,
-    HandlerErrorOutcome,
 )
 from tests.conftest import register_v2_repo
 
@@ -833,9 +832,11 @@ def test_add_writes_local_before_stripping_shared(tmp_path: Path, monkeypatch):
 
     monkeypatch.setattr(claude_hooks_mod, "write_json_config", failing_write)
 
-    with pytest.raises(OSError, match="disk full"):
-        materialize_hooks_claude_code(repo, remove=False)
+    line = materialize_hooks_claude_code(repo, remove=False)
 
+    assert line.kind is ClaudeHookKind.WRITE_FAILED
+    assert line.write_failure is not None
+    assert line.write_failure.reason == "disk full"
     assert shared.read_text(encoding="utf-8") == before
     assert not _settings(repo).exists()
 
@@ -1195,23 +1196,19 @@ def test_setup_all_with_hooks_prints_codex_trust_guidance(tmp_path: Path, monkey
     assert "review and trust" in result.output
 
 
-def test_setup_all_hook_failure_does_not_abort(tmp_path: Path, monkeypatch):
-    """A hook-wiring failure is caught and reported, not propagated."""
+def test_setup_all_hook_write_failure_is_typed_and_does_not_abort(tmp_path: Path, monkeypatch):
+    """A hook file that cannot be written is a typed WRITE_FAILED outcome with its path;
+    the rest of setup still runs."""
     repo, _store = _make_project(tmp_path)
+    (repo / ".claude" / "settings.local.json").mkdir(parents=True)
 
-    import nauro.cli.integrations.orchestrator as orchestrator_mod
-
-    def boom(repo, *, remove):
-        raise RuntimeError("simulated wiring failure")
-
-    monkeypatch.setattr(orchestrator_mod, "materialize_hooks_claude_code", boom)
-
-    # Must not raise; the rest of setup still produces its lines.
     lines = setup_all_surfaces([repo], with_hooks=True)
-    assert any(
-        isinstance(line, HandlerErrorOutcome) and "hook" in line.message and "error" in line.message
-        for line in lines
-    )
+
+    failed = [line for line in lines if getattr(line, "kind", None) is ClaudeHookKind.WRITE_FAILED]
+    assert len(failed) == 1
+    assert failed[0].write_failure is not None
+    assert failed[0].write_failure.path == repo / ".claude" / "settings.local.json"
+    assert failed[0].write_failure.errno is not None
     # MCP wiring still happened despite the hook failure.
     assert (repo / ".mcp.json").is_file()
 

--- a/packages/nauro/tests/test_setup_write_failures.py
+++ b/packages/nauro/tests/test_setup_write_failures.py
@@ -1,0 +1,246 @@
+"""Every setup codec reports a write it could not land as a typed outcome, and setup exits 1."""
+
+from __future__ import annotations
+
+import errno
+import subprocess
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from nauro.cli.integrations import codex_config, orchestrator
+from nauro.cli.integrations.agents import materialize_agents_cursor_for_repo
+from nauro.cli.integrations.codex_config import _configure_codex
+from nauro.cli.integrations.codex_hooks import materialize_hooks_codex
+from nauro.cli.integrations.json_mcp import _configure_mcp
+from nauro.cli.integrations.skills import (
+    materialize_skills_codex,
+    materialize_skills_cursor_for_repo,
+)
+from nauro.cli.main import app
+from nauro.setup.outcomes import (
+    AgentKind,
+    AgentsMdKind,
+    CodexConfigKind,
+    CodexHookKind,
+    JsonMcpKind,
+    RawLine,
+    SkillKind,
+    WriteFailure,
+    is_failure,
+)
+from nauro.setup.render import render
+from nauro.store import _atomic
+from nauro.store.registry import find_projects_by_name_v2, register_project_v2
+from nauro.templates.scaffolds import scaffold_project_store
+
+runner = CliRunner()
+
+
+def _repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    return repo
+
+
+def test_json_mcp_reports_a_config_it_cannot_write(tmp_path: Path):
+    repo = _repo(tmp_path)
+    (repo / ".mcp.json").mkdir()
+
+    outcome = _configure_mcp(repo, remove=False)
+
+    assert outcome.kind is JsonMcpKind.WRITE_FAILED
+    assert outcome.write_failure is not None
+    assert outcome.write_failure.path == repo / ".mcp.json"
+    assert outcome.write_failure.errno is not None
+    assert is_failure(outcome)
+
+
+def test_codex_config_reports_a_config_it_cannot_write(tmp_path: Path):
+    config = tmp_path / "config.toml"
+    config.mkdir()
+
+    outcome = _configure_codex(remove=False, config_path=config)
+
+    assert outcome.kind is CodexConfigKind.WRITE_FAILED
+    assert outcome.write_failure is not None
+    assert outcome.write_failure.path == config
+
+
+def test_codex_hooks_report_a_file_they_cannot_write(tmp_path: Path):
+    repo = _repo(tmp_path)
+    (repo / ".codex" / "hooks.json").mkdir(parents=True)
+
+    outcome = materialize_hooks_codex(repo, remove=False)
+
+    assert outcome.kind is CodexHookKind.WRITE_FAILED
+    assert outcome.write_failure is not None
+    assert outcome.write_failure.path == repo / ".codex" / "hooks.json"
+
+
+def test_skill_and_agent_files_that_cannot_be_written_are_reported_per_file(tmp_path: Path):
+    repo = _repo(tmp_path)
+    (repo / ".cursor" / "rules" / "nauro-adopt.mdc").mkdir(parents=True)
+    (repo / ".cursor" / "agents" / "nauro-planner.md").mkdir(parents=True)
+
+    skills = materialize_skills_cursor_for_repo(repo, remove=False)
+    agents = materialize_agents_cursor_for_repo(repo, remove=False)
+
+    failed_skills = [o for o in skills if o.kind is SkillKind.WRITE_FAILED]
+    assert [o.target for o in failed_skills] == [repo / ".cursor" / "rules" / "nauro-adopt.mdc"]
+    assert failed_skills[0].write_failure is not None
+    failed_agents = [o for o in agents if o.kind is AgentKind.WRITE_FAILED]
+    assert [o.target for o in failed_agents] == [repo / ".cursor" / "agents" / "nauro-planner.md"]
+    assert any(o.kind is AgentKind.INSTALLED for o in agents)
+
+
+def test_is_failure_ignores_raw_lines_and_successes(tmp_path: Path):
+    repo = _repo(tmp_path)
+    assert not is_failure(RawLine("header"))
+    assert not is_failure(_configure_mcp(repo, remove=False))
+
+
+def test_setup_exits_nonzero_when_a_codec_could_not_write(tmp_path: Path, monkeypatch):
+    repo = _repo(tmp_path)
+    _pid, store = register_project_v2("proj", [repo])
+    scaffold_project_store("proj", store)
+    monkeypatch.chdir(repo)
+    monkeypatch.setattr(
+        codex_config, "codex_config_path", lambda: tmp_path / "codex" / "config.toml"
+    )
+    (repo / ".mcp.json").mkdir()
+
+    result = runner.invoke(app, ["setup", "claude-code"])
+
+    assert result.exit_code == 1, result.output
+    assert f"{repo}: could not write {repo / '.mcp.json'}" in result.output
+
+    (repo / ".mcp.json").rmdir()
+    assert runner.invoke(app, ["setup", "claude-code"]).exit_code == 0
+
+
+def test_a_failure_inside_the_atomic_write_names_the_target(tmp_path: Path, monkeypatch):
+    repo = _repo(tmp_path)
+    (repo / ".mcp.json").write_text("{}", encoding="utf-8")
+
+    def _denied(src, dst):
+        raise PermissionError(errno.EACCES, "Permission denied", str(src))
+
+    monkeypatch.setattr(_atomic.os, "replace", _denied)
+
+    outcome = _configure_mcp(repo, remove=False)
+
+    assert outcome.kind is JsonMcpKind.WRITE_FAILED
+    assert outcome.write_failure == WriteFailure(
+        repo / ".mcp.json", errno.EACCES, "Permission denied"
+    )
+
+
+def test_skill_and_agent_files_that_are_not_utf8_are_preserved(tmp_path: Path):
+    repo = _repo(tmp_path)
+    skill = repo / ".cursor" / "rules" / "nauro-adopt.mdc"
+    agent = repo / ".cursor" / "agents" / "nauro-planner.md"
+    for path in (skill, agent):
+        path.parent.mkdir(parents=True)
+        path.write_bytes(b"\xff\xfe not text")
+
+    kinds = {
+        (o.target, remove): o.kind
+        for remove in (False, True)
+        for o in (
+            *materialize_skills_cursor_for_repo(repo, remove=remove),
+            *materialize_agents_cursor_for_repo(repo, remove=remove),
+        )
+        if o.target in (skill, agent)
+    }
+
+    assert kinds == {
+        (skill, False): SkillKind.PRESERVED_UNDECODABLE,
+        (skill, True): SkillKind.PRESERVED_UNDECODABLE,
+        (agent, False): AgentKind.PRESERVED_UNDECODABLE,
+        (agent, True): AgentKind.PRESERVED_UNDECODABLE,
+    }
+    assert skill.read_bytes() == agent.read_bytes() == b"\xff\xfe not text"
+
+
+def test_legacy_codex_skill_stays_when_its_replacement_was_not_written():
+    legacy = Path.home() / ".codex" / "skills" / "nauro-adopt" / "SKILL.md"
+    legacy.parent.mkdir(parents=True)
+    legacy.write_text("legacy", encoding="utf-8")
+    (Path.home() / ".agents" / "skills" / "nauro-adopt" / "SKILL.md").mkdir(parents=True)
+
+    outcomes = materialize_skills_codex(remove=False)
+
+    assert [o.kind for o in outcomes] == [SkillKind.WRITE_FAILED]
+    assert legacy.read_text(encoding="utf-8") == "legacy"
+
+
+def test_agents_md_regeneration_failure_is_one_typed_outcome(tmp_path: Path, monkeypatch):
+    repo = _repo(tmp_path)
+    pid, store = register_project_v2("proj", [repo])
+    scaffold_project_store("proj", store)
+
+    def _no_space(*_args, **_kwargs):
+        raise OSError(errno.ENOSPC, "No space left on device")
+
+    monkeypatch.setattr(orchestrator, "warn_then_regen", _no_space)
+
+    outcomes = orchestrator.claude_code_surfaces(
+        [repo], remove=False, with_hooks=False, store_name=pid, store_path=store, warn=print
+    )
+
+    failures = [o for o in outcomes if is_failure(o)]
+    assert [o.kind for o in failures] == [AgentsMdKind.WRITE_FAILED]
+    assert render(failures[0]) == ["AGENTS.md regeneration: write failed - No space left on device"]
+
+
+def test_adopt_exits_nonzero_when_a_codec_could_not_write(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    repo = tmp_path / "myrepo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    monkeypatch.chdir(repo)
+    (repo / ".mcp.json").mkdir()
+
+    result = runner.invoke(app, ["adopt", "--name", "alpha"])
+
+    assert result.exit_code == 1, result.output
+    assert f"could not write {repo / '.mcp.json'}" in result.output
+    assert "re-run 'nauro setup all'" in result.output
+    assert "Next: restart your agent" not in result.output
+
+
+def test_unadopt_keeps_the_adoption_when_a_removal_could_not_be_written(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    repo = tmp_path / "myrepo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    monkeypatch.chdir(repo)
+    assert runner.invoke(app, ["adopt", "--name", "alpha"]).exit_code == 0
+    (repo / ".mcp.json").unlink()
+    (repo / ".mcp.json").mkdir()
+
+    result = runner.invoke(app, ["adopt", "--remove", "--yes"])
+
+    assert result.exit_code == 1, result.output
+    assert "re-run 'nauro adopt --remove'" in result.output
+    assert (repo / ".nauro" / "config.json").is_file()
+    assert len(find_projects_by_name_v2("alpha")) == 1
+
+
+def test_a_claude_md_bridge_that_cannot_be_written_fails_setup(tmp_path: Path, monkeypatch):
+    repo = _repo(tmp_path)
+    _pid, store = register_project_v2("proj", [repo])
+    scaffold_project_store("proj", store)
+    monkeypatch.chdir(repo)
+    monkeypatch.setattr(
+        codex_config, "codex_config_path", lambda: tmp_path / "codex" / "config.toml"
+    )
+    (repo / "CLAUDE.md").mkdir()
+
+    result = runner.invoke(app, ["setup", "all"])
+
+    assert result.exit_code == 1, result.output
+    assert f"{repo}: CLAUDE.md bridge error - CLAUDE.md is not a regular file" in result.output

--- a/scripts/ruff_budget_baseline.jsonl
+++ b/scripts/ruff_budget_baseline.jsonl
@@ -93,9 +93,8 @@
 {"path":"packages/nauro/src/nauro/cli/integrations/json_mcp.py","rule":"PLR0911","count":1}
 {"path":"packages/nauro/src/nauro/cli/integrations/json_mcp.py","rule":"PLR0912","count":1}
 {"path":"packages/nauro/src/nauro/cli/integrations/legacy.py","rule":"RET505","count":1}
-{"path":"packages/nauro/src/nauro/cli/integrations/orchestrator.py","rule":"B905","count":2}
-{"path":"packages/nauro/src/nauro/cli/integrations/orchestrator.py","rule":"BLE001","count":16}
-{"path":"packages/nauro/src/nauro/cli/integrations/orchestrator.py","rule":"C901","count":2}
+{"path":"packages/nauro/src/nauro/cli/integrations/orchestrator.py","rule":"B905","count":1}
+{"path":"packages/nauro/src/nauro/cli/integrations/orchestrator.py","rule":"BLE001","count":1}
 {"path":"packages/nauro/src/nauro/cli/nauro_command.py","rule":"SIM103","count":1}
 {"path":"packages/nauro/src/nauro/cli/utils.py","rule":"PLR0912","count":1}
 {"path":"packages/nauro/src/nauro/graph/html_render.py","rule":"C901","count":1}
@@ -116,7 +115,7 @@
 {"path":"packages/nauro/src/nauro/setup/claude_bridge.py","rule":"PLR0911","count":2}
 {"path":"packages/nauro/src/nauro/setup/git_hygiene.py","rule":"PLR0911","count":3}
 {"path":"packages/nauro/src/nauro/setup/git_hygiene.py","rule":"PLR0912","count":1}
-{"path":"packages/nauro/src/nauro/setup/render.py","rule":"PLR0911","count":9}
+{"path":"packages/nauro/src/nauro/setup/render.py","rule":"PLR0911","count":7}
 {"path":"packages/nauro/src/nauro/store/generation_authority.py","rule":"TRY300","count":1}
 {"path":"packages/nauro/src/nauro/store/generation_authority.py","rule":"TRY301","count":1}
 {"path":"packages/nauro/src/nauro/store/generation_installation.py","rule":"BLE001","count":3}


### PR DESCRIPTION
## Why

The setup codecs wrapped their writes in nothing and left the orchestrator to catch any exception into a formatted string, so a config or skill file that could not be written rendered as one prose line and setup still exited 0. Scripts and users saw a wired repo that was not.

## What changed

- Each codec guards its own write path. An OS error on the JSON MCP configs, the Claude hook settings, the Codex config, the Codex hooks, or any skill or agent file becomes a WRITE_FAILED outcome of that codec's own kind carrying the file, errno and reason. A failure inside the atomic writer names the codec's target, not the tmp sibling. Skill and agent files are guarded per file, and a file that is not UTF-8 text is preserved and reported rather than aborting the surface.
- The AGENTS.md regeneration and removal the orchestrator drives itself get a small outcome of their own, shared by `setup claude-code` and `setup all`. The fifteen catch-all arms and the string-carrying handler outcome are gone.
- The setup commands and adopt render everything, then exit 1 when any outcome is a failed write; a CLAUDE.md bridge the regeneration could not write counts. Un-adopt stops before it deletes the repo config or deregisters, so the re-run it names still finds the adoption.
- The legacy `~/.codex/skills` copy is moved aside only once its replacement under `~/.agents/skills` is in place.
- Ruff budget: orchestrator blind-except entry 16 to 1 and its complexity entry removed.

## Risk / what to review

- A store-side error during AGENTS.md regeneration now propagates from setup, as it already does from sync, init, attach and reconnect.
- 840 added lines against the 800 default; the review round added the un-adopt guard, the bridge-failure exit and their tests.

## Test plan

Full pytest for both packages on the rebased branch: 7039 passed, 121 skipped, 12 failed. The 12 are permission-denial tests that fail identically on origin/main under this container's root user. ruff check and format, the ruff and docstring budgets, the single-sourced check and the import-linter contracts all pass. Tests name each scenario: every codec's write failure, a failure inside the atomic writer, non-UTF-8 skill and agent files, the legacy Codex skill left in place, the regeneration failure outcome, setup and adopt exiting 1, un-adopt keeping the adoption, and the bridge failure.